### PR TITLE
fix(windows): Ignore `os.sysconf` with windows

### DIFF
--- a/src/tabpfn/model/memory.py
+++ b/src/tabpfn/model/memory.py
@@ -251,6 +251,13 @@ class MemoryUsageEstimator:
                 free_memory = (
                     os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES") / 1e9
                 )
+            except AttributeError:
+                # TODO: `os.sysconf` does not exist on windows.
+                free_memory = cls.convert_units(
+                    default_gb_cpu_if_failed_to_calculate,
+                    "gb",
+                    "b",
+                )
             except ValueError:
                 warnings.warn(
                     "Could not get system memory, defaulting to"


### PR DESCRIPTION
Fixes issue #100 by simply going with the default.

Should raise a specific issue to implement this properly