### PR TITLE
Specify numpy version requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "tabpfn"
 version = "2.0.2"
 dependencies = [
   "torch>=2.1",
+  "numpy<2.0.0",
   "scikit-learn>=1",
   "typing_extensions",
   "scipy",


### PR DESCRIPTION
When importing tabpfn, I got an error saying that some files were complied using numpy < 2.0 but my environment had numpy >2.0. This PR will ensure that the proper version of numpy is installed to reduce friction for future people importing the package