### PR TITLE
Increase minimum scikit-learn versiont to fix error when using TabPFN as part of a pipeline

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "tabpfn"
 version = "2.0.2"
 dependencies = [
   "torch>=2.1",
-  "scikit-learn>=1.4.2",
+  "scikit-learn>=1.4.1.post1",
   "typing_extensions",
   "scipy",
   "pandas",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "tabpfn"
 version = "2.0.2"
 dependencies = [
   "torch>=2.1",
-  "scikit-learn>=1",
+  "scikit-learn>=1.4.2",
   "typing_extensions",
   "scipy",
   "pandas",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "tabpfn"
 version = "2.0.2"
 dependencies = [
   "torch>=2.1",
-  "scikit-learn>=1.4.1.post1",
+  "scikit-learn>=1.2.0",
   "typing_extensions",
   "scipy",
   "pandas",

--- a/src/tabpfn/utils.py
+++ b/src/tabpfn/utils.py
@@ -17,7 +17,8 @@ import pandas as pd
 import torch
 from sklearn.base import check_array, is_classifier
 from sklearn.compose import ColumnTransformer, make_column_selector
-from sklearn.preprocessing import OrdinalEncoder
+from sklearn.preprocessing import OrdinalEncoder, FunctionTransformer
+
 from sklearn.utils.multiclass import check_classification_targets
 from torch import nn
 
@@ -454,7 +455,7 @@ def _get_ordinal_encoder(
     to_convert = ["category", "string"]
     return ColumnTransformer(
         transformers=[("encoder", oe, make_column_selector(dtype_include=to_convert))],
-        remainder="passthrough",
+        remainder=FunctionTransformer(),
         sparse_threshold=0.0,
         verbose_feature_names_out=False,
     )

--- a/tests/test_classifier_interface.py
+++ b/tests/test_classifier_interface.py
@@ -9,6 +9,8 @@ import sklearn.datasets
 import torch
 from sklearn.base import check_is_fitted
 from sklearn.utils.estimator_checks import parametrize_with_checks
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
 
 from tabpfn import TabPFNClassifier
 
@@ -129,3 +131,27 @@ def test_balanced_probabilities(X_y: tuple[np.ndarray, np.ndarray]) -> None:
     expected_mean = 1.0 / len(np.unique(y))
     assert np.allclose(mean_probs, expected_mean, rtol=0.1), \
         "Class probabilities are not properly balanced"
+
+def test_classifier_in_pipeline(X_y: tuple[np.ndarray, np.ndarray]) -> None:
+    """Test that TabPFNClassifier works correctly within a sklearn pipeline."""
+    X, y = X_y
+    
+    # Create a simple preprocessing pipeline
+    pipeline = Pipeline([
+        ('scaler', StandardScaler()),
+        ('classifier', TabPFNClassifier(
+            n_estimators=2  # Fewer estimators for faster testing
+        ))
+    ])
+    
+    pipeline.fit(X, y)
+    probabilities = pipeline.predict_proba(X)
+    
+    # Check that probabilities sum to 1 for each prediction
+    assert np.allclose(probabilities.sum(axis=1), 1.0)
+    
+    # Check that the mean probability for each class is roughly equal
+    mean_probs = probabilities.mean(axis=0)
+    expected_mean = 1.0 / len(np.unique(y))
+    assert np.allclose(mean_probs, expected_mean, rtol=0.1), \
+        "Class probabilities are not properly balanced in pipeline"

--- a/tests/test_regressor_interface.py
+++ b/tests/test_regressor_interface.py
@@ -9,6 +9,8 @@ import sklearn.datasets
 import torch
 from sklearn.base import check_is_fitted
 from sklearn.utils.estimator_checks import parametrize_with_checks
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
 
 from tabpfn import TabPFNRegressor
 
@@ -110,3 +112,36 @@ def test_sklearn_compatible_estimator(
         estimator.inference_precision = torch.float64
 
     check(estimator)
+
+
+def test_regressor_in_pipeline(X_y: tuple[np.ndarray, np.ndarray]) -> None:
+    """Test that TabPFNRegressor works correctly within a sklearn pipeline."""
+    X, y = X_y
+    
+    # Create a simple preprocessing pipeline
+    pipeline = Pipeline([
+        ('scaler', StandardScaler()),
+        ('regressor', TabPFNRegressor(
+            n_estimators=2  # Fewer estimators for faster testing
+        ))
+    ])
+    
+    pipeline.fit(X, y)
+    predictions = pipeline.predict(X)
+    
+    # Check predictions shape
+    assert predictions.shape == (X.shape[0],), "Predictions shape is incorrect"
+    
+    # Test different prediction modes through the pipeline
+    predictions_median = pipeline.predict(X, output_type="median")
+    assert predictions_median.shape == (X.shape[0],), "Median predictions shape is incorrect"
+    
+    predictions_mode = pipeline.predict(X, output_type="mode")
+    assert predictions_mode.shape == (X.shape[0],), "Mode predictions shape is incorrect"
+    
+    quantiles = pipeline.predict(X, output_type="quantiles", quantiles=[0.1, 0.9])
+    assert isinstance(quantiles, list)
+    assert len(quantiles) == 2
+    assert quantiles[0].shape == (X.shape[0],), "Quantile predictions shape is incorrect"
+
+


### PR DESCRIPTION
TabPFN fails when used as part of a sklearn pipeline for sklearn's version older than 1.4.2.
This PR adds tests which fails for these older versions and bump the minimum sklearn version to 1.4.2 in the pytoml.