### PR TITLE
fix: make fingerprint feature deterministic

### DIFF
--- a/src/tabpfn/model/preprocessing.py
+++ b/src/tabpfn/model/preprocessing.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import warnings
 from abc import abstractmethod
 from collections import UserList
@@ -474,8 +475,7 @@ _CONSTANT = 10**12
 
 
 def float_hash_arr(arr: np.ndarray) -> float:
-    b = arr.tobytes()
-    _hash = hash(b)
+    _hash = int(hashlib.sha256(arr.tobytes()).hexdigest(), 16)
     return _hash % _CONSTANT / _CONSTANT
 
 


### PR DESCRIPTION
Using Python's built-in hash is not consistent between runs due to salting. 

Thus, the fingerprint feature using the built-in hash is not deterministic, making the input data non-deterministic and making the predictions non-deterministic between runs. Hashlib's hash is consistent between runs and thus does not face this problem. 

This broke during the refactoring. The commit below is essentially reverting a commit that happened during the refactor. 


FYI: @eddiebergman 
