### PR TITLE
Add Python 3.12 PyPi tag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ classifiers = [
   'Programming Language :: Python :: 3.9',
   'Programming Language :: Python :: 3.10',
   'Programming Language :: Python :: 3.11',
+  'Programming Language :: Python :: 3.12',
 ]
 license = { file = "LICENSE" }
 


### PR DESCRIPTION
Seems that the Python 3.12 support isn't tagged in PyPi, so I added it.