### PR TITLE
Improve offline usage documentation and error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,22 @@ git clone https://github.com/PriorLabs/TabPFN.git
 pip install -e "TabPFN[dev]"
 ```
 
+### Offline Usage
+
+TabPFN automatically downloads model weights when first used. For offline usage:
+
+1. Download the model files manually from HuggingFace:
+   - Classifier: [tabpfn-v2-classifier.ckpt](https://huggingface.co/Prior-Labs/TabPFN-v2-clf/resolve/main/tabpfn-v2-classifier.ckpt)
+   - Regressor: [tabpfn-v2-regressor.ckpt](https://huggingface.co/Prior-Labs/TabPFN-v2-reg/resolve/main/tabpfn-v2-regressor.ckpt)
+
+2. Place the file in one of these locations:
+   - Specify directly: `TabPFNClassifier(model_path="/path/to/model.ckpt")`
+   - Set environment variable: `os.environ["TABPFN_MODEL_CACHE_DIR"] = "/path/to/dir"`
+   - Default OS cache directory:
+     - Windows: `%APPDATA%\tabpfn\`
+     - macOS: `~/Library/Caches/tabpfn/`
+     - Linux: `~/.cache/tabpfn/`
+
 ### Basic Usage
 
 #### Classification

--- a/src/tabpfn/utils.py
+++ b/src/tabpfn/utils.py
@@ -390,7 +390,12 @@ def load_model_criterion_config(
             model_name=model_name,
         )
         if res != "ok":
-            raise RuntimeError(f"Failed to download model to {model_path}!") from res[0]
+            raise RuntimeError(
+                f"Failed to download model to {model_path}!\n\n"
+                f"For offline usage, please download the model manually from:\n"
+                f"https://huggingface.co/Prior-Labs/TabPFN-v2-{'clf' if which == 'classifier' else 'reg'}/resolve/main/{model_name}\n\n"
+                f"Then place it at: {model_path}"
+            ) from res[0]
 
     loaded_model, criterion, config = load_model(path=model_path, model_seed=model_seed)
     loaded_model.cache_trainset_representation = cache_trainset_representation

--- a/src/tabpfn/utils.py
+++ b/src/tabpfn/utils.py
@@ -390,11 +390,12 @@ def load_model_criterion_config(
             model_name=model_name,
         )
         if res != "ok":
+            repo_type = "clf" if which == "classifier" else "reg"
             raise RuntimeError(
                 f"Failed to download model to {model_path}!\n\n"
                 f"For offline usage, please download the model manually from:\n"
-                f"https://huggingface.co/Prior-Labs/TabPFN-v2-{'clf' if which == 'classifier' else 'reg'}/resolve/main/{model_name}\n\n"
-                f"Then place it at: {model_path}"
+                f"https://huggingface.co/Prior-Labs/TabPFN-v2-{repo_type}/resolve/main/{model_name}\n\n"
+                f"Then place it at: {model_path}",
             ) from res[0]
 
     loaded_model, criterion, config = load_model(path=model_path, model_seed=model_seed)


### PR DESCRIPTION
## Summary
- Add offline usage section to README with direct download links
- Clarify where TabPFN looks for model files in each OS
- Improve error message when model download fails to provide direct download URL

## Test plan
- Confirmed README changes render correctly
- Tested error message display with network disconnected