### PR TITLE
Fix index error by override set_output for internal transformers

### DIFF
--- a/src/tabpfn/classifier.py
+++ b/src/tabpfn/classifier.py
@@ -25,6 +25,7 @@ from typing_extensions import Self
 
 import numpy as np
 import torch
+from sklearn import config_context
 from sklearn.base import BaseEstimator, ClassifierMixin, check_is_fitted
 from sklearn.preprocessing import LabelEncoder
 
@@ -374,6 +375,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
         tags.estimator_type = "classifier"
         return tags
 
+    @config_context(transform_output="default")
     def fit(self, X: XType, y: YType) -> Self:
         """Fit the model.
 
@@ -518,6 +520,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
         y = np.argmax(proba, axis=1)
         return self.label_encoder_.inverse_transform(y)  # type: ignore
 
+    @config_context(transform_output="default")
     def predict_proba(self, X: XType) -> np.ndarray:
         """Predict the probabilities of the classes for the provided input samples.
 

--- a/src/tabpfn/model/encoders.py
+++ b/src/tabpfn/model/encoders.py
@@ -507,7 +507,11 @@ class NanHandlingEncoderStep(SeqEncStep):
 
 
 class RemoveEmptyFeaturesEncoderStep(SeqEncStep):
-    """Encoder step to remove empty (constant) features."""
+    """Encoder step to remove empty (constant) features.
+    Was changed to NOT DO ANYTHING, the removal of empty features now
+    done elsewhere, but the saved model still needs this encoder step.
+    TODO: REMOVE.
+    """
 
     def __init__(self, **kwargs: Any):
         """Initialize the RemoveEmptyFeaturesEncoderStep.
@@ -525,7 +529,7 @@ class RemoveEmptyFeaturesEncoderStep(SeqEncStep):
             x: The input tensor.
             **kwargs: Additional keyword arguments (unused).
         """
-        self.sel = (x[1:] == x[0]).sum(0) != (x.shape[0] - 1)
+        # self.sel = (x[1:] == x[0]).sum(0) != (x.shape[0] - 1)
 
     def _transform(self, x: torch.Tensor, **kwargs: Any) -> tuple[torch.Tensor]:
         """Remove empty features from the input tensor.
@@ -537,7 +541,8 @@ class RemoveEmptyFeaturesEncoderStep(SeqEncStep):
         Returns:
             A tuple containing the transformed tensor with empty features removed.
         """
-        return (select_features(x, self.sel),)
+        # return (select_features(x, self.sel),)
+        return (x,)
 
 
 class RemoveDuplicateFeaturesEncoderStep(SeqEncStep):

--- a/src/tabpfn/regressor.py
+++ b/src/tabpfn/regressor.py
@@ -25,6 +25,7 @@ from typing_extensions import Self, overload
 
 import numpy as np
 import torch
+from sklearn import config_context
 from sklearn.base import (
     BaseEstimator,
     RegressorMixin,
@@ -380,6 +381,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
         tags.estimator_type = "regressor"
         return tags
 
+    @config_context(transform_output="default")
     def fit(self, X: XType, y: YType) -> Self:
         """Fit the model.
 
@@ -556,6 +558,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
     ) -> dict[str, np.ndarray | FullSupportBarDistribution]: ...
 
     # FIXME: improve to not have noqa C901, PLR0912
+    @config_context(transform_output="default")
     def predict(  # noqa: C901, PLR0912
         self,
         X: XType,

--- a/tests/test_regressor_interface.py
+++ b/tests/test_regressor_interface.py
@@ -351,3 +351,40 @@ def test_pandas_output_config():
         model.fit(X, y)
         polars_pred = model.predict(X)
         np.testing.assert_array_almost_equal(default_pred, polars_pred)
+
+
+def test_constant_feature_handling(X_y: tuple[np.ndarray, np.ndarray]) -> None:
+    """Test that constant features are properly handled and don't affect predictions."""
+    X, y = X_y
+
+    # Create a TabPFNRegressor with fixed random state for reproducibility
+    model = TabPFNRegressor(n_estimators=2, random_state=42)
+    model.fit(X, y)
+
+    # Get predictions on original data
+    original_predictions = model.predict(X)
+
+    # Create a new dataset with added constant features
+    X_with_constants = np.hstack(
+        [
+            X,
+            np.zeros((X.shape[0], 3)),  # Add 3 constant zero features
+            np.ones((X.shape[0], 2)),  # Add 2 constant one features
+            np.full((X.shape[0], 1), 5.0),  # Add 1 constant with value 5.0
+        ],
+    )
+
+    # Create and fit a new model with the same random state
+    model_with_constants = TabPFNRegressor(n_estimators=2, random_state=42)
+    model_with_constants.fit(X_with_constants, y)
+
+    # Get predictions on data with constant features
+    constant_predictions = model_with_constants.predict(X_with_constants)
+
+    # Verify predictions are the same (within numerical precision)
+    np.testing.assert_array_almost_equal(
+        original_predictions,
+        constant_predictions,
+        decimal=5,  # Allow small numerical differences
+        err_msg="Predictions changed after adding constant features",
+    )


### PR DESCRIPTION
Fix #213 Fix #196 

Override `set_output` with "default" mode to prevent internal transformer from outputing pandas DataFrame (which breaks the torch preprocessing).
Also deactivate `RemoveEmptyFeaturesEncoderStep` which was redundant (not necessary to fix the bug here).