### PR TITLE
Fix README format in section Performance & Limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,10 +248,10 @@ A: **Yes!**
 **Q: How can I improve TabPFN’s performance?**  
 A: Best practices:
 - Use **AutoTabPFNClassifier** from [TabPFN Extensions](https://github.com/priorlabs/tabpfn-extensions) for post-hoc ensembling
-- Feature engineering: Add domain-specific features to improve model performance
+- Feature engineering: Add domain-specific features to improve model performance  
 Not effective:
-- Adapt feature scaling
-- Convert categorical features to numerical values (e.g., one-hot encoding)
+  - Adapt feature scaling
+  - Convert categorical features to numerical values (e.g., one-hot encoding)
 
 ## 🛠️ Development
 


### PR DESCRIPTION
# Why
In the README section `Performance & Limitations`, the answer for `Q: How can I improve TabPFN’s performance?` is confusing due to formatting.
It remains unclear whether `Adapt feature scaling` and `one-hot encoding` are not effective or indeed best practices.

# What
- Add two blanks at end of line to wrap text
- Indent bullet points `Adapt feature scaling` and `one-hot encoding`  

Before:
<img width="821" alt="image" src="https://github.com/user-attachments/assets/3e2769d2-b8fc-448d-b65a-a5628764caea" />

After:
<img width="692" alt="image" src="https://github.com/user-attachments/assets/da8577bc-b27e-45bf-8920-abf35cc98e56" />

# Hint to reviewer
- This PR assumes that `Adapt feature scaling` and `one-hot encoding` are not effective.
- You can merge this PR as is, or change the format as you like in this or other PR