### PR TITLE
added an adaptive batching mechanism to handle large test sets based on estimated memory usage

### DIFF
--- a/src/tabpfn/classifier.py
+++ b/src/tabpfn/classifier.py
@@ -369,8 +369,9 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
         sample_size = X.shape[0]
         feature_size = X.shape[1]
         dtype_size = np.dtype(X.dtype).itemsize
-        return sample_size * feature_size * dtype_size / (1024 ** 2)  # Convert bytes to MB
-    
+         # Convert bytes to MB and return
+        return sample_size * feature_size * dtype_size / (1024 ** 2)
+
     # TODO: We can remove this from scikit-learn lower bound of 1.6
     def _more_tags(self) -> dict[str, Any]:
         return {
@@ -550,11 +551,13 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
 
         # Estimate memory usage and determine batch size
         estimated_memory_usage = self._estimate_memory_usage(X)
-        available_memory = torch.cuda.get_device_properties(self.device_).total_memory / (1024 ** 2)  # Convert to MB
+        available_memory = (
+            torch.cuda.get_device_properties(self.device_).total_memory / (1024 ** 2)
+        )  # Convert to MB
         batch_size = max(1, int(available_memory // estimated_memory_usage))
 
         for i in range(0, X.shape[0], batch_size):
-            X_batch = X[i:i + batch_size]
+            X[i:i + batch_size]
             for output, config in self.executor_.iter_outputs(
                 X,
                 device=self.device_,


### PR DESCRIPTION
This PR fixes #125 
## Decription
added an adaptive batching mechanism to handle large test sets based on estimated memory usage. The default behavior can be overridden by expert users by adjusting the `memory_saving_mode` parameter.

## changes made
1. Added a method to estimate memory usage.
2. Modified the predict_proba method to use adaptive batching.
