### PR TITLE
Rework allow_cpu_override to be usable without environment variables

### DIFF
--- a/src/tabpfn/base.py
+++ b/src/tabpfn/base.py
@@ -245,15 +245,22 @@ def create_inference_engine(  # noqa: PLR0913
 
 
 def check_cpu_warning(
-    device: str | torch.device, X: np.ndarray | torch.Tensor | pd.DataFrame
+    device: str | torch.device,
+    X: np.ndarray | torch.Tensor | pd.DataFrame,
+    allow_cpu_override: bool = False,
 ) -> None:
     """Check if using CPU with large datasets and warn or error appropriately.
 
     Args:
         device: The torch device being used
         X: The input data (NumPy array, Pandas DataFrame, or Torch Tensor)
+        allow_cpu_override: If True, allow CPU usage with large datasets.
     """
-    allow_cpu_override = os.getenv("TABPFN_ALLOW_CPU_LARGE_DATASET", "0") == "1"
+    allow_cpu_override = allow_cpu_override or (os.getenv("TABPFN_ALLOW_CPU_LARGE_DATASET", "0") == "1")
+
+    if allow_cpu_override:
+        return
+
     device_mapped = infer_device_and_type(device)
 
     # Determine number of samples
@@ -264,15 +271,14 @@ def check_cpu_warning(
 
     if torch.device(device_mapped).type == "cpu":
         if num_samples > 1000:
-            if not allow_cpu_override:
-                raise RuntimeError(
-                    "Running on CPU with more than 1000 samples is not allowed "
-                    "by default due to slow performance.\n"
-                    "To override this behavior, set the environment variable "
-                    "TABPFN_ALLOW_CPU_LARGE_DATASET=1.\n"
-                    "Alternatively, consider using a GPU or the tabpfn-client API: "
-                    "https://github.com/PriorLabs/tabpfn-client"
-                )
+            raise RuntimeError(
+                "Running on CPU with more than 1000 samples is not allowed "
+                "by default due to slow performance.\n"
+                "To override this behavior, set the environment variable "
+                "TABPFN_ALLOW_CPU_LARGE_DATASET=1 or set ignore_pretraining_limits=True.\n"
+                "Alternatively, consider using a GPU or the tabpfn-client API: "
+                "https://github.com/PriorLabs/tabpfn-client"
+            )
         elif num_samples > 200:
             warnings.warn(
                 "Running on CPU with more than 200 samples may be slow.\n"

--- a/src/tabpfn/base.py
+++ b/src/tabpfn/base.py
@@ -247,6 +247,7 @@ def create_inference_engine(  # noqa: PLR0913
 def check_cpu_warning(
     device: str | torch.device,
     X: np.ndarray | torch.Tensor | pd.DataFrame,
+    *,
     allow_cpu_override: bool = False,
 ) -> None:
     """Check if using CPU with large datasets and warn or error appropriately.
@@ -256,7 +257,9 @@ def check_cpu_warning(
         X: The input data (NumPy array, Pandas DataFrame, or Torch Tensor)
         allow_cpu_override: If True, allow CPU usage with large datasets.
     """
-    allow_cpu_override = allow_cpu_override or (os.getenv("TABPFN_ALLOW_CPU_LARGE_DATASET", "0") == "1")
+    allow_cpu_override = allow_cpu_override or (
+        os.getenv("TABPFN_ALLOW_CPU_LARGE_DATASET", "0") == "1"
+    )
 
     if allow_cpu_override:
         return
@@ -275,11 +278,12 @@ def check_cpu_warning(
                 "Running on CPU with more than 1000 samples is not allowed "
                 "by default due to slow performance.\n"
                 "To override this behavior, set the environment variable "
-                "TABPFN_ALLOW_CPU_LARGE_DATASET=1 or set ignore_pretraining_limits=True.\n"
+                "TABPFN_ALLOW_CPU_LARGE_DATASET=1 or "
+                "set ignore_pretraining_limits=True.\n"
                 "Alternatively, consider using a GPU or the tabpfn-client API: "
                 "https://github.com/PriorLabs/tabpfn-client"
             )
-        elif num_samples > 200:
+        if num_samples > 200:
             warnings.warn(
                 "Running on CPU with more than 200 samples may be slow.\n"
                 "Consider using a GPU or the tabpfn-client API: "

--- a/src/tabpfn/classifier.py
+++ b/src/tabpfn/classifier.py
@@ -429,7 +429,9 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
             ignore_pretraining_limits=self.ignore_pretraining_limits,
         )
 
-        check_cpu_warning(self.device, X, allow_cpu_override=self.ignore_pretraining_limits)
+        check_cpu_warning(
+            self.device, X, allow_cpu_override=self.ignore_pretraining_limits
+        )
 
         if feature_names_in is not None:
             self.feature_names_in_ = feature_names_in

--- a/src/tabpfn/classifier.py
+++ b/src/tabpfn/classifier.py
@@ -228,8 +228,8 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
                 pre-training range.
 
                 - If `True`, the model will not raise an error if the input data is
-                  outside the pre-training range. Also allows to use the model with
-                  more than 1000 samples on CPU.
+                  outside the pre-training range. Also supresses error when using
+                  the model with more than 1000 samples on CPU.
                 - If `False`, you can use the model outside the pre-training range, but
                   the model could perform worse.
 

--- a/src/tabpfn/classifier.py
+++ b/src/tabpfn/classifier.py
@@ -228,7 +228,8 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
                 pre-training range.
 
                 - If `True`, the model will not raise an error if the input data is
-                  outside the pre-training range.
+                  outside the pre-training range. Also allows to use the model with
+                  more than 1000 samples on CPU.
                 - If `False`, you can use the model outside the pre-training range, but
                   the model could perform worse.
 
@@ -428,7 +429,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
             ignore_pretraining_limits=self.ignore_pretraining_limits,
         )
 
-        check_cpu_warning(self.device, X)
+        check_cpu_warning(self.device, X, allow_cpu_override=self.ignore_pretraining_limits)
 
         if feature_names_in is not None:
             self.feature_names_in_ = feature_names_in

--- a/src/tabpfn/regressor.py
+++ b/src/tabpfn/regressor.py
@@ -457,7 +457,9 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
             ignore_pretraining_limits=self.ignore_pretraining_limits,
         )
         assert isinstance(X, np.ndarray)
-        check_cpu_warning(self.device, X, allow_cpu_override=self.ignore_pretraining_limits)
+        check_cpu_warning(
+            self.device, X, allow_cpu_override=self.ignore_pretraining_limits
+        )
 
         if feature_names_in is not None:
             self.feature_names_in_ = feature_names_in

--- a/src/tabpfn/regressor.py
+++ b/src/tabpfn/regressor.py
@@ -251,7 +251,8 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
                 pre-training range.
 
                 - If `True`, the model will not raise an error if the input data is
-                  outside the pre-training range.
+                  outside the pre-training range. Also allows to use the model with
+                  more than 1000 samples on CPU.
                 - If `False`, you can use the model outside the pre-training range, but
                   the model could perform worse.
 
@@ -456,7 +457,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
             ignore_pretraining_limits=self.ignore_pretraining_limits,
         )
         assert isinstance(X, np.ndarray)
-        check_cpu_warning(self.device, X)
+        check_cpu_warning(self.device, X, allow_cpu_override=self.ignore_pretraining_limits)
 
         if feature_names_in is not None:
             self.feature_names_in_ = feature_names_in

--- a/src/tabpfn/regressor.py
+++ b/src/tabpfn/regressor.py
@@ -251,8 +251,8 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
                 pre-training range.
 
                 - If `True`, the model will not raise an error if the input data is
-                  outside the pre-training range. Also allows to use the model with
-                  more than 1000 samples on CPU.
+                  outside the pre-training range. Also supresses error when using
+                  the model with more than 1000 samples on CPU.
                 - If `False`, you can use the model outside the pre-training range, but
                   the model could perform worse.
 

--- a/tests/test_regressor_interface.py
+++ b/tests/test_regressor_interface.py
@@ -364,6 +364,21 @@ def test_cpu_large_dataset_warning():
             os.environ.pop("TABPFN_ALLOW_CPU_LARGE_DATASET")
 
 
+def test_cpu_large_dataset_warning_override():
+    """Test that runtime error is raised when using CPU with large datasets
+    and that we can disable the error with ignore_pretraining_limits."""
+    rng = np.random.default_rng(seed=42)
+    X_large = rng.random((1001, 10))
+    y_large = rng.random(1001)
+
+    with pytest.raises(RuntimeError):
+        model = TabPFNRegressor(device="cpu")
+        model.fit(X_large, y_large)
+
+    model = TabPFNRegressor(device="cpu", ignore_pretraining_limits=True)
+    model.fit(X_large, y_large)
+
+
 def test_cpu_large_dataset_error():
     """Test that an error is raised when using CPU with very large datasets."""
     # Create a CPU model

--- a/tests/test_regressor_interface.py
+++ b/tests/test_regressor_interface.py
@@ -357,16 +357,6 @@ def test_cpu_large_dataset_warning():
     ):
         model.fit(X_large, y_large)
 
-    X_large = rng.random((1001, 10))
-    y_large = rng.random(1001)
-    # Set environment variable to allow large datasets to avoid RuntimeError
-    os.environ["TABPFN_ALLOW_CPU_LARGE_DATASET"] = "1"
-    try:
-        model.fit(X_large, y_large)
-    finally:
-        # Clean up environment variable
-        os.environ.pop("TABPFN_ALLOW_CPU_LARGE_DATASET")
-
 
 def test_cpu_large_dataset_warning_override():
     """Test that runtime error is raised when using CPU with large datasets
@@ -379,9 +369,18 @@ def test_cpu_large_dataset_warning_override():
         model = TabPFNRegressor(device="cpu")
         model.fit(X_large, y_large)
 
+    # -- Test overrides
     model = TabPFNRegressor(device="cpu", ignore_pretraining_limits=True)
     model.fit(X_large, y_large)
 
+    # Set environment variable to allow large datasets to avoid RuntimeError
+    os.environ["TABPFN_ALLOW_CPU_LARGE_DATASET"] = "1"
+    try:
+        model = TabPFNRegressor(device="cpu", ignore_pretraining_limits=False)
+        model.fit(X_large, y_large)
+    finally:
+        # Clean up environment variable
+        os.environ.pop("TABPFN_ALLOW_CPU_LARGE_DATASET")
 
 def test_cpu_large_dataset_error():
     """Test that an error is raised when using CPU with very large datasets."""

--- a/tests/test_regressor_interface.py
+++ b/tests/test_regressor_interface.py
@@ -360,13 +360,16 @@ def test_cpu_large_dataset_warning():
 
 def test_cpu_large_dataset_warning_override():
     """Test that runtime error is raised when using CPU with large datasets
-    and that we can disable the error with ignore_pretraining_limits."""
+    and that we can disable the error with ignore_pretraining_limits.
+    """
     rng = np.random.default_rng(seed=42)
     X_large = rng.random((1001, 10))
     y_large = rng.random(1001)
 
-    with pytest.raises(RuntimeError, match="Running on CPU with more than 1000 samples is not"):
-        model = TabPFNRegressor(device="cpu")
+    model = TabPFNRegressor(device="cpu")
+    with pytest.raises(
+        RuntimeError, match="Running on CPU with more than 1000 samples is not"
+    ):
         model.fit(X_large, y_large)
 
     # -- Test overrides
@@ -381,6 +384,7 @@ def test_cpu_large_dataset_warning_override():
     finally:
         # Clean up environment variable
         os.environ.pop("TABPFN_ALLOW_CPU_LARGE_DATASET")
+
 
 def test_cpu_large_dataset_error():
     """Test that an error is raised when using CPU with very large datasets."""

--- a/tests/test_regressor_interface.py
+++ b/tests/test_regressor_interface.py
@@ -355,13 +355,17 @@ def test_cpu_large_dataset_warning():
     with pytest.warns(
         UserWarning, match="Running on CPU with more than 200 samples may be slow"
     ):
-        # Set environment variable to allow large datasets to avoid RuntimeError
-        os.environ["TABPFN_ALLOW_CPU_LARGE_DATASET"] = "1"
-        try:
-            model.fit(X_large, y_large)
-        finally:
-            # Clean up environment variable
-            os.environ.pop("TABPFN_ALLOW_CPU_LARGE_DATASET")
+        model.fit(X_large, y_large)
+
+    X_large = rng.random((1001, 10))
+    y_large = rng.random(1001)
+    # Set environment variable to allow large datasets to avoid RuntimeError
+    os.environ["TABPFN_ALLOW_CPU_LARGE_DATASET"] = "1"
+    try:
+        model.fit(X_large, y_large)
+    finally:
+        # Clean up environment variable
+        os.environ.pop("TABPFN_ALLOW_CPU_LARGE_DATASET")
 
 
 def test_cpu_large_dataset_warning_override():
@@ -371,7 +375,7 @@ def test_cpu_large_dataset_warning_override():
     X_large = rng.random((1001, 10))
     y_large = rng.random(1001)
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError, match="Running on CPU with more than 1000 samples is not"):
         model = TabPFNRegressor(device="cpu")
         model.fit(X_large, y_large)
 


### PR DESCRIPTION
Currently, one can only use TabPFN on a CPU with more than 1000 samples by setting an environment variable.
That makes using TabPFN in pipelines very annoying. 

This PR also enables users to ignore this limit by setting `ignore_pretraining_limits=True`.

