### PR TITLE
Fix missing comma in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 ]
 requires-python = ">=3.9"
 authors = [
-  { name = "Noah Hollmann" }
+  { name = "Noah Hollmann" },
   { name = "Samuel Müller" },
   { name = "Lennart Purucker" },
   { name = "Arjun Krishnakumar" },


### PR DESCRIPTION
`pip install -e ".[dev]"` currently yields the following error due to a missing comma on line 20. Error was introduced in commit 233e20b7fa2d0515eddd978bf7a75fba6523f497
```
tomllib.TOMLDecodeError: Unclosed array (at line 20, column 3)
```