### PR TITLE
Use hash based versioning for actions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           src: "./src ./tests"
           version: 0.8.6
-      - uses: chartboost/ruff-action@d0a0e814ec17e92d33be7d24dd922b479f1bcd38 # v1.1.1
+      - uses: astral-sh/ruff-action@d0a0e814ec17e92d33be7d24dd922b479f1bcd38 # v1.1.1
         with:
           src: "./src ./tests"
           version: 0.8.6

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: chartboost/ruff-action@d0a0e814ec17e92d33be7d24dd922b479f1bcd38 # v1.1.1
+      - uses: astral-sh/ruff-action@d0a0e814ec17e92d33be7d24dd922b479f1bcd38 # v1.1.1
         with:
           src: "./src ./tests"
           version: 0.8.6

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,12 +9,12 @@ jobs:
     name: Ruff Linting & Formatting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: chartboost/ruff-action@v1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: chartboost/ruff-action@d0a0e814ec17e92d33be7d24dd922b479f1bcd38 # v1.1.1
         with:
           src: "./src ./tests"
           version: 0.8.6
-      - uses: chartboost/ruff-action@v1
+      - uses: chartboost/ruff-action@d0a0e814ec17e92d33be7d24dd922b479f1bcd38 # v1.1.1
         with:
           src: "./src ./tests"
           version: 0.8.6
@@ -48,16 +48,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           enable-cache: true
 


### PR DESCRIPTION
Using commit hashes is more secure as it locks to a specific version, preventing new (potentially malicious) version from running. This would prevent for instance: https://www.wiz.io/blog/github-action-tj-actions-changed-files-supply-chain-attack-cve-2025-30066