### PR TITLE
bump package version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tabpfn"
-version = "2.0.7"
+version = "2.0.9"
 dependencies = [
   "torch>=2.1,<3",
   "scikit-learn>=1.2.0,<1.7",


### PR DESCRIPTION
Going from 2.0.7 to 2.0.9 because the 2.0.8 bump wasn't pushed