### PR TITLE
Fix is_autocast_available fallback

### DIFF
--- a/src/tabpfn/utils.py
+++ b/src/tabpfn/utils.py
@@ -190,7 +190,7 @@ def is_autocast_available(device_type: str) -> bool:
                 or (
                     device_type == torch.device("cpu").type
                     and (
-                        getattr(torch, "cpu", None) is not None
+                        hasattr(torch, "cpu")
                         and hasattr(torch.cpu, "amp")
                     )
                 )

--- a/src/tabpfn/utils.py
+++ b/src/tabpfn/utils.py
@@ -189,7 +189,10 @@ def is_autocast_available(device_type: str) -> bool:
                 device_type == torch.device("cuda").type
                 or (
                     device_type == torch.device("cpu").type
-                    and hasattr(torch.cpu, "amp")
+                    and (
+                        getattr(torch, "cpu", None) is not None
+                        and hasattr(torch.cpu, "amp")
+                    )
                 )
             ),
         )


### PR DESCRIPTION
## Summary
- avoid AttributeError when torch.cpu is absent in `is_autocast_available`
- verify `get_total_memory_windows` tests

## Testing
- `pytest tests/test_utils.py -q`