### PR TITLE
Enable auto append_original

### DIFF
--- a/src/tabpfn/model/preprocessing.py
+++ b/src/tabpfn/model/preprocessing.py
@@ -877,7 +877,7 @@ class ReshapeFeatureDistributionsStep(FeaturePreprocessingTransformerStep):
         *,
         transform_name: str = "safepower",
         apply_to_categorical: bool = False,
-        append_to_original: bool = False,
+        append_to_original: bool | Literal["auto"] = False,
         subsample_features: float = -1,
         global_transformer_name: str | None = None,
         random_state: int | np.random.Generator | None = None,
@@ -942,15 +942,21 @@ class ReshapeFeatureDistributionsStep(FeaturePreprocessingTransformerStep):
 
         numerical_ix = [i for i in range(n_features) if i not in categorical_features]
 
+        append_to_original = (
+            n_features < 500
+            if self.append_to_original == "auto"
+            else self.append_to_original
+        )
+
         # -------- Append to original ------
         # If we append to original, all the categorical indices are kept in place
         # as the first transform is a passthrough on the whole X as it is above
-        if self.append_to_original and self.apply_to_categorical:
+        if append_to_original and self.apply_to_categorical:
             trans_ixs = categorical_features + numerical_ix
             transformers.append(("original", "passthrough", all_feats_ix))
             cat_ix = categorical_features  # Exist as they are in original
 
-        elif self.append_to_original and not self.apply_to_categorical:
+        elif append_to_original and not self.apply_to_categorical:
             trans_ixs = numerical_ix
             # Includes the categoricals passed through
             transformers.append(("original", "passthrough", all_feats_ix))
@@ -960,11 +966,11 @@ class ReshapeFeatureDistributionsStep(FeaturePreprocessingTransformerStep):
         # We only have categorical indices if we don't transform them
         # The first transformer will be a passthrough on the categorical indices
         # Making them the first
-        elif not self.append_to_original and self.apply_to_categorical:
+        elif not append_to_original and self.apply_to_categorical:
             trans_ixs = categorical_features + numerical_ix
             cat_ix = []  # We have none left, they've been transformed
 
-        elif not self.append_to_original and not self.apply_to_categorical:
+        elif not append_to_original and not self.apply_to_categorical:
             trans_ixs = numerical_ix
             transformers.append(("cats", "passthrough", categorical_features))
             cat_ix = list(range(len(categorical_features)))  # They are at start

--- a/src/tabpfn/preprocessing.py
+++ b/src/tabpfn/preprocessing.py
@@ -56,7 +56,9 @@ class PreprocessorConfig:
         categorical_name:
             Name of the categorical encoding method.
             Options: "none", "numeric", "onehot", "ordinal", "ordinal_shuffled", "none".
-        append_original: Whether to append original features to the transformed features
+        append_original: Whether to append original features to the transformed
+            features. Set to ``"auto"`` to append only if the dataset has fewer
+            than 500 features.
         subsample_features: Fraction of features to subsample. -1 means no subsampling.
         global_transformer_name: Name of the global transformer to use.
     """
@@ -117,7 +119,7 @@ class PreprocessorConfig:
         "ordinal_shuffled",
         "ordinal_very_common_categories_shuffled",
     ] = "none"
-    append_original: bool = False
+    append_original: bool | Literal["auto"] = False
     subsample_features: float = -1
     global_transformer_name: str | None = None
 
@@ -125,7 +127,7 @@ class PreprocessorConfig:
     def __str__(self) -> str:
         return (
             f"{self.name}_cat:{self.categorical_name}"
-            + ("_and_none" if self.append_original else "")
+            + ("_and_none" if self.append_original is True else "")
             + (
                 f"_subsample_feats_{self.subsample_features}"
                 if self.subsample_features > 0
@@ -176,7 +178,7 @@ def default_classifier_preprocessor_configs() -> list[PreprocessorConfig]:
     return [
         PreprocessorConfig(
             "quantile_uni_coarse",
-            append_original=True,
+            append_original="auto",
             categorical_name="ordinal_very_common_categories_shuffled",
             global_transformer_name="svd",
             subsample_features=-1,
@@ -194,7 +196,7 @@ def default_regressor_preprocessor_configs() -> list[PreprocessorConfig]:
     return [
         PreprocessorConfig(
             "quantile_uni",
-            append_original=True,
+            append_original="auto",
             categorical_name="ordinal_very_common_categories_shuffled",
             global_transformer_name="svd",
         ),


### PR DESCRIPTION
## Summary
- add an "auto" option for `append_original`
- update default preprocessor configs to use the new option
- document that "auto" only appends when there are fewer than 500 features
- compute automatic behaviour when creating preprocessing pipelines

## Testing
- `pre-commit run --files src/tabpfn/preprocessing.py src/tabpfn/model/preprocessing.py`
- `pytest -q` *(failed: tests ran but appear to stop midway)*