### PR TITLE
Remove unused download script

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,9 +228,9 @@ This script will download the main classifier and regressor models, as well as a
 
 **Manual Download**
 
-1. Download the model files manually from HuggingFace:
-   - Classifier: [tabpfn-v2-classifier.ckpt](https://huggingface.co/Prior-Labs/TabPFN-v2-clf/resolve/main/tabpfn-v2-classifier.ckpt)
-   - Regressor: [tabpfn-v2-regressor.ckpt](https://huggingface.co/Prior-Labs/TabPFN-v2-reg/resolve/main/tabpfn-v2-regressor.ckpt)
+1. Download the model files manually from HuggingFace (or use the S3 fallback if HuggingFace is unavailable):
+   - Classifier: [tabpfn-v2-classifier.ckpt](https://huggingface.co/Prior-Labs/TabPFN-v2-clf/resolve/main/tabpfn-v2-classifier.ckpt) ([S3 fallback](https://storage.googleapis.com/tabpfn-v2-model-files/05152025/tabpfn-v2-classifier.ckpt))
+   - Regressor: [tabpfn-v2-regressor.ckpt](https://huggingface.co/Prior-Labs/TabPFN-v2-reg/resolve/main/tabpfn-v2-regressor.ckpt) ([S3 fallback](https://storage.googleapis.com/tabpfn-v2-model-files/05152025/tabpfn-v2-regressor.ckpt))
 
 2. Place the file in one of these locations:
    - Specify directly: `TabPFNClassifier(model_path="/path/to/model.ckpt")`

--- a/src/tabpfn/model/loading.py
+++ b/src/tabpfn/model/loading.py
@@ -35,6 +35,9 @@ from tabpfn.model.transformer import PerFeatureTransformer
 
 logger = logging.getLogger(__name__)
 
+# Public fallback base URL for model downloads
+FALLBACK_S3_BASE_URL = "https://storage.googleapis.com/tabpfn-v2-model-files/05152025"
+
 
 class ModelType(str, Enum):
     CLASSIFIER = "classifier"
@@ -83,10 +86,18 @@ class ModelSource:
         )
 
     def get_fallback_urls(self) -> list[str]:
-        return [
-            f"https://huggingface.co/{self.repo_id}/resolve/main/{filename}?download=true"
+        """Return list of fallback URLs for model downloads."""
+        urls = [
+            (
+                "https://huggingface.co/"
+                f"{self.repo_id}/resolve/main/{filename}?download=true"
+            )
             for filename in self.filenames
         ]
+        urls.extend(
+            [f"{FALLBACK_S3_BASE_URL}/{filename}" for filename in self.filenames]
+        )
+        return urls
 
 
 def _get_model_source(version: ModelVersion, model_type: ModelType) -> ModelSource:
@@ -199,38 +210,42 @@ def _try_direct_downloads(
         if filename not in source.filenames:
             source.filenames.append(filename)
 
-    model_url = (
-        f"https://huggingface.co/{source.repo_id}/resolve/main/{filename}?download=true"
-    )
-    config_url = f"https://huggingface.co/{source.repo_id}/resolve/main/config.json?download=true"
+    url_pairs = [
+        (
+            f"https://huggingface.co/{source.repo_id}/resolve/main/{filename}?download=true",
+            f"https://huggingface.co/{source.repo_id}/resolve/main/config.json?download=true",
+        ),
+        (f"{FALLBACK_S3_BASE_URL}/{filename}", f"{FALLBACK_S3_BASE_URL}/config.json"),
+    ]
 
-    # Create parent directory if it doesn't exist
+    last_error: Exception | None = None
     base_path.parent.mkdir(parents=True, exist_ok=True)
 
-    logger.info(f"Attempting download from {model_url}")
-
-    try:
-        # Download model checkpoint
-        with urllib.request.urlopen(model_url) as response:  # noqa: S310
-            if response.status != 200:
-                raise URLError(
-                    f"HTTP {response.status} when downloading from {model_url}",
-                )
-            base_path.write_bytes(response.read())
-
-        # Try to download config.json
-        config_path = base_path.parent / "config.json"
+    for model_url, config_url in url_pairs:
+        logger.info(f"Attempting download from {model_url}")
         try:
-            with urllib.request.urlopen(config_url) as response:  # noqa: S310
-                if response.status == 200:
-                    config_path.write_bytes(response.read())
-        except Exception:  # noqa: BLE001
-            logger.warning("Failed to download config.json!")
-            # Continue even if config.json download fails
+            with urllib.request.urlopen(model_url) as response:  # noqa: S310
+                if response.status != 200:
+                    raise URLError(
+                        f"HTTP {response.status} when downloading from {model_url}",
+                    )
+                base_path.write_bytes(response.read())
 
-        logger.info(f"Successfully downloaded to {base_path}")
-    except Exception as e:
-        raise Exception("Direct download failed!") from e
+            config_path = base_path.parent / "config.json"
+            try:
+                with urllib.request.urlopen(config_url) as response:  # noqa: S310
+                    if response.status == 200:
+                        config_path.write_bytes(response.read())
+            except Exception:  # noqa: BLE001
+                logger.warning("Failed to download config.json!")
+
+            logger.info(f"Successfully downloaded to {base_path}")
+            return
+        except Exception as e:  # noqa: BLE001
+            last_error = e
+            logger.warning(f"Failed download from {model_url}: {e!s}")
+
+    raise Exception("Direct download failed!") from last_error
 
 
 def download_model(

--- a/tests/test_download_fallbacks.py
+++ b/tests/test_download_fallbacks.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import urllib.request
+from pathlib import Path
+from urllib.error import URLError
+
+from tabpfn.model.loading import (
+    FALLBACK_S3_BASE_URL,
+    ModelSource,
+    _try_direct_downloads,
+)
+
+
+class DummyResponse:
+    def __init__(self, data: bytes = b"data", status: int = 200) -> None:
+        """Store dummy response information."""
+        self.data = data
+        self.status = status
+
+    def read(self) -> bytes:
+        """Return response data."""
+        return self.data
+
+    def __enter__(self) -> DummyResponse:
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+
+def test_try_direct_downloads_fallback(monkeypatch, tmp_path: Path) -> None:
+    src = ModelSource.get_classifier_v2()
+    dest = tmp_path / src.default_filename
+    calls: list[str] = []
+
+    def fake_urlopen(url: str):
+        calls.append(url)
+        if url.startswith("https://huggingface.co/"):
+            raise URLError("hf down")
+        return DummyResponse()
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    _try_direct_downloads(dest, src)
+
+    assert dest.exists()
+    assert any(url.startswith(FALLBACK_S3_BASE_URL) for url in calls)


### PR DESCRIPTION
## Summary
- delete `download_all_tabpfn_models.sh`
- test S3 fallback logic using mocked `urlopen`
- clean README instructions to reference only `download_all_models.py`

## Testing
- `pre-commit run --files README.md src/tabpfn/model/loading.py tests/test_download_fallbacks.py`
- `PYTHONPATH=$PWD/src pytest -q tests/test_download_fallbacks.py`
