### PR TITLE
Add TPU and MPS device support

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ For optimal performance, use the `AutoTabPFNClassifier` or `AutoTabPFNRegressor`
    ```python 
    from tabpfn_extensions.post_hoc_ensembles.sklearn_interface import AutoTabPFNClassifier
 
-   clf = AutoTabPFNClassifier(max_time=120, device="cuda") # 120 seconds tuning time
+   # "auto" selects CUDA or MPS when available
+   clf = AutoTabPFNClassifier(max_time=120, device="auto") # 120 seconds tuning time
    clf.fit(X_train, y_train)
    predictions = clf.predict(X_test)
    ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,9 @@ dev = [
   "mike",
   "black",  # This allows mkdocstrings to format signatures in the docs
 ]
+tpu = [
+  "torch_xla>=2.1,<3",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]  # Where the tests are located

--- a/tests/test_device_detection.py
+++ b/tests/test_device_detection.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import pytest
+import sklearn.datasets
+import torch
+
+from tabpfn import TabPFNClassifier
+from tabpfn.utils import infer_device_and_type
+
+
+def test_auto_prefers_cuda(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    if getattr(torch.backends, "mps", None):
+        monkeypatch.setattr(torch.backends.mps, "is_available", lambda: False)
+    device = infer_device_and_type("auto")
+    assert device.type == "cuda"
+
+
+def test_auto_prefers_mps_when_cuda_unavailable(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    if getattr(torch.backends, "mps", None):
+        monkeypatch.setattr(torch.backends.mps, "is_available", lambda: True)
+    else:
+        pytest.skip("MPS backend not available in torch")
+    device = infer_device_and_type("auto")
+    assert device.type == "mps"
+
+
+def test_auto_falls_back_to_cpu(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    if getattr(torch.backends, "mps", None):
+        monkeypatch.setattr(torch.backends.mps, "is_available", lambda: False)
+    device = infer_device_and_type("auto")
+    assert device.type == "cpu"
+
+
+def test_mps_string_returns_device():
+    device = infer_device_and_type("mps")
+    assert isinstance(device, torch.device)
+    assert device.type == "mps"
+
+
+def test_model_runs_on_mps_if_available():
+    if not (getattr(torch.backends, "mps", None) and torch.backends.mps.is_available()):
+        pytest.skip("MPS backend not available in torch")
+
+    X, y = sklearn.datasets.load_iris(return_X_y=True)
+    X, y = X[:10], y[:10]
+
+    model = TabPFNClassifier(n_estimators=1, device="mps")
+    model.fit(X, y)
+    predictions = model.predict(X)
+
+    assert len(predictions) == len(y)


### PR DESCRIPTION
## Summary
- expand device detection to support Apple MPS and TPUs
- document automatic device selection in README
- use `is_autocast_available` helper in tests
- add tests for device detection logic

## Testing
- `ruff check src/tabpfn/utils.py tests/test_classifier_interface.py tests/test_regressor_interface.py tests/test_device_detection.py tests/test_utils.py`
- `PYTHONPATH=src pytest -k infer_device -q`
- `PYTHONPATH=src pytest tests/test_device_detection.py -q`
