### PR TITLE
Fix variable name in interface tests

### DIFF
--- a/tests/test_classifier_interface.py
+++ b/tests/test_classifier_interface.py
@@ -40,7 +40,7 @@ fit_modes = [
     "fit_with_cache",
 ]
 inference_precision_methods = ["auto", "autocast", torch.float64, torch.float16]
-remove_remove_outliers_stds = [None, 12]
+remove_outliers_stds = [None, 12]
 estimators = [1, 2]
 
 all_combinations = list(
@@ -51,7 +51,7 @@ all_combinations = list(
         multiclass_decoders,
         fit_modes,
         inference_precision_methods,
-        remove_remove_outliers_stds,
+        remove_outliers_stds,
     ),
 )
 

--- a/tests/test_regressor_interface.py
+++ b/tests/test_regressor_interface.py
@@ -37,7 +37,7 @@ fit_modes = [
     "fit_with_cache",
 ]
 inference_precision_methods = ["auto", "autocast", torch.float64, torch.float16]
-remove_remove_outliers_stds = [None, 12]
+remove_outliers_stds = [None, 12]
 estimators = [1, 2]
 
 all_combinations = list(
@@ -47,7 +47,7 @@ all_combinations = list(
         feature_shift_decoders,
         fit_modes,
         inference_precision_methods,
-        remove_remove_outliers_stds,
+        remove_outliers_stds,
     ),
 )
 


### PR DESCRIPTION
## Summary
- fix typo in variable name for outlier removal standard deviation options
- update parameter combinations in classifier and regressor interface tests

## Testing
- `pytest tests/test_classifier_interface.py tests/test_regressor_interface.py -q`

------
https://chatgpt.com/codex/tasks/task_b_685c2a2a51a88333a9b4a123203c93eb