### PR TITLE
Fix quantiles docstring

### DIFF
--- a/src/tabpfn/regressor.py
+++ b/src/tabpfn/regressor.py
@@ -742,7 +742,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
                 - If `"median"`, we return the median over the predicted distribution.
                 - If `"mode"`, we return the mode over the predicted distribution.
                 - If `"quantiles"`, we return the quantiles of the predicted
-                    distribution. The parameter `output_quantiles` determines which
+                    distribution. The parameter `quantiles` determines which
                     quantiles are returned.
                 - If `"main"`, we return the all output types above in a dict.
                 - If `"full"`, we return the full output of the model, including the

--- a/tests/test_finetuning_classifier.py
+++ b/tests/test_finetuning_classifier.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import unittest
 from functools import partial
-from typing import Literal
+from typing import Any, Literal
 from unittest.mock import patch
 
 import numpy as np
@@ -51,7 +51,7 @@ default_config = {
     "inference_precision": "auto",
 }
 
-param_values = {
+param_values: dict[str, list[Any]] = {
     "n_estimators": estimators,
     "device": devices,
     "fit_mode": fit_modes,

--- a/tests/test_finetuning_regressor.py
+++ b/tests/test_finetuning_regressor.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import unittest
 from functools import partial
-from typing import Literal
+from typing import Any, Literal
 from unittest.mock import patch
 
 import numpy as np
@@ -54,7 +54,7 @@ default_config = {
     "optimization_space": "raw_label_space",
 }
 
-param_values = {
+param_values: dict[str, list[Any]] = {
     "n_estimators": estimators,
     "device": devices,
     "fit_mode": fit_modes,


### PR DESCRIPTION
## Summary
- correct parameter reference in `TabPFNRegressor.predict` docstring
- annotate parameter dictionaries in finetuning tests so mypy passes

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685c2a3aefd08333a99fdda06631172b