### PR TITLE
Fix contextlib import for preprocessing

### DIFF
--- a/src/tabpfn/model/preprocessing.py
+++ b/src/tabpfn/model/preprocessing.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import warnings
 from abc import abstractmethod
@@ -14,7 +15,6 @@ from typing_extensions import Self, override
 import numpy as np
 import scipy
 import torch
-from pandas.core.common import contextlib
 from scipy.stats import shapiro
 from sklearn.compose import ColumnTransformer, make_column_selector
 from sklearn.decomposition import TruncatedSVD


### PR DESCRIPTION
## Summary
- replace `pandas.core.common` contextlib import with the builtin module
- keep `contextlib.suppress` usage intact

## Testing
- `pytest -q tests/test_preprocessing.py::test_diff_znorm_initialization`

------
https://chatgpt.com/codex/tasks/task_b_685c647238bc833394d865a2a0da3c76