### PR TITLE
Fix docstring for generate_index_permutations

### DIFF
--- a/src/tabpfn/preprocessing.py
+++ b/src/tabpfn/preprocessing.py
@@ -250,7 +250,6 @@ def generate_index_permutations(
         subsample:
             Number of indices to subsample. If `int`, subsample that many
             indices. If float, subsample that fraction of indices.
-            random_state: Random number generator.
         random_state: Random number generator.
 
     Returns:


### PR DESCRIPTION
## Summary
- fix the generate_index_permutations docstring to document `subsample` and `random_state` separately

## Testing
- `pre-commit run --files src/tabpfn/preprocessing.py`

------
https://chatgpt.com/codex/tasks/task_b_685c65ccecf88333acb0394da36dbf35