### PR TITLE
Fix small typo in preprocessing docstring

### DIFF
--- a/src/tabpfn/preprocessing.py
+++ b/src/tabpfn/preprocessing.py
@@ -624,7 +624,7 @@ def fit_preprocessing_one(
 
 
 def transform_labels_one(config, y_train):
-    """Transform the labels for one ensembel config.
+    """Transform the labels for one ensemble config.
         for both regression or classification.
 
     Args:


### PR DESCRIPTION
## Summary
- fix a spelling error in `transform_labels_one` docstring

## Testing
- `pre-commit run --files src/tabpfn/preprocessing.py`
- `pytest tests/test_preprocessing.py::test_diff_znorm_initialization -q`

------
https://chatgpt.com/codex/tasks/task_b_685c65dd28d48333b673a4a761f9a696