### PR TITLE
Extend preprocessing test

### DIFF
--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -43,8 +43,16 @@ def test_preprocessing_large_dataset():
     # Run the preprocessing step
     result = preprocessing_step.fit_transform(X, categorical_features)
 
-    # Assert the result is not None
+    # Assert the result is not None and has the correct structure
     assert result is not None
+
+    Xt = result.X
+
+    # Verify the output shape matches the input shape
+    assert Xt.shape == (num_samples, num_features)
+
+    # Verify the dtype of the output matches the dtype of the input
+    assert Xt.dtype == X.dtype
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- ensure preprocessing test checks the shape and dtype of the transformed result

## Testing
- `pytest tests/test_preprocessing.py::test_preprocessing_large_dataset -q`
- `pytest -q` *(fails: attempted to download data)*

------
https://chatgpt.com/codex/tasks/task_b_685c65bf17988333b2557b073367ca46