### PR TITLE
Add saving/loading example

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,10 +240,31 @@ This script will download the main classifier and regressor models, as well as a
      - macOS: `~/Library/Caches/tabpfn/`
      - Linux: `~/.cache/tabpfn/`
 
-**Q: I'm getting a `pickle` error when loading the model. What should I do?**  
+**Q: I'm getting a `pickle` error when loading the model. What should I do?**
 A: Try the following:
 - Download the newest version of tabpfn `pip install tabpfn --upgrade`
 - Ensure model files downloaded correctly (re-download if needed)
+
+**Q: How do I save and load a trained TabPFN model?**
+A: Use the utilities from `tabpfn.model.loading`:
+
+```python
+from tabpfn.model.loading import (
+    save_fitted_tabpfn_model,
+    load_fitted_tabpfn_model,
+)
+from tabpfn import TabPFNRegressor
+
+# After fitting `reg` on GPU
+save_fitted_tabpfn_model(reg, "my_reg.pkl")
+
+# Later or on a CPU-only machine
+reg_cpu = load_fitted_tabpfn_model("my_reg.pkl", device="cpu")
+```
+
+To store just the foundation model weights (without a fitted estimator) use
+`save_tabpfn_model(reg.model_, "my_tabpfn.ckpt")` and reload them with
+`load_model_criterion_config`.
 
 ### **Performance & Limitations**
 

--- a/examples/save_and_load_model.py
+++ b/examples/save_and_load_model.py
@@ -1,0 +1,29 @@
+"""Example of saving and loading a fitted TabPFN model."""
+
+from __future__ import annotations
+
+# Copyright (c) Prior Labs GmbH 2025.
+
+from pathlib import Path
+
+from sklearn.datasets import load_diabetes
+from sklearn.model_selection import train_test_split
+
+from tabpfn import TabPFNRegressor
+from tabpfn.model.loading import (
+    load_fitted_tabpfn_model,
+    save_fitted_tabpfn_model,
+)
+
+# Train a regressor on GPU
+X, y = load_diabetes(return_X_y=True)
+X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.33, random_state=42)
+reg = TabPFNRegressor(device="cuda")
+reg.fit(X_train, y_train)
+
+# Save the fitted estimator
+save_fitted_tabpfn_model(reg, Path("trained_reg.pkl"))
+
+# Load on CPU for inference
+reg_cpu = load_fitted_tabpfn_model(Path("trained_reg.pkl"), device="cpu")
+print(reg_cpu.predict(X_test)[:5])

--- a/src/tabpfn/model/loading.py
+++ b/src/tabpfn/model/loading.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import dataclasses
 import logging
 import os
@@ -12,10 +13,11 @@ import warnings
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Literal, cast, overload
+from typing import TYPE_CHECKING, Literal, cast, overload
 from urllib.error import URLError
 
 import torch
+from sklearn.utils.validation import joblib
 from torch import nn
 
 from tabpfn.model.bar_distribution import BarDistribution, FullSupportBarDistribution
@@ -31,6 +33,9 @@ from tabpfn.model.encoders import (
     VariableNumFeaturesEncoderStep,
 )
 from tabpfn.model.transformer import PerFeatureTransformer
+
+if TYPE_CHECKING:
+    from sklearn.base import BaseEstimator
 
 logger = logging.getLogger(__name__)
 
@@ -708,6 +713,18 @@ def get_n_out(
 
 # NOTE: This function doesn't seem to be used anywhere.
 def save_tabpfn_model(model: nn.Module, save_path: Path | str) -> None:
+    """Save the underlying TabPFN foundation model to ``save_path``.
+
+    This writes only the base pre-trained weights and configuration. It does
+    **not** store a fitted :class:`TabPFNRegressor`/``Classifier`` instance.
+
+    Parameters
+    ----------
+    model:
+        The internal model object of a ``TabPFN`` estimator.
+    save_path:
+        Path to save the checkpoint to.
+    """
     # Get model state dict
     model_state = model.model_.state_dict()
 
@@ -729,3 +746,55 @@ def save_tabpfn_model(model: nn.Module, save_path: Path | str) -> None:
 
     # Save the checkpoint
     torch.save(checkpoint, save_path)
+
+
+def save_fitted_tabpfn_model(estimator: BaseEstimator, save_path: Path | str) -> None:
+    """Serialize a trained TabPFN estimator with :mod:`joblib`.
+
+    The estimator is deep-copied and moved to CPU before dumping so the
+    resulting file can be loaded on machines without a GPU. ``joblib`` is used
+    under the hood to avoid relying on raw :mod:`pickle`.
+    """
+    est = copy.deepcopy(estimator)
+    est.model_.to("cpu")
+    if hasattr(est, "bardist_") and est.bardist_ is not None:
+        est.bardist_ = est.bardist_.cpu()
+    if hasattr(est, "normalized_bardist_") and est.normalized_bardist_ is not None:
+        est.normalized_bardist_ = est.normalized_bardist_.cpu()
+    if hasattr(est, "executor_") and hasattr(est.executor_, "model"):
+        est.executor_.model = est.executor_.model.cpu()
+        if hasattr(est.executor_, "X_trains"):
+            est.executor_.X_trains = [
+                x.cpu() if isinstance(x, torch.Tensor) else x
+                for x in est.executor_.X_trains
+            ]
+        if hasattr(est.executor_, "y_trains"):
+            est.executor_.y_trains = [
+                y.cpu() if isinstance(y, torch.Tensor) else y
+                for y in est.executor_.y_trains
+            ]
+
+    est.device_ = torch.device("cpu")
+    est.device = "cpu"
+
+    joblib.dump(est, save_path, compress=3)
+
+
+def load_fitted_tabpfn_model(
+    load_path: Path | str, device: str | torch.device = "cpu"
+) -> BaseEstimator:
+    """Load a fitted TabPFN estimator saved with ``save_fitted_tabpfn_model``.
+
+    Uses :func:`joblib.load` under the hood.
+    """
+    est = joblib.load(load_path)
+    est.device = device
+    est.device_ = torch.device(device)
+    est.model_.to(est.device_)
+    if hasattr(est, "bardist_") and est.bardist_ is not None:
+        est.bardist_ = est.bardist_.to(est.device_)
+    if hasattr(est, "normalized_bardist_") and est.normalized_bardist_ is not None:
+        est.normalized_bardist_ = est.normalized_bardist_.to(est.device_)
+    if hasattr(est, "executor_") and hasattr(est.executor_, "model"):
+        est.executor_.model = est.executor_.model.to(est.device_)
+    return est

--- a/tests/test_save_load_fitted_model.py
+++ b/tests/test_save_load_fitted_model.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import numpy as np
+import torch
+from sklearn.datasets import make_regression
+
+from tabpfn import TabPFNRegressor
+from tabpfn.model.loading import load_fitted_tabpfn_model, save_fitted_tabpfn_model
+
+
+def test_save_and_load_fitted_model(tmp_path):
+    X, y = make_regression(n_samples=20, n_features=4, random_state=0)
+    reg = TabPFNRegressor(
+        n_estimators=1,
+        device="cpu",
+        fit_mode="fit_preprocessors",
+        inference_precision=torch.float32,
+    )
+    reg.fit(X, y)
+
+    path = tmp_path / "model.pkl"
+    save_fitted_tabpfn_model(reg, path)
+
+    loaded = load_fitted_tabpfn_model(path, device="cpu")
+
+    np.testing.assert_allclose(reg.predict(X[:5]), loaded.predict(X[:5]))


### PR DESCRIPTION
## Summary
- document how to save and restore a TabPFN model
- add `examples/save_and_load_model.py`
- clarify `save_tabpfn_model` docstring and implement `save_fitted_tabpfn_model`
- provide tests for saving/loading fitted models
- tweak fitted-model save docstring

## Testing
- `pre-commit run --files src/tabpfn/model/loading.py README.md examples/save_and_load_model.py tests/test_save_load_fitted_model.py`
- `pytest -q tests/test_save_load_fitted_model.py`


------
https://chatgpt.com/codex/tasks/task_b_685c5da037fc83338f5ae3d822d595e0