### PR TITLE
Update embedding docs

### DIFF
--- a/src/tabpfn/classifier.py
+++ b/src/tabpfn/classifier.py
@@ -819,12 +819,21 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
         X: XType,
         data_source: Literal["train", "test"] = "test",
     ) -> np.ndarray:
-        """Get the embeddings for the input data `X`.
+        """Get embeddings for the input data ``X``.
 
-        Parameters:
-            X (XType): The input data.
-            data_source str: Extract either the train or test embeddings
+        Parameters
+        ----------
+        X : XType
+            The input data.
+        data_source : {"train", "test"}, default="test"
+            Select the transformer output to return. Use ``"train"`` to obtain
+            embeddings from the training tokens and ``"test"`` for the test
+            tokens. When ``n_estimators > 1`` the returned array has shape
+            ``(n_estimators, n_samples, embedding_dim)``.
+
         Returns:
-            np.ndarray: The computed embeddings for each fitted estimator.
+        -------
+        np.ndarray
+            The computed embeddings for each fitted estimator.
         """
         return _get_embeddings(self, X, data_source)

--- a/src/tabpfn/classifier.py
+++ b/src/tabpfn/classifier.py
@@ -821,19 +821,17 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
     ) -> np.ndarray:
         """Get embeddings for the input data ``X``.
 
-        Parameters
-        ----------
-        X : XType
-            The input data.
-        data_source : {"train", "test"}, default="test"
-            Select the transformer output to return. Use ``"train"`` to obtain
-            embeddings from the training tokens and ``"test"`` for the test
-            tokens. When ``n_estimators > 1`` the returned array has shape
-            ``(n_estimators, n_samples, embedding_dim)``.
+        Args:
+            X : XType
+                The input data.
+            data_source : {"train", "test"}, default="test"
+                Select the transformer output to return. Use ``"train"`` to obtain
+                embeddings from the training tokens and ``"test"`` for the test
+                tokens. When ``n_estimators > 1`` the returned array has shape
+                ``(n_estimators, n_samples, embedding_dim)``.
 
         Returns:
-        -------
-        np.ndarray
-            The computed embeddings for each fitted estimator.
+            np.ndarray
+                The computed embeddings for each fitted estimator.
         """
         return _get_embeddings(self, X, data_source)

--- a/src/tabpfn/regressor.py
+++ b/src/tabpfn/regressor.py
@@ -1012,7 +1012,21 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
         X: XType,
         data_source: Literal["train", "test"] = "test",
     ) -> np.ndarray:
-        """Gets the embeddings for the input data `X`."""
+        """Gets the embeddings for the input data `X`.
+
+        Args:
+            X : XType
+                The input data.
+            data_source : {"train", "test"}, default="test"
+                Select the transformer output to return. Use ``"train"`` to obtain
+                embeddings from the training tokens and ``"test"`` for the test
+                tokens. When ``n_estimators > 1`` the returned array has shape
+                ``(n_estimators, n_samples, embedding_dim)``.
+
+        Returns:
+            np.ndarray
+                The computed embeddings for each fitted estimator.
+        """
         return _get_embeddings(self, X, data_source)
 
 

--- a/src/tabpfn/utils.py
+++ b/src/tabpfn/utils.py
@@ -64,7 +64,7 @@ def _get_embeddings(
             When ``n_estimators > 1`` the returned array has shape
             ``(n_estimators, n_samples, embedding_dim)``. You can average over the
             first axis or reshape to concatenate the estimators, e.g.:
-    
+
                 emb = _get_embeddings(model, X)
                 emb_avg = emb.mean(axis=0)
                 emb_concat = emb.reshape(emb.shape[1], -1)

--- a/src/tabpfn/utils.py
+++ b/src/tabpfn/utils.py
@@ -47,14 +47,30 @@ def _get_embeddings(
     X: XType,
     data_source: Literal["train", "test"] = "test",
 ) -> np.ndarray:
-    """Get the embeddings for the input data `X`.
+    """Extract embeddings from a fitted TabPFN model.
 
-    Parameters:
-        model TabPFNClassifier | TabPFNRegressor: The fitted classifier or regressor.
-        X (XType): The input data.
-        data_source str: Extract either the train or test embeddings
+    Parameters
+    ----------
+    model : TabPFNClassifier | TabPFNRegressor
+        The fitted classifier or regressor.
+    X : XType
+        The input data.
+    data_source : {"train", "test"}, default="test"
+        Select the transformer output to return. Use ``"train"`` to obtain
+        embeddings from the training tokens and ``"test"`` for the test tokens.
+
+        When ``n_estimators > 1`` the returned array has shape
+        ``(n_estimators, n_samples, embedding_dim)``. You can average over the
+        first axis or reshape to concatenate the estimators, e.g.::
+
+            emb = _get_embeddings(model, X)
+            emb_avg = emb.mean(axis=0)
+            emb_concat = emb.reshape(emb.shape[1], -1)
+
     Returns:
-        np.ndarray: The computed embeddings for each fitted estimator.
+    -------
+    np.ndarray
+        The computed embeddings for each fitted estimator.
     """
     check_is_fitted(model)
 

--- a/src/tabpfn/utils.py
+++ b/src/tabpfn/utils.py
@@ -49,28 +49,25 @@ def _get_embeddings(
 ) -> np.ndarray:
     """Extract embeddings from a fitted TabPFN model.
 
-    Parameters
-    ----------
-    model : TabPFNClassifier | TabPFNRegressor
-        The fitted classifier or regressor.
-    X : XType
-        The input data.
-    data_source : {"train", "test"}, default="test"
-        Select the transformer output to return. Use ``"train"`` to obtain
-        embeddings from the training tokens and ``"test"`` for the test tokens.
-
-        When ``n_estimators > 1`` the returned array has shape
-        ``(n_estimators, n_samples, embedding_dim)``. You can average over the
-        first axis or reshape to concatenate the estimators, e.g.::
-
-            emb = _get_embeddings(model, X)
-            emb_avg = emb.mean(axis=0)
-            emb_concat = emb.reshape(emb.shape[1], -1)
+    Args:
+        model : TabPFNClassifier | TabPFNRegressor
+            The fitted classifier or regressor.
+        X : XType
+            The input data.
+        data_source : {"train", "test"}, default="test"
+            Select the transformer output to return. Use ``"train"`` to obtain
+            embeddings from the training tokens and ``"test"`` for the test tokens.
 
     Returns:
-    -------
-    np.ndarray
-        The computed embeddings for each fitted estimator.
+        np.ndarray
+            The computed embeddings for each fitted estimator.
+            When ``n_estimators > 1`` the returned array has shape
+            ``(n_estimators, n_samples, embedding_dim)``. You can average over the
+            first axis or reshape to concatenate the estimators, e.g.:
+    
+                emb = _get_embeddings(model, X)
+                emb_avg = emb.mean(axis=0)
+                emb_concat = emb.reshape(emb.shape[1], -1)
     """
     check_is_fitted(model)
 


### PR DESCRIPTION
## Summary
- clarify embedding docs about `data_source` and ensemble shapes

## Testing
- `pre-commit run --files src/tabpfn/utils.py src/tabpfn/classifier.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685d0dda879c8333910b89344a0b3f0b