### PR TITLE
Add saving/loading example

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,10 +240,31 @@ This script will download the main classifier and regressor models, as well as a
      - macOS: `~/Library/Caches/tabpfn/`
      - Linux: `~/.cache/tabpfn/`
 
-**Q: I'm getting a `pickle` error when loading the model. What should I do?**  
+**Q: I'm getting a `pickle` error when loading the model. What should I do?**
 A: Try the following:
 - Download the newest version of tabpfn `pip install tabpfn --upgrade`
 - Ensure model files downloaded correctly (re-download if needed)
+
+**Q: How do I save and load a trained TabPFN model?**
+A: Call :meth:`save_fit_state` on the fitted estimator and restore it with
+``TabPFNClassifier.load_from_fit_state`` or ``TabPFNRegressor.load_from_fit_state``.
+
+```python
+from tabpfn import TabPFNRegressor
+
+# Train the regressor on GPU
+reg = TabPFNRegressor(device="cuda")
+reg.fit(X_train, y_train)
+reg.save_fit_state("my_reg.tabpfn_fit")
+
+# Later or on a CPU-only machine
+reg_cpu = TabPFNRegressor.load_from_fit_state("my_reg.tabpfn_fit", device="cpu")
+```
+
+To store just the foundation model weights (without a fitted estimator) use
+``save_tabpfn_model(reg.model_, "my_tabpfn.ckpt")``. This merely saves a
+checkpoint of the pre-trained weights so you can later create and fit a fresh
+estimator. Reload the checkpoint with ``load_model_criterion_config``.
 
 ### **Performance & Limitations**
 

--- a/README.md
+++ b/README.md
@@ -249,8 +249,13 @@ A: Try the following:
 A: Use :func:`save_fitted_tabpfn_model` to persist a fitted estimator and reload
 it later with :func:`load_fitted_tabpfn_model` (or the corresponding
 ``load_from_fit_state`` class methods).
+from tabpfn.model.loading import (
+    load_fitted_tabpfn_model,
+    save_fitted_tabpfn_model,
+)
+save_fitted_tabpfn_model(reg, "my_reg.tabpfn_fit")
 
-```python
+reg_cpu = load_fitted_tabpfn_model("my_reg.tabpfn_fit", device="cpu")
 from tabpfn import TabPFNRegressor
 from tabpfn.model.loading import (
     load_fitted_tabpfn_model,

--- a/README.md
+++ b/README.md
@@ -246,19 +246,24 @@ A: Try the following:
 - Ensure model files downloaded correctly (re-download if needed)
 
 **Q: How do I save and load a trained TabPFN model?**
-A: Call :meth:`save_fit_state` on the fitted estimator and restore it with
-``TabPFNClassifier.load_from_fit_state`` or ``TabPFNRegressor.load_from_fit_state``.
+A: Use :func:`save_fitted_tabpfn_model` to persist a fitted estimator and reload
+it later with :func:`load_fitted_tabpfn_model` (or the corresponding
+``load_from_fit_state`` class methods).
 
 ```python
 from tabpfn import TabPFNRegressor
+from tabpfn.model.loading import (
+    load_fitted_tabpfn_model,
+    save_fitted_tabpfn_model,
+)
 
 # Train the regressor on GPU
 reg = TabPFNRegressor(device="cuda")
 reg.fit(X_train, y_train)
-reg.save_fit_state("my_reg.tabpfn_fit")
+save_fitted_tabpfn_model(reg, "my_reg.tabpfn_fit")
 
 # Later or on a CPU-only machine
-reg_cpu = TabPFNRegressor.load_from_fit_state("my_reg.tabpfn_fit", device="cpu")
+reg_cpu = load_fitted_tabpfn_model("my_reg.tabpfn_fit", device="cpu")
 ```
 
 To store just the foundation model weights (without a fitted estimator) use

--- a/examples/save_and_load_model.py
+++ b/examples/save_and_load_model.py
@@ -14,6 +14,10 @@ from tabpfn.model.loading import (
     load_fitted_tabpfn_model,
     save_fitted_tabpfn_model,
 )
+save_fitted_tabpfn_model(reg, Path("trained_reg.tabpfn_fit"))
+reg_cpu = load_fitted_tabpfn_model(Path("trained_reg.tabpfn_fit"), device="cpu")
+    save_fitted_tabpfn_model,
+)
 
 # Train a regressor on GPU
 X, y = load_diabetes(return_X_y=True)

--- a/examples/save_and_load_model.py
+++ b/examples/save_and_load_model.py
@@ -1,0 +1,25 @@
+"""Example of saving and loading a fitted TabPFN model."""
+
+from __future__ import annotations
+
+# Copyright (c) Prior Labs GmbH 2025.
+
+from pathlib import Path
+
+from sklearn.datasets import load_diabetes
+from sklearn.model_selection import train_test_split
+
+from tabpfn import TabPFNRegressor
+
+# Train a regressor on GPU
+X, y = load_diabetes(return_X_y=True)
+X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.33, random_state=42)
+reg = TabPFNRegressor(device="cuda")
+reg.fit(X_train, y_train)
+
+# Save the fitted estimator
+reg.save_fit_state(Path("trained_reg.tabpfn_fit"))
+
+# Load on CPU for inference
+reg_cpu = TabPFNRegressor.load_from_fit_state(Path("trained_reg.tabpfn_fit"), device="cpu")
+print(reg_cpu.predict(X_test)[:5])

--- a/examples/save_and_load_model.py
+++ b/examples/save_and_load_model.py
@@ -10,6 +10,10 @@ from sklearn.datasets import load_diabetes
 from sklearn.model_selection import train_test_split
 
 from tabpfn import TabPFNRegressor
+from tabpfn.model.loading import (
+    load_fitted_tabpfn_model,
+    save_fitted_tabpfn_model,
+)
 
 # Train a regressor on GPU
 X, y = load_diabetes(return_X_y=True)
@@ -18,8 +22,8 @@ reg = TabPFNRegressor(device="cuda")
 reg.fit(X_train, y_train)
 
 # Save the fitted estimator
-reg.save_fit_state(Path("trained_reg.tabpfn_fit"))
+save_fitted_tabpfn_model(reg, Path("trained_reg.tabpfn_fit"))
 
 # Load on CPU for inference
-reg_cpu = TabPFNRegressor.load_from_fit_state(Path("trained_reg.tabpfn_fit"), device="cpu")
+reg_cpu = load_fitted_tabpfn_model(Path("trained_reg.tabpfn_fit"), device="cpu")
 print(reg_cpu.predict(X_test)[:5])

--- a/src/tabpfn/__init__.py
+++ b/src/tabpfn/__init__.py
@@ -2,6 +2,10 @@ from importlib.metadata import version
 
 from tabpfn.classifier import TabPFNClassifier
 from tabpfn.misc.debug_versions import display_debug_info
+from tabpfn.model.loading import (
+    load_fitted_tabpfn_model,
+    save_fitted_tabpfn_model,
+)
 from tabpfn.regressor import TabPFNRegressor
 
 try:
@@ -14,4 +18,6 @@ __all__ = [
     "TabPFNRegressor",
     "__version__",
     "display_debug_info",
+    "load_fitted_tabpfn_model",
+    "save_fitted_tabpfn_model",
 ]

--- a/src/tabpfn/__init__.py
+++ b/src/tabpfn/__init__.py
@@ -6,6 +6,12 @@ from tabpfn.model.loading import (
     load_fitted_tabpfn_model,
     save_fitted_tabpfn_model,
 )
+    "load_fitted_tabpfn_model",
+    "save_fitted_tabpfn_model",
+from tabpfn.model.loading import (
+    load_fitted_tabpfn_model,
+    save_fitted_tabpfn_model,
+)
 from tabpfn.regressor import TabPFNRegressor
 
 try:

--- a/src/tabpfn/classifier.py
+++ b/src/tabpfn/classifier.py
@@ -18,13 +18,13 @@
 
 from __future__ import annotations
 
-import typing
-from collections.abc import Sequence
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 from typing_extensions import Self
 
-from tabpfn.inference import InferenceEngine, InferenceEngineBatchedNoPreprocessing
+from tabpfn.model.loading import (
+    load_fitted_tabpfn_model,
+    save_fitted_tabpfn_model,
+)
 from tabpfn.model.loading import (
     load_fitted_tabpfn_model,
     save_fitted_tabpfn_model,
@@ -825,7 +825,6 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
         """Save the fitted model state to ``path``.
 
         This is a thin wrapper around :func:`save_fitted_tabpfn_model`.
-        """
         save_fitted_tabpfn_model(self, path)
         est = load_fitted_tabpfn_model(path, device=device)
         if not isinstance(est, cls):
@@ -833,19 +832,3 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
                 f"Attempting to load a '{est.__class__.__name__}' as '{cls.__name__}'"
             )
         return est
-            est.n_classes_ = len(est.classes_)
-
-            est.preprocessor_ = joblib.load(tmp / "preprocessor.joblib")
-            est.label_encoder_ = joblib.load(tmp / "label_encoder.joblib")
-
-            est.executor_ = InferenceEngine.load_state(tmp / "executor.joblib")
-            if hasattr(est.executor_, "model"):
-                est.model_ = est.executor_.model
-
-            est.device_ = torch.device(device)
-            if hasattr(est.executor_, "model"):
-                est.executor_.model = est.executor_.model.to(est.device_)
-            if hasattr(est.executor_, "models"):
-                est.executor_.models = [m.to(est.device_) for m in est.executor_.models]
-
-            return est

--- a/src/tabpfn/inference.py
+++ b/src/tabpfn/inference.py
@@ -9,6 +9,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterator, Sequence
 from copy import deepcopy
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 from typing_extensions import override
 
@@ -99,6 +100,35 @@ class InferenceEngine(ABC):
         raise NotImplementedError(
             "This inference engine does not support torch.inference_mode changes."
         )
+
+    def save_state(self, path: str | Path) -> None:
+        """Persist the executor to ``path`` using ``joblib``.
+
+        The executor is first moved to CPU so the resulting file can be loaded
+        on machines without a GPU.
+        """
+        from copy import deepcopy
+        from pathlib import Path
+
+        import joblib
+
+        path = Path(path)
+        cpu_copy = deepcopy(self)
+        if hasattr(cpu_copy, "model") and cpu_copy.model is not None:
+            cpu_copy.model = cpu_copy.model.cpu()
+        if hasattr(cpu_copy, "models"):
+            cpu_copy.models = [m.cpu() for m in cpu_copy.models]
+
+        joblib.dump(cpu_copy, path)
+
+    @staticmethod
+    def load_state(path: str | Path) -> InferenceEngine:
+        """Load an executor saved with :meth:`save_state`."""
+        from pathlib import Path
+
+        import joblib
+
+        return joblib.load(Path(path))
 
 
 @dataclass

--- a/src/tabpfn/model/loading.py
+++ b/src/tabpfn/model/loading.py
@@ -708,6 +708,20 @@ def get_n_out(
 
 # NOTE: This function doesn't seem to be used anywhere.
 def save_tabpfn_model(model: nn.Module, save_path: Path | str) -> None:
+    """Save the underlying TabPFN foundation model to ``save_path``.
+
+    This writes only the base pre-trained weights and configuration. It does
+    **not** store a fitted :class:`TabPFNRegressor`/``Classifier`` instance.
+    The resulting file is merely a checkpoint consumed by
+    :func:`load_model_criterion_config` to build a new estimator.
+
+    Parameters
+    ----------
+    model:
+        The internal model object of a ``TabPFN`` estimator.
+    save_path:
+        Path to save the checkpoint to.
+    """
     # Get model state dict
     model_state = model.model_.state_dict()
 

--- a/src/tabpfn/model/loading.py
+++ b/src/tabpfn/model/loading.py
@@ -3,21 +3,27 @@
 from __future__ import annotations
 
 import dataclasses
+import json
 import logging
 import os
+import shutil
 import sys
+import tempfile
 import urllib.request
 import urllib.response
 import warnings
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Literal, cast, overload
+from typing import TYPE_CHECKING, Any, Literal, cast, overload
 from urllib.error import URLError
 
+import joblib
+import numpy as np
 import torch
 from torch import nn
 
+from tabpfn.inference import InferenceEngine
 from tabpfn.model.bar_distribution import BarDistribution, FullSupportBarDistribution
 from tabpfn.model.config import ModelConfig
 from tabpfn.model.encoders import (
@@ -31,6 +37,9 @@ from tabpfn.model.encoders import (
     VariableNumFeaturesEncoderStep,
 )
 from tabpfn.model.transformer import PerFeatureTransformer
+
+if TYPE_CHECKING:
+    from sklearn.base import BaseEstimator
 
 logger = logging.getLogger(__name__)
 
@@ -743,3 +752,131 @@ def save_tabpfn_model(model: nn.Module, save_path: Path | str) -> None:
 
     # Save the checkpoint
     torch.save(checkpoint, save_path)
+
+
+def save_fitted_tabpfn_model(estimator: BaseEstimator, path: Path | str) -> None:
+    """Persist a fitted TabPFN estimator to ``path``.
+
+    This stores the initialization parameters, fitted preprocessors and the
+    prepared :class:`InferenceEngine` so the model can be reloaded without
+    refitting. The heavy foundation weights are not included.
+    """
+    from pathlib import Path
+
+    if not hasattr(estimator, "executor_"):
+        raise RuntimeError("Estimator must be fitted before saving.")
+
+    path = Path(path)
+    if path.suffix != ".tabpfn_fit":
+        raise ValueError("Path must end with .tabpfn_fit")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+
+        params = estimator.get_params(deep=False)
+        params = {
+            k: (str(v) if isinstance(v, torch.dtype) else v) for k, v in params.items()
+        }
+        params["__class_name__"] = estimator.__class__.__name__
+        with (tmp / "init_params.json").open("w") as f:
+            json.dump(params, f)
+
+        state: dict[str, Any] = {
+            "inferred_categorical_indices": estimator.inferred_categorical_indices_,
+        }
+        if hasattr(estimator, "classes_"):
+            state["classes"] = estimator.classes_.tolist()
+            state["class_counts"] = estimator.class_counts_.tolist()
+        else:
+            state["y_train_mean"] = getattr(estimator, "y_train_mean_", 0.0)
+            state["y_train_std"] = getattr(estimator, "y_train_std_", 1.0)
+
+        with (tmp / "preprocessor_state.json").open("w") as f:
+            json.dump(state, f)
+
+        joblib.dump(estimator.preprocessor_, tmp / "preprocessor.joblib")
+
+        if hasattr(estimator, "label_encoder_"):
+            joblib.dump(estimator.label_encoder_, tmp / "label_encoder.joblib")
+        if hasattr(estimator, "bardist_"):
+            joblib.dump(estimator.bardist_, tmp / "bardist.joblib")
+        if hasattr(estimator, "normalized_bardist_"):
+            joblib.dump(
+                estimator.normalized_bardist_, tmp / "normalized_bardist.joblib"
+            )
+
+        estimator.executor_.save_state(tmp / "executor.joblib")
+
+        shutil.make_archive(str(path).replace(".tabpfn_fit", ""), "zip", tmp)
+        shutil.move(str(path).replace(".tabpfn_fit", "") + ".zip", path)
+
+
+def load_fitted_tabpfn_model(  # noqa: PLR0912,C901
+    path: Path | str, *, device: str | torch.device = "cpu"
+) -> BaseEstimator:
+    """Load a fitted TabPFN estimator saved with ``save_fitted_tabpfn_model``."""
+    from importlib import import_module
+    from pathlib import Path
+
+    path = Path(path)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        shutil.unpack_archive(path, tmpdir, "zip")
+        tmp = Path(tmpdir)
+
+        with (tmp / "init_params.json").open() as f:
+            params = json.load(f)
+
+        saved_cls = params.pop("__class_name__")
+        if isinstance(params.get("inference_precision"), str) and params[
+            "inference_precision"
+        ].startswith("torch."):
+            dtype_name = params["inference_precision"].split(".")[1]
+            params["inference_precision"] = getattr(torch, dtype_name)
+
+        params["device"] = device
+
+        if saved_cls == "TabPFNClassifier":
+            cls = import_module("tabpfn.classifier").TabPFNClassifier
+        elif saved_cls == "TabPFNRegressor":
+            cls = import_module("tabpfn.regressor").TabPFNRegressor
+        else:
+            raise TypeError(f"Unknown estimator class '{saved_cls}'")
+
+        est = cls(**params)
+        est._initialize_model_variables()
+
+        with (tmp / "preprocessor_state.json").open() as f:
+            state = json.load(f)
+
+        est.inferred_categorical_indices_ = state["inferred_categorical_indices"]
+        if saved_cls == "TabPFNClassifier":
+            est.classes_ = np.array(state["classes"])
+            est.class_counts_ = np.array(state["class_counts"])
+            est.n_classes_ = len(est.classes_)
+        else:
+            est.y_train_mean_ = state["y_train_mean"]
+            est.y_train_std_ = state["y_train_std"]
+
+        est.preprocessor_ = joblib.load(tmp / "preprocessor.joblib")
+        if (tmp / "label_encoder.joblib").exists():
+            est.label_encoder_ = joblib.load(tmp / "label_encoder.joblib")
+        if (tmp / "bardist.joblib").exists():
+            est.bardist_ = joblib.load(tmp / "bardist.joblib")
+        if (tmp / "normalized_bardist.joblib").exists():
+            est.normalized_bardist_ = joblib.load(tmp / "normalized_bardist.joblib")
+
+        est.executor_ = InferenceEngine.load_state(tmp / "executor.joblib")
+        if hasattr(est.executor_, "model"):
+            est.model_ = est.executor_.model
+
+        est.device_ = torch.device(device)
+        if hasattr(est.executor_, "model"):
+            est.executor_.model = est.executor_.model.to(est.device_)
+        if hasattr(est.executor_, "models"):
+            est.executor_.models = [m.to(est.device_) for m in est.executor_.models]
+        if hasattr(est, "bardist_") and est.bardist_ is not None:
+            est.bardist_ = est.bardist_.to(est.device_)
+        if hasattr(est, "normalized_bardist_") and est.normalized_bardist_ is not None:
+            est.normalized_bardist_ = est.normalized_bardist_.to(est.device_)
+
+        return est

--- a/src/tabpfn/regressor.py
+++ b/src/tabpfn/regressor.py
@@ -17,6 +17,9 @@
 
 from __future__ import annotations
 
+import json
+import shutil
+import tempfile
 import typing
 from collections.abc import Callable, Sequence
 from functools import partial
@@ -594,6 +597,12 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
                 " is done as part of the inference engine"
             )
 
+        # Keep the processed training data so ``save_fit_state`` can persist a
+        # fitted model. These arrays are also stored in the inference engine but
+        # we keep a reference here for easy serialization.
+        self._fit_X_ = X_preprocessed
+        self._fit_y_ = y_preprocessed
+
         # Create the inference engine
         self.executor_ = create_inference_engine(
             X_train=X_preprocessed,
@@ -644,6 +653,11 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
             )
 
         assert len(ensemble_configs) == self.n_estimators
+
+        # Keep the processed training data so ``save_fit_state`` can persist
+        # a fitted model. scikit-learn does not retain ``X`` and ``y``.
+        self._fit_X_ = X
+        self._fit_y_ = y
 
         self.is_constant_target_ = np.unique(y).size == 1
         self.constant_value_ = y[0] if self.is_constant_target_ else None
@@ -1014,6 +1028,82 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
     ) -> np.ndarray:
         """Gets the embeddings for the input data `X`."""
         return _get_embeddings(self, X, data_source)
+
+    def save_fit_state(self, path: Path | str) -> None:
+        """Save the fitted model state to ``path`` without foundation weights."""
+        if not hasattr(self, "executor_"):
+            raise RuntimeError("Estimator must be fitted before saving.")
+
+        path = Path(path)
+        if path.suffix != ".tabpfn_fit":
+            raise ValueError("Path must end with .tabpfn_fit")
+
+        if not hasattr(self, "_fit_X_"):
+            raise RuntimeError("Training data not stored; cannot save state.")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            params = self.get_params(deep=False)
+            params = {
+                k: (str(v) if isinstance(v, torch.dtype) else v)
+                for k, v in params.items()
+            }
+            params["__class_name__"] = self.__class__.__name__
+            with (tmp / "init_params.json").open("w") as f:
+                json.dump(params, f)
+
+            state = {
+                "inferred_categorical_indices": self.inferred_categorical_indices_,
+                "y_train_mean": getattr(self, "y_train_mean_", 0.0),
+                "y_train_std": getattr(self, "y_train_std_", 1.0),
+            }
+            with (tmp / "preprocessor_state.json").open("w") as f:
+                json.dump(state, f)
+
+            np.save(tmp / "X_train.npy", np.asarray(self._fit_X_))
+            np.save(tmp / "y_train.npy", np.asarray(self._fit_y_))
+
+            shutil.make_archive(str(path).replace(".tabpfn_fit", ""), "zip", tmp)
+            shutil.move(str(path).replace(".tabpfn_fit", "") + ".zip", path)
+
+    @classmethod
+    def load_from_fit_state(
+        cls, path: Path | str, *, device: str | torch.device = "cpu"
+    ) -> TabPFNRegressor:
+        """Restore a fitted regressor saved with :meth:`save_fit_state`."""
+        path = Path(path)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            shutil.unpack_archive(path, tmpdir, "zip")
+            tmp = Path(tmpdir)
+
+            with (tmp / "init_params.json").open() as f:
+                params = json.load(f)
+            saved_cls = params.pop("__class_name__")
+            if saved_cls != cls.__name__:
+                raise TypeError(
+                    f"Attempting to load a '{saved_cls}' as '{cls.__name__}'"
+                )
+
+            if isinstance(params.get("inference_precision"), str) and params[
+                "inference_precision"
+            ].startswith("torch."):
+                dtype_name = params["inference_precision"].split(".")[1]
+                params["inference_precision"] = getattr(torch, dtype_name)
+
+            params["device"] = device
+            est = cls(**params)
+
+            X_train = np.load(tmp / "X_train.npy")
+            y_train = np.load(tmp / "y_train.npy")
+
+            with (tmp / "preprocessor_state.json").open() as f:
+                state = json.load(f)
+            est.fit(X_train, y_train)
+            est.inferred_categorical_indices_ = state["inferred_categorical_indices"]
+            est.y_train_mean_ = state["y_train_mean"]
+            est.y_train_std_ = state["y_train_std"]
+
+            return est
 
 
 def _logits_to_output(

--- a/tests/test_save_load_fitted_model.py
+++ b/tests/test_save_load_fitted_model.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+from sklearn.datasets import make_regression
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from tabpfn import TabPFNRegressor
+
+
+def test_save_and_load_fitted_model(tmp_path):
+    X, y = make_regression(n_samples=20, n_features=4, random_state=0)
+    reg = TabPFNRegressor(
+        n_estimators=1,
+        device="cpu",
+        fit_mode="fit_preprocessors",
+        inference_precision=torch.float32,
+    )
+    reg.fit(X, y)
+
+    path = tmp_path / "model.tabpfn_fit"
+    reg.save_fit_state(path)
+
+    loaded = TabPFNRegressor.load_from_fit_state(path, device="cpu")
+
+    np.testing.assert_allclose(reg.predict(X[:5]), loaded.predict(X[:5]))

--- a/tests/test_save_load_fitted_model.py
+++ b/tests/test_save_load_fitted_model.py
@@ -14,6 +14,12 @@ from tabpfn.model.loading import (
     load_fitted_tabpfn_model,
     save_fitted_tabpfn_model,
 )
+    preds_before = reg.predict(X[:5])
+    save_fitted_tabpfn_model(reg, path)
+    loaded = load_fitted_tabpfn_model(path, device="cpu")
+
+    np.testing.assert_allclose(preds_before, loaded.predict(X[:5]))
+)
 
 
 def test_save_and_load_fitted_model(tmp_path):

--- a/tests/test_save_load_fitted_model.py
+++ b/tests/test_save_load_fitted_model.py
@@ -10,6 +10,10 @@ from sklearn.datasets import make_regression
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from tabpfn import TabPFNRegressor
+from tabpfn.model.loading import (
+    load_fitted_tabpfn_model,
+    save_fitted_tabpfn_model,
+)
 
 
 def test_save_and_load_fitted_model(tmp_path):
@@ -23,8 +27,10 @@ def test_save_and_load_fitted_model(tmp_path):
     reg.fit(X, y)
 
     path = tmp_path / "model.tabpfn_fit"
-    reg.save_fit_state(path)
+    preds_before = reg.predict(X[:5])
 
-    loaded = TabPFNRegressor.load_from_fit_state(path, device="cpu")
+    save_fitted_tabpfn_model(reg, path)
 
-    np.testing.assert_allclose(reg.predict(X[:5]), loaded.predict(X[:5]))
+    loaded = load_fitted_tabpfn_model(path, device="cpu")
+
+    np.testing.assert_allclose(preds_before, loaded.predict(X[:5]))


### PR DESCRIPTION
## Summary
- document how to save and restore a TabPFN model
- add `examples/save_and_load_model.py`
- clarify `save_tabpfn_model` docstring and implement `save_fit_state`
- provide tests for saving/loading fitted models
- tweak fitted-model save docstring

## Testing
- `pre-commit run --files README.md examples/save_and_load_model.py src/tabpfn/model/loading.py src/tabpfn/classifier.py src/tabpfn/regressor.py tests/test_save_load_fitted_model.py`
- `pytest -q tests/test_save_load_fitted_model.py`

------
https://chatgpt.com/codex/tasks/task_b_685c5da037fc83338f5ae3d822d595e0