### PR TITLE
[Fix] Make cloning Safepower work and be scikit-learn compatible

### DIFF
--- a/src/tabpfn/model/preprocessing.py
+++ b/src/tabpfn/model/preprocessing.py
@@ -175,6 +175,7 @@ class SafePowerTransformer(PowerTransformer):
         variance_threshold: float = 1e-3,
         large_value_threshold: float = 100,
         method="yeo-johnson",
+        *,
         standardize=True,
         copy=True,
     ):

--- a/src/tabpfn/model/preprocessing.py
+++ b/src/tabpfn/model/preprocessing.py
@@ -174,9 +174,11 @@ class SafePowerTransformer(PowerTransformer):
         self,
         variance_threshold: float = 1e-3,
         large_value_threshold: float = 100,
-        **kwargs: Any,
+        method="yeo-johnson",
+        standardize=True,
+        copy=True,
     ):
-        super().__init__(**kwargs)
+        super().__init__(method=method, standardize=standardize, copy=copy)
         self.variance_threshold = variance_threshold
         self.large_value_threshold = large_value_threshold
 


### PR DESCRIPTION
## Motivation and Context

If you clone a scikit-learn-like model/transformer, it requires key-word arguments to correctly set the init values. 

---

## Public API Changes

-   [X] No Public API changes


## Checklist

-   [X ] The changes have been tested locally.