### PR TITLE
Change default estimators for classifier from 4 to 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- Increased the default value of the `n_estimators` parameter in `TabPFNClassifier` from `4` to `8`. This change aims to improve average accuracy by default, with the trade-off of increased inference time and memory usage. ([#384](https://github.com/PriorLabs/TabPFN/pull/384))
+
+## [2.1.0] - 2025-07-04
+
+### Changed
+- **New Default Model**: The default classifier model has been updated to a new finetuned version (`tabpfn-v2-classifier-finetuned-zk73skhh.ckpt`) to improve out-of-the-box performance.
+- **Overhauled Examples**: The finetuning examples (`finetune_classifier.py`, `finetune_regressor.py`) have been completely rewritten with a clearer structure, centralized configuration, and more robust evaluation.
+- Simplified `ignore_pretraining_limits` behavior by removing redundant warnings when the flag is enabled.
+
+### Fixed
+- The model now automatically switches between `fit_mode='batched'` and standard modes when calling `fit()` and `fit_from_preprocessed()`. This prevents crashes and provides a smoother finetuning experience by logging a warning instead of raising an error.

--- a/src/tabpfn/classifier.py
+++ b/src/tabpfn/classifier.py
@@ -139,7 +139,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
     def __init__(  # noqa: PLR0913
         self,
         *,
-        n_estimators: int = 4,
+        n_estimators: int = 8,
         categorical_features_indices: Sequence[int] | None = None,
         softmax_temperature: float = 0.9,
         balance_probabilities: bool = False,


### PR DESCRIPTION
## Motivation and Context

More ensemble members increase the performance on average. We take the tradeoff slightly more towards better accuracy,

---

## Public API Changes

-   [ ] No Public API changes
-   [ X ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?
Full Benchmark + tests

---

## Checklist

-   [X] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [ ] A entry has been added to `CHANGELOG.md` (if relevant for users).
-   [ ] The code follows the project's style guidelines.
-   [X] I have considered the impact of these changes on the public API.

---