### PR TITLE
Fix loading for saved finetune models

### DIFF
--- a/src/tabpfn/model/loading.py
+++ b/src/tabpfn/model/loading.py
@@ -678,7 +678,14 @@ def load_model(
     # `True`, dissallowing loading of arbitrary objects.
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=FutureWarning)
-        checkpoint = torch.load(path, map_location="cpu", weights_only=None)
+        # When ``weights_only`` is ``True`` (the default in PyTorch >=2.6)
+        # non-tensor objects such as our ``ModelConfig`` are discarded when
+        # loading the checkpoint. This results in ``checkpoint["config"]`` being
+        # ``None`` which later triggers a ``TypeError`` in
+        # :meth:`ModelConfig.upgrade_config`.  Explicitly setting
+        # ``weights_only=False`` ensures the full checkpoint, including the
+        # configuration dataclass, is loaded correctly across PyTorch versions.
+        checkpoint = torch.load(path, map_location="cpu", weights_only=False)
 
     assert "state_dict" in checkpoint
     assert "config" in checkpoint


### PR DESCRIPTION
## Summary
- ensure torch.load keeps non-tensor config data when loading model checkpoints

## Testing
- `pytest -q` *(fails: KeyboardInterrupt after 314 passed / 66 skipped)*

------
https://chatgpt.com/codex/tasks/task_b_687671ce90ac8333a5f2e75c13f4e6fc