### PR TITLE
Fix: Ensure compatibility with np.random.Generator in AdaptiveQuantileTransformer

### DIFF
--- a/src/tabpfn/model/preprocessing.py
+++ b/src/tabpfn/model/preprocessing.py
@@ -117,6 +117,18 @@ class AdaptiveQuantileTransformer(QuantileTransformer):
         # and self.n_quantiles will reflect the value used for the fit.
         self.n_quantiles = effective_n_quantiles
 
+        # Convert Generator to RandomState if needed for sklearn compatibility
+        if isinstance(self.random_state, np.random.Generator):
+            # Generate a random integer to use as seed for RandomState
+            seed = int(self.random_state.integers(0, 2**31))
+            self.random_state = np.random.RandomState(seed)
+        elif hasattr(self.random_state, "bit_generator"):
+            # Handle other Generator-like objects
+            raise ValueError(
+                f"Unsupported random state type: {type(self.random_state)}. "
+                "Please provide an integer seed or np.random.RandomState object."
+            )
+
         return super().fit(X, y)
 
 

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -8,6 +8,7 @@ import torch
 
 from tabpfn.model import preprocessing
 from tabpfn.model.preprocessing import (
+    AdaptiveQuantileTransformer,
     DifferentiableZNormStep,
     FeaturePreprocessingTransformerStep,
     ReshapeFeatureDistributionsStep,
@@ -288,3 +289,38 @@ def test__preprocessing_steps__transform__no_sample_interdependence():
 
         # Test 3: Categorical features should remain the same
         assert result_full.categorical_features == result_subset.categorical_features
+
+
+def test_adaptive_quantile_transformer_with_numpy_generator():
+    """Tests that AdaptiveQuantileTransformer can handle a np.random.Generator.
+
+    This test ensures that the transformer is compatible with NumPy's modern
+    random number generation API, which is passed down from other parts of
+    the TabPFN codebase. It replicates the conditions that previously caused a
+    ValueError in scikit-learn's check_random_state.
+    """
+    # ARRANGE: Create sample data and a modern NumPy random number generator
+    rng = np.random.default_rng(42)
+    X = rng.random((100, 10))
+
+    # ARRANGE: Instantiate the transformer with the Generator object
+    # This is the exact condition that caused the bug
+    transformer = AdaptiveQuantileTransformer(
+        output_distribution="uniform",
+        n_quantiles=10,
+        random_state=rng,
+    )
+
+    # ACT & ASSERT: Ensure that fitting the transformer does not raise an error
+    try:
+        transformer.fit(X)
+    except ValueError as e:
+        pytest.fail(
+            "AdaptiveQuantileTransformer.fit() raised an unexpected ValueError.\n"
+            "This means the np.random.Generator compatibility fix is not working.\n"
+            f"Error: {e}"
+        )
+
+    # Further assertion to ensure the transformer is functional
+    assert hasattr(transformer, "quantiles_")
+    assert transformer.quantiles_.shape == (10, 10)


### PR DESCRIPTION
## Motivation and Context

---

## Public API Changes

-   [x] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?
**Description**
This pull request addresses a ValueError that occurs when a numpy.random.Generator instance is passed as the random_state to the AdaptiveQuantileTransformer. The underlying sklearn.preprocessing.QuantileTransformer does not support the modern NumPy random API and expects an integer seed or a np.random.RandomState object.

The error manifested during the regressor.fit() call, with the traceback pointing to scikit-learn's check_random_state utility function:

`ValueError: Generator(PCG64) at 0x1318FFCA0 cannot be used to seed a numpy.random.RandomState instance`

**The Fix**
The fit method of AdaptiveQuantileTransformer has been updated to act as a compatibility layer. It now checks if self.random_state is a np.random.Generator instance. If it is, the method uses the generator to create a single random integer, which is then used to seed a new, compatible np.random.RandomState instance before calling the parent super().fit() method.

This resolves the crash while preserving the intended stochastic behavior from the centrally managed random state generator.

**Testing**
A new unit test, test_adaptive_quantile_transformer_with_numpy_generator, has been added to test_preprocessing.py. This test specifically:

Instantiates AdaptiveQuantileTransformer with a np.random.default_rng() generator.

Calls the .fit() method.

Asserts that no ValueError is raised, confirming the fix is effective.



---

## Checklist

-   [x] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [ ] A entry has been added to `CHANGELOG.md` (if relevant for users).
-   [x] The code follows the project's style guidelines.
-   [ ] I have considered the impact of these changes on the public API.

---