### PR TITLE
Fix config return in initialize_tabpfn_model() + add initialization tests

### DIFF
--- a/src/tabpfn/base.py
+++ b/src/tabpfn/base.py
@@ -450,7 +450,6 @@ def _initialize_model_variables_helper(
     and RNG object.
     """
     static_seed, rng = infer_random_state(calling_instance.random_state)
-
     if model_type == "regressor":
         (
             calling_instance.model_,
@@ -486,6 +485,7 @@ def _initialize_model_variables_helper(
     _config = ModelInterfaceConfig.from_user_input(
         inference_config=calling_instance.inference_config,
     )  # shorter alias
+
     calling_instance.interface_config_ = _config
 
     outlier_removal_std = _config.OUTLIER_REMOVAL_STD

--- a/src/tabpfn/base.py
+++ b/src/tabpfn/base.py
@@ -137,7 +137,7 @@ def initialize_tabpfn_model(
         if which == "classifier":
             # The classifier's bar distribution is not used;
             # pass check_bar_distribution_criterion=False
-            model, _, config_ = load_model_criterion_config(
+            model, _, config = load_model_criterion_config(
                 model_path=model_path,
                 check_bar_distribution_criterion=False,
                 cache_trainset_representation=(fit_mode == "fit_with_cache"),
@@ -148,7 +148,7 @@ def initialize_tabpfn_model(
             norm_criterion = None
         else:
             # The regressor's bar distribution is required
-            model, bardist, config_ = load_model_criterion_config(
+            model, bardist, config = load_model_criterion_config(
                 model_path=model_path,
                 check_bar_distribution_criterion=True,
                 cache_trainset_representation=(fit_mode == "fit_with_cache"),

--- a/tests/test_classifier_interface.py
+++ b/tests/test_classifier_interface.py
@@ -21,6 +21,7 @@ from sklearn.utils.estimator_checks import parametrize_with_checks
 from torch import nn
 
 from tabpfn import TabPFNClassifier
+from tabpfn.base import ClassifierModelSpecs, initialize_tabpfn_model
 from tabpfn.preprocessing import PreprocessorConfig
 
 from .utils import check_cpu_float16_support
@@ -704,3 +705,54 @@ def test_classifier_with_text_and_na() -> None:
     # Check output shapes
     assert probabilities.shape == (X.shape[0], len(np.unique(y)))
     assert predictions.shape == (X.shape[0],)
+
+
+def test_initialize_model_variables_classifier_sets_required_attributes() -> None:
+    # 1) Standalone initializer
+    model, config, norm_criterion = initialize_tabpfn_model(
+        model_path="auto",
+        which="classifier",
+        fit_mode="low_memory",
+    )
+    assert model is not None, "model should be initialized for classifier"
+    assert config is not None, "config should be initialized for classifier"
+    assert norm_criterion is None, "norm_criterion should be None for classifier"
+
+    # 2) Test the sklearn-style wrapper on TabPFNClassifier
+    classifier = TabPFNClassifier(model_path="auto", device="cpu", random_state=42)
+    byte_size, rng = classifier._initialize_model_variables()
+
+    # split each combined assertion into two
+    assert hasattr(classifier, "model_"), "classifier should have model_ attribute"
+    assert classifier.model_ is not None, "model_ should be initialized for classifier"
+
+    assert hasattr(classifier, "config_"), "classifier should have config_ attribute"
+    assert (
+        classifier.config_ is not None
+    ), "config_ should be initialized for classifier"
+
+    assert not hasattr(
+        classifier, "bardist_"
+    ), "classifier should not have bardist_ attribute"
+
+    # 3) Reuse via ClassifierModelSpecs
+    new_model_state = classifier.model_
+    new_config = classifier.config_
+    spec = ClassifierModelSpecs(model=new_model_state, config=new_config)
+
+    classifier2 = TabPFNClassifier(model_path=spec)
+    byte_size2, rng2 = classifier2._initialize_model_variables()
+
+    assert hasattr(classifier2, "model_"), "classifier2 should have model_ attribute"
+    assert (
+        classifier2.model_ is not None
+    ), "model_ should be initialized for classifier2"
+
+    assert hasattr(classifier2, "config_"), "classifier2 should have config_ attribute"
+    assert (
+        classifier2.config_ is not None
+    ), "config_ should be initialized for classifier2"
+
+    assert not hasattr(
+        classifier2, "bardist_"
+    ), "classifier2 should not have bardist_ attribute"

--- a/tests/test_classifier_interface.py
+++ b/tests/test_classifier_interface.py
@@ -720,7 +720,7 @@ def test_initialize_model_variables_classifier_sets_required_attributes() -> Non
 
     # 2) Test the sklearn-style wrapper on TabPFNClassifier
     classifier = TabPFNClassifier(model_path="auto", device="cpu", random_state=42)
-    byte_size, rng = classifier._initialize_model_variables()
+    _, _ = classifier._initialize_model_variables()
 
     # split each combined assertion into two
     assert hasattr(classifier, "model_"), "classifier should have model_ attribute"
@@ -741,7 +741,7 @@ def test_initialize_model_variables_classifier_sets_required_attributes() -> Non
     spec = ClassifierModelSpecs(model=new_model_state, config=new_config)
 
     classifier2 = TabPFNClassifier(model_path=spec)
-    byte_size2, rng2 = classifier2._initialize_model_variables()
+    _, _ = classifier2._initialize_model_variables()
 
     assert hasattr(classifier2, "model_"), "classifier2 should have model_ attribute"
     assert (

--- a/tests/test_classifier_interface.py
+++ b/tests/test_classifier_interface.py
@@ -722,7 +722,6 @@ def test_initialize_model_variables_classifier_sets_required_attributes() -> Non
     classifier = TabPFNClassifier(model_path="auto", device="cpu", random_state=42)
     _, _ = classifier._initialize_model_variables()
 
-    # split each combined assertion into two
     assert hasattr(classifier, "model_"), "classifier should have model_ attribute"
     assert classifier.model_ is not None, "model_ should be initialized for classifier"
 

--- a/tests/test_classifier_interface.py
+++ b/tests/test_classifier_interface.py
@@ -720,7 +720,7 @@ def test_initialize_model_variables_classifier_sets_required_attributes() -> Non
 
     # 2) Test the sklearn-style wrapper on TabPFNClassifier
     classifier = TabPFNClassifier(model_path="auto", device="cpu", random_state=42)
-    _, _ = classifier._initialize_model_variables()
+    classifier._initialize_model_variables()
 
     assert hasattr(classifier, "model_"), "classifier should have model_ attribute"
     assert classifier.model_ is not None, "model_ should be initialized for classifier"
@@ -740,7 +740,7 @@ def test_initialize_model_variables_classifier_sets_required_attributes() -> Non
     spec = ClassifierModelSpecs(model=new_model_state, config=new_config)
 
     classifier2 = TabPFNClassifier(model_path=spec)
-    _, _ = classifier2._initialize_model_variables()
+    classifier2._initialize_model_variables()
 
     assert hasattr(classifier2, "model_"), "classifier2 should have model_ attribute"
     assert (

--- a/tests/test_regressor_interface.py
+++ b/tests/test_regressor_interface.py
@@ -544,7 +544,7 @@ def test_initialize_model_variables_regressor_sets_required_attributes() -> None
 
     # 2) Test the sklearn-style wrapper on TabPFNRegressor
     regressor = TabPFNRegressor(model_path="auto", device="cpu", random_state=42)
-    byte_size, rng = regressor._initialize_model_variables()
+    _, _ = regressor._initialize_model_variables()
 
     assert hasattr(regressor, "model_"), "regressor should have model_ attribute"
     assert regressor.model_ is not None, "model_ should be initialized for regressor"
@@ -564,7 +564,7 @@ def test_initialize_model_variables_regressor_sets_required_attributes() -> None
         norm_criterion=regressor.bardist_,
     )
     reg2 = TabPFNRegressor(model_path=spec)
-    byte_size2, rng2 = reg2._initialize_model_variables()
+    _, _ = reg2._initialize_model_variables()
 
     assert hasattr(reg2, "model_"), "regressor2 should have model_ attribute"
     assert reg2.model_ is not None, "model_ should be initialized for regressor2"

--- a/tests/test_regressor_interface.py
+++ b/tests/test_regressor_interface.py
@@ -544,7 +544,7 @@ def test_initialize_model_variables_regressor_sets_required_attributes() -> None
 
     # 2) Test the sklearn-style wrapper on TabPFNRegressor
     regressor = TabPFNRegressor(model_path="auto", device="cpu", random_state=42)
-    _, _ = regressor._initialize_model_variables()
+    regressor._initialize_model_variables()
 
     assert hasattr(regressor, "model_"), "regressor should have model_ attribute"
     assert regressor.model_ is not None, "model_ should be initialized for regressor"
@@ -564,7 +564,7 @@ def test_initialize_model_variables_regressor_sets_required_attributes() -> None
         norm_criterion=regressor.bardist_,
     )
     reg2 = TabPFNRegressor(model_path=spec)
-    _, _ = reg2._initialize_model_variables()
+    reg2._initialize_model_variables()
 
     assert hasattr(reg2, "model_"), "regressor2 should have model_ attribute"
     assert reg2.model_ is not None, "model_ should be initialized for regressor2"

--- a/tests/test_regressor_interface.py
+++ b/tests/test_regressor_interface.py
@@ -19,6 +19,7 @@ from sklearn.utils.estimator_checks import parametrize_with_checks
 from torch import nn
 
 from tabpfn import TabPFNRegressor
+from tabpfn.base import RegressorModelSpecs, initialize_tabpfn_model
 from tabpfn.preprocessing import PreprocessorConfig
 
 from .utils import check_cpu_float16_support
@@ -526,3 +527,50 @@ def test_constant_target(X_y: tuple[np.ndarray, np.ndarray]) -> None:
         assert np.all(
             quantile_prediction == 5.0
         ), "Quantile predictions are not constant as expected for full output"
+
+
+def test_initialize_model_variables_regressor_sets_required_attributes() -> None:
+    # 1) Standalone initializer
+    model, config, norm_criterion = initialize_tabpfn_model(
+        model_path="auto",
+        which="regressor",
+        fit_mode="low_memory",
+    )
+    assert model is not None, "model should be initialized for regressor"
+    assert config is not None, "config should be initialized for regressor"
+    assert (
+        norm_criterion is not None
+    ), "norm_criterion should be initialized for regressor"
+
+    # 2) Test the sklearn-style wrapper on TabPFNRegressor
+    regressor = TabPFNRegressor(model_path="auto", device="cpu", random_state=42)
+    byte_size, rng = regressor._initialize_model_variables()
+
+    assert hasattr(regressor, "model_"), "regressor should have model_ attribute"
+    assert regressor.model_ is not None, "model_ should be initialized for regressor"
+
+    assert hasattr(regressor, "config_"), "regressor should have config_ attribute"
+    assert regressor.config_ is not None, "config_ should be initialized for regressor"
+
+    assert hasattr(regressor, "bardist_"), "regressor should have bardist_ attribute"
+    assert (
+        regressor.bardist_ is not None
+    ), "bardist_ should be initialized for regressor"
+
+    # 3) Reuse via RegressorModelSpecs
+    spec = RegressorModelSpecs(
+        model=regressor.model_,
+        config=regressor.config_,
+        norm_criterion=regressor.bardist_,
+    )
+    reg2 = TabPFNRegressor(model_path=spec)
+    byte_size2, rng2 = reg2._initialize_model_variables()
+
+    assert hasattr(reg2, "model_"), "regressor2 should have model_ attribute"
+    assert reg2.model_ is not None, "model_ should be initialized for regressor2"
+
+    assert hasattr(reg2, "config_"), "regressor2 should have config_ attribute"
+    assert reg2.config_ is not None, "config_ should be initialized for regressor2"
+
+    assert hasattr(reg2, "bardist_"), "regressor2 should have bardist_ attribute"
+    assert reg2.bardist_ is not None, "bardist_ should be initialized for regressor2"


### PR DESCRIPTION
## Motivation and Context

Bug Fix for our model initialization, retrieving the class config attribute was previously broken. 

This PR adds explicit tests to ensure that:

- For **classifiers**, `initialize_tabpfn_model(..., which="classifier")` returns `(model, config, norm_criterion=None)` and that both the standalone initializer and the `TabPFNClassifier` wrapper set `model_` and `config_` but **do not** set `bardist_`.
- For **regressors**, `initialize_tabpfn_model(..., which="regressor")` returns `(model, config, norm_criterion)` and that both the standalone initializer and the `TabPFNRegressor` wrapper set `model_`, `config_`, and `bardist_`.

By codifying these behaviors with tests, we catch regressions early and guarantee the public API remains consistent.

---

## Public API Changes

- [x] No Public API changes  
- [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?

- **Unit tests added**  
  - `tests/test_classifier_interface.py`  
    - `test_initialize_model_variables_classifier_sets_required_attributes` verifies:
      - Standalone initializer returns `(model, config, None)`
      - `TabPFNClassifier._initialize_model_variables()` sets `model_` and `config_` only
      - Reuse via `ClassifierModelSpecs` also sets attributes correctly
  - `tests/test_regressor_interface.py`  
    - `test_initialize_model_variables_regressor_sets_required_attributes` verifies:
      - Standalone initializer returns `(model, config, norm_criterion)`
      - `TabPFNRegressor._initialize_model_variables()` sets `model_`, `config_`, and `bardist_`
      - Reuse via `RegressorModelSpecs` also sets attributes correctly
- Ran the full test suite locally to ensure no other failures or regressions

---

## Checklist

- [x] The changes have been tested locally.  
- [ ] Documentation has been updated (if the public API or usage changes).  
- [x] An entry has been added to `CHANGELOG.md` (if relevant for users).  
- [x] The code follows the project's style guidelines.  
- [x] I have considered the impact of these changes on the public API.  