### PR TITLE
[BUG] hanging fix for all NaN inputs

### DIFF
--- a/src/tabpfn/model/preprocessing.py
+++ b/src/tabpfn/model/preprocessing.py
@@ -585,7 +585,7 @@ class AddFingerprintFeaturesStep(FeaturePreprocessingTransformerStep):
             for i, row in enumerate(salted_X):
                 h = float_hash_arr(row)
                 add_to_hash = 0
-                while h in seen_hashes:
+                while h in seen_hashes and not (np.sum(np.isnan(row)) == row.size):
                     add_to_hash += 1
                     h = float_hash_arr(row + add_to_hash)
                 X_h[i] = h


### PR DESCRIPTION
## Motivation and Context
When computing Shapley value with TabPFNExplainer, the imputer created coalitions that could result in all NaN values. Since NaN + anything = NaN, the program hang at float_hash_arr()
---

## Public API Changes

-   [ x ] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?
This proposed PR is a bug-fix
---

## Checklist

-   [x ] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [ ] A entry has been added to `CHANGELOG.md` (if relevant for users).
-   [x] The code follows the project's style guidelines.
-   [x] I have considered the impact of these changes on the public API.

---