### PR TITLE
Use FunctionTransformer in the standard way

### DIFF
--- a/src/tabpfn/model/preprocessing.py
+++ b/src/tabpfn/model/preprocessing.py
@@ -743,12 +743,14 @@ class ReshapeFeatureDistributionsStep(FeaturePreprocessingTransformerStep):
                     ),
                     (
                         "ordinal",
+                        # default FunctionTransformer yields the identity function
                         FunctionTransformer(),
                         # "other" or "ordinal"
                         make_column_selector("ordinal*"),
                     ),
                     (
                         "normal",
+                        # default FunctionTransformer yields the identity function
                         FunctionTransformer(),
                         make_column_selector("normal*"),
                     ),
@@ -825,7 +827,8 @@ class ReshapeFeatureDistributionsStep(FeaturePreprocessingTransformerStep):
                 random_state=random_state,
             ),
             "robust": RobustScaler(unit_variance=True),
-            "none": FunctionTransformer(),
+            # default FunctionTransformer yields the identity function
+            "none": FunctionTransformer(), 
             **get_all_kdi_transformers(),
         }
 
@@ -866,6 +869,7 @@ class ReshapeFeatureDistributionsStep(FeaturePreprocessingTransformerStep):
             "scaler": make_standard_scaler_safe(("standard", StandardScaler())),
             "svd": FeatureUnion(
                 [
+                    # default FunctionTransformer yields the identity function
                     ("passthrough", FunctionTransformer()),
                     (
                         "svd",

--- a/src/tabpfn/model/preprocessing.py
+++ b/src/tabpfn/model/preprocessing.py
@@ -828,7 +828,7 @@ class ReshapeFeatureDistributionsStep(FeaturePreprocessingTransformerStep):
             ),
             "robust": RobustScaler(unit_variance=True),
             # default FunctionTransformer yields the identity function
-            "none": FunctionTransformer(), 
+            "none": FunctionTransformer(),
             **get_all_kdi_transformers(),
         }
 

--- a/src/tabpfn/model/preprocessing.py
+++ b/src/tabpfn/model/preprocessing.py
@@ -651,11 +651,6 @@ class ShuffleFeaturesStep(FeaturePreprocessingTransformerStep):
         return X[:, self.index_permutation_]
 
 
-class NoneTransformer(FunctionTransformer):
-    def __init__(self) -> None:
-        super().__init__(func=_identity, inverse_func=_identity, check_inverse=False)
-
-
 class ReshapeFeatureDistributionsStep(FeaturePreprocessingTransformerStep):
     """Reshape the feature distributions using different transformations."""
 
@@ -748,13 +743,13 @@ class ReshapeFeatureDistributionsStep(FeaturePreprocessingTransformerStep):
                     ),
                     (
                         "ordinal",
-                        NoneTransformer(),
+                        FunctionTransformer(),
                         # "other" or "ordinal"
                         make_column_selector("ordinal*"),
                     ),
                     (
                         "normal",
-                        NoneTransformer(),
+                        FunctionTransformer(),
                         make_column_selector("normal*"),
                     ),
                 ],
@@ -830,7 +825,7 @@ class ReshapeFeatureDistributionsStep(FeaturePreprocessingTransformerStep):
                 random_state=random_state,
             ),
             "robust": RobustScaler(unit_variance=True),
-            "none": FunctionTransformer(_identity),
+            "none": FunctionTransformer(),
             **get_all_kdi_transformers(),
         }
 
@@ -871,7 +866,7 @@ class ReshapeFeatureDistributionsStep(FeaturePreprocessingTransformerStep):
             "scaler": make_standard_scaler_safe(("standard", StandardScaler())),
             "svd": FeatureUnion(
                 [
-                    ("passthrough", FunctionTransformer(func=_identity)),
+                    ("passthrough", FunctionTransformer()),
                     (
                         "svd",
                         Pipeline(


### PR DESCRIPTION
The standard way to create a sklearn transformer that does nothing is to pass None in the constructor to FunctionTransformer. When converting sklearn pipelines to ONNX format, this is also important as arbitrary Python functions are not supported, so that's also a step in that direction.

## Motivation and Context

---

## Public API Changes

-   [X] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?
Locally
---

## Checklist

-   [X] The changes have been tested locally.
-   [] Documentation has been updated (if the public API or usage changes).
-   [] An entry has been added to `CHANGELOG.md` (if relevant for users).
-   [X] The code follows the project's style guidelines.
-   [X] I have considered the impact of these changes on the public API.

---