### PR TITLE
Fix enable_gqa compatibility check for scaled_dot_product_attention

### DIFF
--- a/src/tabpfn/model/attention/full_attention.py
+++ b/src/tabpfn/model/attention/full_attention.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import contextlib
 import math
 from functools import partial
 from typing import TYPE_CHECKING
@@ -592,13 +591,16 @@ class MultiHeadAttention(Attention):
             # kwarg enable_gqa
             # Check if enable_gqa is supported by trying to call the function with
             # the parameter
-            with contextlib.suppress(TypeError, RuntimeError):
+            try:
                 _ = torch.nn.functional.scaled_dot_product_attention(
                     torch.empty(1, 1, 1, 1),
                     torch.empty(1, 1, 1, 1),
                     torch.empty(1, 1, 1, 1),
                     enable_gqa=True,
                 )
+                USE_TORCH_2_GQA = True
+            except (TypeError, RuntimeError):
+                pass
 
             # if torch.cuda.is_available():
             #     device = torch.cuda.current_device()
@@ -609,7 +611,7 @@ class MultiHeadAttention(Attention):
             # USE_TORCH_2_GQA = nvidia_compute_capability >= "8" and TORCH_2_SUPPORTS_GQ
             # The code above hangs on multi-gpu settings,
             # so we use a temporary solution:
-            USE_TORCH_2_GQA = True  # TODO
+            # USE_TORCH_2_GQA = True  # TODO
             # TODO: add logging for something like this
             # if use_flash_attention and USE_TORCH_2_GQA:
             # print("Using FlashAttention might be slower than torch's implementation,


### PR DESCRIPTION
## Motivation and Context

#418

Fixes a bug in the `enable_gqa` parameter detection logic that causes TypeError on PyTorch versions < 2.5.
The `enable_gqa` parameter was added to `torch.nn.functional.scaled_dot_product_attention` in PyTorch 2.5. The existing code attempts to detect support for this parameter but has broken logic - it uses `contextlib.suppress` to catch errors during the test call, then unconditionally sets `USE_TORCH_2_GQA = True` regardless of whether the test succeeded.

The `contextlib.suppress` has been replaced with explicit try/except logic that only sets `USE_TORCH_2_GQA = True` if the test call succeeds.

---

## Public API Changes

-   [x] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?

```
import numpy as np
from sklearn.preprocessing import StandardScaler
from tabpfn import TabPFNRegressor

x = np.array([[1, 4], [2, 5], [3, 6]])
context_x = np.array([[7, 9], [8, 10]])
context_y = np.array([1.5, 2.3])

scaler = StandardScaler()
context_x_scaled = scaler.fit_transform(context_x).clip(-100, 100)
x_scaled = scaler.transform(x).clip(-100, 100)

m = TabPFNRegressor(device="cpu")
m.fit(context_x_scaled, context_y)
result = m.predict(x_scaled, output_type="full", quantiles=[0.1, 0.5, 0.9])
```

The code above previously failed when executed in an environment with PyTorch 2.4, but succeeds with the changes made in this PR.

---

## Checklist

-   [x] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [ ] A entry has been added to `CHANGELOG.md` (if relevant for users).
-   [x] The code follows the project's style guidelines.
-   [x] I have considered the impact of these changes on the public API.

---