### PR TITLE
TPU Device Support for TabPFNClassifier/TabPFNRegressor using torch_xla

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added a new `predict_logits()` method to `TabPFNClassifier` to return raw model outputs (logits). This is useful for model explainability tasks (e.g., with SHAP) that benefit from unnormalized, additive outputs.
 - Support for MPS device: TabPFN can run on local Apple MPS Accelerator.
+- Support for xla device: TabPFN can be run on a TPU accelerator. 
 
 ### Changed
 - Increased the default value of the `n_estimators` parameter in `TabPFNClassifier` from `4` to `8`. This change aims to improve average accuracy by default, with the trade-off of increased inference time and memory usage. ([#384](https://github.com/PriorLabs/TabPFN/pull/384))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ dev = [
   "mike",
   "black",  # This allows mkdocstrings to format signatures in the docs
 ]
+tpu = ["torch_xla>=2.7,<3.0"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]  # Where the tests are located

--- a/src/tabpfn/classifier.py
+++ b/src/tabpfn/classifier.py
@@ -223,7 +223,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
             device:
                 The device to use for inference with TabPFN. If set to "auto", the
                 device is selected based on availability in the following order of
-                priority: "cuda", "mps", and then "cpu". You can also set the device
+                priority: "cuda", "mps", "xla", and then "cpu". You can also set the device
                 manually to one of these options.
 
                 See PyTorch's documentation on devices for more information about

--- a/src/tabpfn/regressor.py
+++ b/src/tabpfn/regressor.py
@@ -252,7 +252,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
             device:
                 The device to use for inference with TabPFN. If set to "auto", the
                 device is selected based on availability in the following order of
-                priority: "cuda", "mps", and then "cpu". You can also set the device
+                priority: "cuda", "mps", "xla", and then "cpu". You can also set the device
                 manually to one of these options.
 
                 See PyTorch's documentation on devices for more information about

--- a/tests/test_classifier_interface.py
+++ b/tests/test_classifier_interface.py
@@ -23,7 +23,7 @@ from torch import nn
 from tabpfn import TabPFNClassifier
 from tabpfn.base import ClassifierModelSpecs, initialize_tabpfn_model
 from tabpfn.preprocessing import PreprocessorConfig
-from tabpfn.utils import infer_device_and_type
+from tabpfn.utils import infer_device_and_type, xla_is_available
 
 from .utils import check_cpu_float16_support
 
@@ -36,6 +36,8 @@ if torch.cuda.is_available() and "cuda" not in exclude_devices:
     devices.append("cuda")
 if torch.backends.mps.is_available() and "mps" not in exclude_devices:
     devices.append("mps")
+if xla_is_available() and "xla" not in exclude_devices:
+    devices.append("xla")
 
 is_cpu_float16_supported = check_cpu_float16_support()
 
@@ -95,7 +97,7 @@ def X_y() -> tuple[np.ndarray, np.ndarray]:
 )
 def test_fit(
     n_estimators: int,
-    device: Literal["cuda", "mps", "cpu"],
+    device: Literal["cuda", "mps", "xla", "cpu"],
     feature_shift_decoder: Literal["shuffle", "rotate"],
     multiclass_decoder: Literal["shuffle", "rotate"],
     fit_mode: Literal["low_memory", "fit_preprocessors", "fit_with_cache"],

--- a/tests/test_regressor_interface.py
+++ b/tests/test_regressor_interface.py
@@ -22,7 +22,7 @@ from torch import nn
 from tabpfn import TabPFNRegressor
 from tabpfn.base import RegressorModelSpecs, initialize_tabpfn_model
 from tabpfn.preprocessing import PreprocessorConfig
-from tabpfn.utils import infer_device_and_type
+from tabpfn.utils import infer_device_and_type, xla_is_available
 
 from .utils import check_cpu_float16_support
 
@@ -35,6 +35,8 @@ if torch.cuda.is_available() and "cuda" not in exclude_devices:
     devices.append("cuda")
 if torch.backends.mps.is_available() and "mps" not in exclude_devices:
     devices.append("mps")
+if xla_is_available() and "xla" not in exclude_devices:
+    devices.append("xla")
 
 # --- Environment-Aware Check for CPU Float16 Support ---
 is_cpu_float16_supported = check_cpu_float16_support()
@@ -82,7 +84,7 @@ def X_y() -> tuple[np.ndarray, np.ndarray]:
 )
 def test_regressor(
     n_estimators: int,
-    device: Literal["cuda", "mps", "cpu"],
+    device: Literal["cuda", "mps", "xla", "cpu"],
     feature_shift_decoder: Literal["shuffle", "rotate"],
     fit_mode: Literal["low_memory", "fit_preprocessors", "fit_with_cache"],
     inference_precision: torch.types._dtype | Literal["autocast", "auto"],


### PR DESCRIPTION
## Motivation and Context

This PR adds TPU support to TabPFN using PyTorch XLA, allowing users to run inference and training on Google's Tensor Processing Units.

**Changes made:**
- Added TPU dependency in `pyproject.toml` - install with `pip install tabpfn[tpu]`
- Added XLA device support - use `TabPFNClassifier(device="xla")` for TPU
- Updated memory calculation in `src/tabpfn/architectures/base/memory.py` to handle XLA devices
- Fixed XLA compatibility in `src/tabpfn/inference.py` by using `torch.no_grad()` instead of `torch.inference_mode()` to avoid version counter errors with XLA tensors

## Public API Changes

-   [ ] No Public API changes
-   [x] Yes, Public API changes (Details below)

---

## How Has This Been Tested?
Tested on Google Colab using device - v2‑8 TPU. Tested TabPFNClassifier & TabPFNRegressor

## Checklist

-   [x] The changes have been tested locally.
-   [x] Documentation has been updated (if the public API or usage changes).
-   [x] A entry has been added to `CHANGELOG.md` (if relevant for users).
-   [x] The code follows the project's style guidelines.
-   [x] I have considered the impact of these changes on the public API.

---