### PR TITLE
Fix GQA api detection on PyTorch<2.5.

### DIFF
--- a/src/tabpfn/architectures/base/attention/full_attention.py
+++ b/src/tabpfn/architectures/base/attention/full_attention.py
@@ -557,24 +557,25 @@ class MultiHeadAttention(Attention):
             # kwarg enable_gqa
             # Check if enable_gqa is supported by trying to call the function with
             # the parameter
-            with contextlib.suppress(TypeError, RuntimeError):
+            try:
                 _ = torch.nn.functional.scaled_dot_product_attention(
                     torch.empty(1, 1, 1, 1),
                     torch.empty(1, 1, 1, 1),
                     torch.empty(1, 1, 1, 1),
                     enable_gqa=True,
                 )
+                TORCH_2_SUPPORTS_GQ = True
+            except (TypeError, RuntimeError):
+                TORCH_2_SUPPORTS_GQ = False
 
-            # if torch.cuda.is_available():
-            #     device = torch.cuda.current_device()
-            #     capability = torch.cuda.get_device_capability(device)
-            #     nvidia_compute_capability = f"{capability[0]}.{capability[1]}"
-            # else:
-            #     nvidia_compute_capability = None
-            # USE_TORCH_2_GQA = nvidia_compute_capability >= "8" and TORCH_2_SUPPORTS_GQ
-            # The code above hangs on multi-gpu settings,
-            # so we use a temporary solution:
-            USE_TORCH_2_GQA = True  # TODO
+            if torch.cuda.is_available():
+                device = torch.cuda.current_device()
+                capability = torch.cuda.get_device_capability(device)
+                nvidia_compute_capability = f"{capability[0]}.{capability[1]}"
+            else:
+                nvidia_compute_capability = None
+            USE_TORCH_2_GQA = nvidia_compute_capability >= "8" and TORCH_2_SUPPORTS_GQ
+
             # TODO: add logging for something like this
             # if use_flash_attention and USE_TORCH_2_GQA:
             # print("Using FlashAttention might be slower than torch's implementation,


### PR DESCRIPTION
Revert the detection of `use_gqa` to before https://github.com/PriorLabs/TabPFN/pull/330.
This PR bypassed the detection to enable support for multi-gpu training, and instead always enabled the `use_gqa` flag. However, this flag is not available if Pytorch is older than 2.5. I reverted the change to the detection by copying the previous implementation from
https://github.com/PriorLabs/TabPFN/blob/17961ba58d6d1c9ec86d0e692909ba306f76d935/src/tabpfn/model/multi_head_attention.py.

The bug was reported in https://github.com/PriorLabs/TabPFN/issues/418

In a follow-up PR I will fix multi-gpu training again.

## Public API changes
No api changes.

## Testing
This bug picked up by the CI because we don't yet have GPU tests enabled. Hence I performed manual testing.

Before this PR (torch 2.4.1):
```
$ python examples/tabpfn_for_multiclass_classification.py
TypeError: scaled_dot_product_attention() got an unexpected keyword argument 'enable_gqa'
```

After this PR (torch 2.4.1 and torch 2.7.1):
```
$ python examples/tabpfn_for_multiclass_classification.py
ROC AUC: 1.0
Accuracy 0.98
```

I benchmarked inference speed before and after this PR on torch 2.7.1, and it was unchanged.