### PR TITLE
raise an error if the model in TabPFNClassifier doesn't have encoder …

### DIFF
--- a/src/tabpfn/utils.py
+++ b/src/tabpfn/utils.py
@@ -708,7 +708,8 @@ def update_encoder_params(
     )
     if not hasattr(norm_layer, "remove_outliers"):
         raise ValueError(
-            "InputNormalizationEncoderStep does not have a remove_outliers attribute, this will break TabPFNClassifier"
+            "InputNormalizationEncoderStep does not have a remove_outliers attribute, "
+            "this will break TabPFNClassifier"
         )
     norm_layer.remove_outliers = (remove_outliers_std is not None) and (
         remove_outliers_std > 0

--- a/src/tabpfn/utils.py
+++ b/src/tabpfn/utils.py
@@ -697,7 +697,7 @@ def update_encoder_params(
     # and inference
     if not hasattr(model, "encoder"):
         raise ValueError(
-            "Model does not have an encoder, this will break TabPFNClassifier"
+            "Model does not have an encoder, this will break TabPFN sklearn wrapper"
         )
 
     encoder = model.encoder
@@ -709,7 +709,7 @@ def update_encoder_params(
     if not hasattr(norm_layer, "remove_outliers"):
         raise ValueError(
             "InputNormalizationEncoderStep does not have a remove_outliers attribute, "
-            "this will break TabPFNClassifier"
+            "this will break TabPFN sklearn wrapper"
         )
     norm_layer.remove_outliers = (remove_outliers_std is not None) and (
         remove_outliers_std > 0

--- a/src/tabpfn/utils.py
+++ b/src/tabpfn/utils.py
@@ -697,7 +697,7 @@ def update_encoder_params(
     # and inference
     if not hasattr(model, "encoder"):
         raise ValueError(
-            "Model does not have an encoder, this will break TabPFN sklearn wrapper"
+            "Model does not have an encoder, this breaks the TabPFN sklearn wrapper."
         )
 
     encoder = model.encoder

--- a/src/tabpfn/utils.py
+++ b/src/tabpfn/utils.py
@@ -693,8 +693,12 @@ def update_encoder_params(
     if remove_outliers_std is not None and remove_outliers_std <= 0:
         raise ValueError("remove_outliers_std must be greater than 0")
 
+    # TODO: find a less hacky way to change settings during training
+    # and inference
     if not hasattr(model, "encoder"):
-        return
+        raise ValueError(
+            "Model does not have an encoder, this will break TabPFNClassifier"
+        )
 
     encoder = model.encoder
 
@@ -702,6 +706,11 @@ def update_encoder_params(
     norm_layer = next(
         e for e in encoder if "InputNormalizationEncoderStep" in str(e.__class__)
     )
+    if not hasattr(norm_layer, "remove_outliers"):
+        raise ValueError(
+            "InputNormalizationEncoderStep does not have a remove_outliers attribute,"
+            "this will break TabPFNClassifier"
+        )
     norm_layer.remove_outliers = (remove_outliers_std is not None) and (
         remove_outliers_std > 0
     )

--- a/src/tabpfn/utils.py
+++ b/src/tabpfn/utils.py
@@ -708,8 +708,7 @@ def update_encoder_params(
     )
     if not hasattr(norm_layer, "remove_outliers"):
         raise ValueError(
-            "InputNormalizationEncoderStep does not have a remove_outliers attribute,"
-            "this will break TabPFNClassifier"
+            "InputNormalizationEncoderStep does not have a remove_outliers attribute, this will break TabPFNClassifier"
         )
     norm_layer.remove_outliers = (remove_outliers_std is not None) and (
         remove_outliers_std > 0

--- a/src/tabpfn/utils.py
+++ b/src/tabpfn/utils.py
@@ -709,7 +709,7 @@ def update_encoder_params(
     if not hasattr(norm_layer, "remove_outliers"):
         raise ValueError(
             "InputNormalizationEncoderStep does not have a remove_outliers attribute, "
-            "this will break TabPFN sklearn wrapper"
+            "this will break the TabPFN sklearn wrapper"
         )
     norm_layer.remove_outliers = (remove_outliers_std is not None) and (
         remove_outliers_std > 0


### PR DESCRIPTION
…attribute to prevent silent behavior difference with our base model

## Motivation and Context

---

## Public API Changes

-   [ ] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?

---

## Checklist

-   [ ] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [ ] A entry has been added to `CHANGELOG.md` (if relevant for users).
-   [ ] The code follows the project's style guidelines.
-   [ ] I have considered the impact of these changes on the public API.

---