### PR TITLE
Enable type annotation rules in the Ruff linter.

### DIFF
--- a/examples/finetune_classifier.py
+++ b/examples/finetune_classifier.py
@@ -102,7 +102,7 @@ def evaluate_model(
     return roc_auc, log_loss_score
 
 
-def main():
+def main() -> None:
     """Main function to configure and run the finetuning workflow."""
     # --- Master Configuration ---
     config = {

--- a/examples/finetune_regressor.py
+++ b/examples/finetune_regressor.py
@@ -103,7 +103,7 @@ def evaluate_regressor(
     return mse, mae, r2
 
 
-def main():
+def main() -> None:
     """Main function to configure and run the finetuning workflow."""
     # --- Master Configuration ---
     # This improved structure separates general settings from finetuning hyperparameters.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
 select = [
   "A",
-  # "ANN", # Handled by mypy
+  "ANN", # type annotations
   "ARG",
   "B",
   "BLE",
@@ -189,7 +189,10 @@ ignore = [
   "N803",    # Argument name `X` should be lowercase
   "N802",    # Function name should be lowercase
   "COM812",  # Trailing comma missing (conflicts with formatter)
-  # These tend to be lighweight and confuse pyright
+  "ANN002",  # No type annotation for *args is okay.
+  "ANN003",  # No type annotation for *kwargs is okay.
+  "ANN204",  # No type annotation for __init__ is okay.
+  "ANN401"   # We do allow Any annotations, but use responsibly.
 ]
 
 exclude = [
@@ -256,6 +259,9 @@ exclude = [
   "FBT001",
   "FBT002",
   "A001",
+]
+"src/tabpfn/architectures/base/preprocessing.py" = [
+  "ANN"
 ]
 "src/tabpfn/model_loading.py" = [
   "C901"

--- a/src/tabpfn/architectures/base/attention/full_attention.py
+++ b/src/tabpfn/architectures/base/attention/full_attention.py
@@ -113,7 +113,7 @@ class MultiHeadAttention(Attention):
         def assert_tensor_shape(
             tensor: torch.Tensor | None,
             expected_shape: list[int | None],
-        ):
+        ) -> None:
             if tensor is None:
                 return
             actual_shape = tensor.size()

--- a/src/tabpfn/classifier.py
+++ b/src/tabpfn/classifier.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import logging
 import typing
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 from typing_extensions import Self
@@ -405,7 +405,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
         self,
         X_raw: XType | list[XType],
         y_raw: YType | list[YType],
-        split_fn,
+        split_fn: Callable,
         max_data_size: None | int = 10000,
     ) -> DatasetCollectionWithPreprocessing:
         """Transforms raw input data into a collection of datasets,
@@ -442,7 +442,10 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
         return _initialize_model_variables_helper(self, "classifier")
 
     def _initialize_dataset_preprocessing(
-        self, X: XType, y: YType, rng
+        self,
+        X: XType,
+        y: YType,
+        rng,  # noqa: ANN001
     ) -> tuple[list[ClassifierEnsembleConfig], XType, YType]:
         """Internal preprocessing method for input arguments.
         Returns ClassifierEnsembleConfigs, inferred categorical indices,
@@ -553,7 +556,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
         cat_ix: list[list[int]],
         configs: list[list[EnsembleConfig]],
         *,
-        no_refit=True,
+        no_refit: bool = True,
     ) -> TabPFNClassifier:
         """Used in Fine-Tuning. Fit the model to preprocessed inputs from torch
         dataloader inside a training loop a Dataset provided by

--- a/src/tabpfn/inference.py
+++ b/src/tabpfn/inference.py
@@ -10,7 +10,7 @@ from collections.abc import Iterator, Sequence
 from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, NoReturn
 from typing_extensions import override
 
 import joblib
@@ -83,7 +83,7 @@ class InferenceEngine(ABC):
         """
         ...
 
-    def use_torch_inference_mode(self, *, use_inference: bool):
+    def use_torch_inference_mode(self, *, use_inference: bool) -> NoReturn:
         """Enable/Disable `torch.inference_mode`.
 
         Disabling allows backpropagation (gradients) but is slower and uses more
@@ -354,7 +354,7 @@ class InferenceEngineBatchedNoPreprocessing(InferenceEngine):
             self.model = self.model.cpu()
 
     @override
-    def use_torch_inference_mode(self, use_inference: bool):
+    def use_torch_inference_mode(self, use_inference: bool) -> None:
         self.inference_mode = use_inference
 
 
@@ -514,7 +514,7 @@ class InferenceEngineCachePreprocessing(InferenceEngine):
             self.model = self.model.cpu()
 
     @override
-    def use_torch_inference_mode(self, use_inference: bool):
+    def use_torch_inference_mode(self, use_inference: bool) -> None:
         self.inference_mode = use_inference
 
 

--- a/src/tabpfn/inference.py
+++ b/src/tabpfn/inference.py
@@ -10,7 +10,7 @@ from collections.abc import Iterator, Sequence
 from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, NoReturn
+from typing import TYPE_CHECKING, Literal
 from typing_extensions import override
 
 import joblib
@@ -83,7 +83,7 @@ class InferenceEngine(ABC):
         """
         ...
 
-    def use_torch_inference_mode(self, *, use_inference: bool) -> NoReturn:
+    def use_torch_inference_mode(self, *, use_inference: bool) -> None:
         """Enable/Disable `torch.inference_mode`.
 
         Disabling allows backpropagation (gradients) but is slower and uses more

--- a/src/tabpfn/utils.py
+++ b/src/tabpfn/utils.py
@@ -580,7 +580,7 @@ def infer_random_state(
 def _process_text_na_dataframe(  # type: ignore
     X: pd.DataFrame,
     placeholder: str = NA_PLACEHOLDER,
-    ord_encoder=None,
+    ord_encoder=None,  # noqa: ANN001
     *,
     fit_encoder: bool = False,
 ) -> np.ndarray:
@@ -824,7 +824,9 @@ def get_total_memory_windows() -> float:
         return 0.0
 
 
-def split_large_data(largeX: XType, largey: YType, max_data_size: int):
+def split_large_data(
+    largeX: XType, largey: YType, max_data_size: int
+) -> tuple[list[XType], list[YType]]:
     """Split a large dataset into chunks along the first dimension.
 
     Args:
@@ -853,7 +855,12 @@ def split_large_data(largeX: XType, largey: YType, max_data_size: int):
     return xlst, ylst
 
 
-def pad_tensors(tensor_list, padding_val=0, *, labels=False):
+def pad_tensors(
+    tensor_list: list[torch.Tensor],
+    padding_val: float | None = 0,
+    *,
+    labels: bool = False,
+) -> list[torch.Tensor]:
     """Pad tensors to maximum dims at the last dimensions.
     if labels=False, 2d tensors are expected, if labels=True, one 1d
     vectors are expected as inputs.
@@ -880,7 +887,7 @@ def pad_tensors(tensor_list, padding_val=0, *, labels=False):
     return ret_list
 
 
-def meta_dataset_collator(batch, padding_val=0.0):
+def meta_dataset_collator(batch: list, padding_val: float = 0.0) -> tuple:
     """Collate function for torch.utils.data.DataLoader.
 
     Designed for batches from DatasetCollectionWithPreprocessing.

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -95,7 +95,7 @@ _METADATA_FILE = (
 )
 
 
-def _get_platform_details():
+def _get_platform_details() -> tuple[dict[str, str], dict[str, str]]:
     """Gathers and returns details for both current and reference platforms.
 
     This function centralizes platform information retrieval and file I/O,
@@ -165,7 +165,7 @@ def is_ci_compatible_platform(os_name, python_version):
     return (os_name, python_major_minor) in CI_PLATFORMS
 
 
-def _generate_skip_logic():
+def _generate_skip_logic() -> tuple[bool, str]:
     """Determines if tests should be skipped and generates the reason string.
 
     This is the core logic that replaces should_run_consistency_tests()
@@ -306,12 +306,12 @@ class ConsistencyTest:
     PLATFORM_METADATA_FILE = REFERENCE_DIR / "platform_metadata.json"
 
     @classmethod
-    def setup_class(cls):
+    def setup_class(cls) -> None:
         """Ensure the reference predictions directory exists."""
         cls.REFERENCE_DIR.mkdir(exist_ok=True)
 
     @classmethod
-    def save_platform_metadata(cls):
+    def save_platform_metadata(cls) -> None:
         """Save current platform information to metadata file."""
         metadata = {
             "os": platform.system(),
@@ -325,7 +325,7 @@ class ConsistencyTest:
             json.dump(metadata, f, indent=2)
 
     @classmethod
-    def load_platform_metadata(cls):
+    def load_platform_metadata(cls) -> dict:
         """Load platform metadata from file.
 
         Returns empty dict if file doesn't exist or can't be read.

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -324,22 +324,6 @@ class ConsistencyTest:
         with cls.PLATFORM_METADATA_FILE.open("w") as f:
             json.dump(metadata, f, indent=2)
 
-    @classmethod
-    def load_platform_metadata(cls) -> dict:
-        """Load platform metadata from file.
-
-        Returns empty dict if file doesn't exist or can't be read.
-        """
-        if not cls.PLATFORM_METADATA_FILE.exists():
-            return {}
-
-        try:
-            with cls.PLATFORM_METADATA_FILE.open("r") as f:
-                return json.load(f)
-        except (json.JSONDecodeError, OSError):
-            # More specific exceptions for file reading issues
-            return {}
-
     def get_dataset_name(self):
         """Get the unique name for this test case."""
         raise NotImplementedError("Subclasses must implement get_dataset_name()")

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import warnings
+from collections.abc import Callable
 from functools import partial
 
 import numpy as np
@@ -209,8 +210,10 @@ def test_reshape_step_append_original_logic(
     assert Xt.shape[1] == expected_output_features
 
 
-def _get_preprocessing_steps():
-    defaults = [
+def _get_preprocessing_steps() -> (
+    list[Callable[..., FeaturePreprocessingTransformerStep]]
+):
+    defaults: list[Callable[..., FeaturePreprocessingTransformerStep]] = [
         cls
         for cls in preprocessing.__dict__.values()
         if (
@@ -220,7 +223,7 @@ def _get_preprocessing_steps():
             and cls is not DifferentiableZNormStep  # works on torch tensors
         )
     ]
-    extras = [
+    extras: list[Callable[..., FeaturePreprocessingTransformerStep]] = [
         partial(
             ReshapeFeatureDistributionsStep,
             transform_name="none",
@@ -232,7 +235,9 @@ def _get_preprocessing_steps():
     return defaults + extras
 
 
-def _get_random_data(rng, n_samples, n_features, cat_inds):
+def _get_random_data(
+    rng: np.random.Generator, n_samples: int, n_features: int, cat_inds: list[int]
+) -> np.ndarray:
     x = rng.random((n_samples, n_features))
     x[:, cat_inds] = rng.integers(0, 3, size=(n_samples, len(cat_inds))).astype(float)
     return x

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -31,7 +31,7 @@ def test_internal_windows_total_memory_multithreaded():
 
     results = []
 
-    def get_memory():
+    def get_memory() -> None:
         results.append(get_total_memory_windows())
 
     threads = []


### PR DESCRIPTION
Enable the ANN rules, but exclude some overly strict ones, in line with our other repositories.

I added type annotations where they were missing. I also:
- ignore ANN for src/tabpfn/architectures/base/preprocessing.py, due to a lot of errors
- delete a class and a method that were not used in any PriorLabs repository
- add noqa in some cases where the type was not obvious, to avoid getting it wrong