### PR TITLE
Improve column selection in RemoveEmptyFeaturesEncoderStep

### DIFF
--- a/src/tabpfn/architectures/base/encoders.py
+++ b/src/tabpfn/architectures/base/encoders.py
@@ -233,25 +233,26 @@ def select_features(x: torch.Tensor, sel: torch.Tensor) -> torch.Tensor:
         The shape is (sequence_length, batch_size, total_features) if batch_size is greater than 1.
     """
     B, total_features = sel.shape
-    sequence_length = x.shape[0]
+
+    # Do nothing if we need to select all of the features
+    if torch.all(sel):
+        return x
 
     # If B == 1, we don't need to append zeros, as the number of features don't need to be fixed.
     if B == 1:
         return x[:, :, sel[0]]
 
-    new_x = torch.zeros(
-        (sequence_length, B, total_features),
-        device=x.device,
-        dtype=x.dtype,
-    )
+    new_x = x.detach().clone()
 
     # For each batch, compute the number of selected features.
     sel_counts = sel.sum(dim=-1)  # shape: (B,)
 
     for b in range(B):
         s = int(sel_counts[b])
-        if s > 0:
-            new_x[:, b, :s] = x[:, b, sel[b]]
+        if s != total_features:
+            if s > 0:
+                new_x[:, b, :s] = x[:, b, sel[b]]
+            new_x[:, b, s:] = 0
 
     return new_x
 
@@ -595,7 +596,7 @@ class NanHandlingEncoderStep(SeqEncStep):
 
 class RemoveEmptyFeaturesEncoderStep(SeqEncStep):
     """Encoder step to remove empty (constant) features.
-    Was changed to NOT DO ANYTHING, the removal of empty features now
+    Was changed to NOT DO ANYTHING(?), the removal of empty features now
     done elsewhere, but the saved model still needs this encoder step.
     TODO: REMOVE.
     """
@@ -607,16 +608,16 @@ class RemoveEmptyFeaturesEncoderStep(SeqEncStep):
             **kwargs: Keyword arguments passed to the parent SeqEncStep.
         """
         super().__init__(**kwargs)
-        self.sel = None
+        self.column_selection_mask = None
 
     def _fit(self, x: torch.Tensor, **kwargs: Any) -> None:
-        """Compute the feature selection mask on the training set.
+        """Compute the non-empty feature selection mask on the training set.
 
         Args:
             x: The input tensor.
             **kwargs: Additional keyword arguments (unused).
         """
-        self.sel = (x[1:] == x[0]).sum(0) != (x.shape[0] - 1)
+        self.column_selection_mask = (x[1:] == x[0]).sum(0) != (x.shape[0] - 1)
 
     def _transform(self, x: torch.Tensor, **kwargs: Any) -> tuple[torch.Tensor]:
         """Remove empty features from the input tensor.
@@ -628,7 +629,7 @@ class RemoveEmptyFeaturesEncoderStep(SeqEncStep):
         Returns:
             A tuple containing the transformed tensor with empty features removed.
         """
-        return (select_features(x, self.sel),)
+        return (select_features(x, self.column_selection_mask),)
 
 
 class RemoveDuplicateFeaturesEncoderStep(SeqEncStep):


### PR DESCRIPTION
## Motivation and Context

This PR improves the encoder step that removes non-empty columns (RemoveEmptyFeaturesEncoderStep). The `select_features`  function was generating 1500 steps in an ONNX graph for the model, which were 30% of the total steps in the graph for a use case with 50 columns.

The updated approach is optimized for the more common scenario where no features are constant. When constant features do exist, the new logic removes them rather than rebuilding the entire tensor, significantly reducing the number of graph nodes.

Additionally, a comment in the code suggests this step is a no-op, but it demonstrably removes empty features. The comment has been updated with a question mark to highlight this discrepancy and request clarification.

---

## Public API Changes

-   [X] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?

Locally, with datasets that contain constant features.

---

## Checklist

-   [X] The changes have been tested locally.
-   [X] Documentation has been updated (if the public API or usage changes).
-   [ ] A entry has been added to `CHANGELOG.md` (if relevant for users).
-   [X] The code follows the project's style guidelines.
-   [X] I have considered the impact of these changes on the public API.

---