### PR TITLE
Ensure tests parameters are in deterministic order.

### DIFF
--- a/tests/test_classifier_interface.py
+++ b/tests/test_classifier_interface.py
@@ -52,7 +52,7 @@ estimators = [1, 2]
 
 model_paths = ModelSource.get_classifier_v2().filenames
 primary_model = ModelSource.get_classifier_v2().default_filename
-other_models = set(model_paths) - {primary_model}
+other_models = [model_path for model_path in model_paths if model_path != primary_model]
 
 # --- Build parameter combinations ---
 # Full grid for the first (primary) model path

--- a/tests/test_regressor_interface.py
+++ b/tests/test_regressor_interface.py
@@ -46,7 +46,7 @@ estimators = [1, 2]
 
 model_paths = ModelSource.get_regressor_v2().filenames
 primary_model = ModelSource.get_regressor_v2().default_filename
-other_models = set(model_paths) - {primary_model}
+other_models = [model_path for model_path in model_paths if model_path != primary_model]
 
 # --- Build parameter combinations ---
 # Full grid for the first (primary) model path


### PR DESCRIPTION
Using the sets results in the lists of models used to parameterise the tests being in a non-deterministic order. This breaks pytest when using xdist, as different processes get different orders.