### PR TITLE
Rename public methods to remove "_" prefix. And fix typo in method name.

### DIFF
--- a/src/tabpfn/base.py
+++ b/src/tabpfn/base.py
@@ -49,6 +49,8 @@ if TYPE_CHECKING:
 
     from tabpfn.architectures.base.bar_distribution import FullSupportBarDistribution
     from tabpfn.architectures.interface import Architecture, ArchitectureConfig
+    from tabpfn.classifier import TabPFNClassifier
+    from tabpfn.regressor import TabPFNRegressor
 
 
 class BaseModelSpecs:
@@ -438,13 +440,17 @@ def get_preprocessed_datasets_helper(
     return DatasetCollectionWithPreprocessing(split_fn, rng, dataset_config_collection)
 
 
-def _initialize_model_variables_helper(
-    calling_instance: Any,
+def initialize_model_variables_helper(
+    calling_instance: TabPFNRegressor | TabPFNClassifier,
     model_type: Literal["regressor", "classifier"],
 ) -> tuple[int, np.random.Generator]:
-    """Helper function to perform initialization
-    of the model, return determined byte_size
-    and RNG object.
+    """Set attributes on the given model to prepare it for inference.
+
+    This includes selecting the device and the inference precision.
+
+    Returns:
+        a tuple (byte_size, rng), where byte_size is the number of bytes in the selected
+        dtype, and rng is a NumPy random Generator for use during inference.
     """
     static_seed, rng = infer_random_state(calling_instance.random_state)
     if model_type == "regressor":

--- a/src/tabpfn/inference.py
+++ b/src/tabpfn/inference.py
@@ -104,7 +104,7 @@ class InferenceEngine(ABC):
             "This inference engine does not support torch.inference_mode changes."
         )
 
-    def save_state_expect_model_weights(self, path: str | Path) -> None:
+    def save_state_except_model_weights(self, path: str | Path) -> None:
         """Persist the executor state to ``path`` without the model weights.
 
         The state is first moved to CPU so the resulting file can be loaded
@@ -354,7 +354,7 @@ class InferenceEngineBatchedNoPreprocessing(InferenceEngine):
             self.model = self.model.cpu()
 
     @override
-    def use_torch_inference_mode(self, use_inference: bool) -> None:
+    def use_torch_inference_mode(self, *, use_inference: bool) -> None:
         self.inference_mode = use_inference
 
 
@@ -446,7 +446,7 @@ class InferenceEngineCachePreprocessing(InferenceEngine):
     @override
     def iter_outputs(
         self,
-        X: np.ndarray | torch.tensor,
+        X: np.ndarray | torch.Tensor,
         *,
         device: torch.device,
         autocast: bool,
@@ -514,7 +514,7 @@ class InferenceEngineCachePreprocessing(InferenceEngine):
             self.model = self.model.cpu()
 
     @override
-    def use_torch_inference_mode(self, use_inference: bool) -> None:
+    def use_torch_inference_mode(self, *, use_inference: bool) -> None:
         self.inference_mode = use_inference
 
 
@@ -529,7 +529,7 @@ class InferenceEngineCacheKV(InferenceEngine):
     """
 
     preprocessors: list[SequentialFeatureTransformer]
-    ensemble_configs: list[EnsembleConfig]
+    ensemble_configs: Sequence[EnsembleConfig]
     cat_ixs: Sequence[list[int]]
     models: list[Architecture]
     n_train_samples: list[int]

--- a/src/tabpfn/model_loading.py
+++ b/src/tabpfn/model_loading.py
@@ -664,7 +664,7 @@ def save_fitted_tabpfn_model(estimator: BaseEstimator, path: Path | str) -> None
         joblib.dump(fitted_attrs, tmp / "fitted_attrs.joblib")
 
         # 3. Save the InferenceEngine state without the model weights
-        estimator.executor_.save_state_expect_model_weights(
+        estimator.executor_.save_state_except_model_weights(
             tmp / "executor_state.joblib"
         )
 


### PR DESCRIPTION
None of the methods are in the public API, so the renames should be safe.

Also fix some minor type errors.

I didn't feel confident writing a docstring for fix_dtypes(), so I applied noqa.