### PR TITLE
Declare joblib dependency.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
   # for union types in Pydantic.
   # Once Python 3.10 is the minimum version, this can be removed.
   "eval-type-backport>=0.2.2",
+  "joblib>=1.2.0",
 ]
 requires-python = ">=3.9"
 authors = [


### PR DESCRIPTION
We depend on joblib, see e.g. `tabpfn.preprocessing`, but currently do not declare this (things still work because scikit-learn depends on it).

Specify >=1.2.0, the same as scikit-learn, so the previous minimum version is maintained.