### PR TITLE
Resolved issue saving & loading the predictor (Regressor/Classifier) model on different devices (cuda / cpu)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,4 @@ cython_debug/
 
 # Claude AI assistant
 CLAUDE.md
+uv.lock

--- a/src/tabpfn/inference.py
+++ b/src/tabpfn/inference.py
@@ -104,7 +104,7 @@ class InferenceEngine(ABC):
             "This inference engine does not support torch.inference_mode changes."
         )
 
-    def save_state_expect_model_weights(self, path: str | Path) -> None:
+    def save_state_except_model_weights(self, path: str | Path) -> None:
         """Persist the executor state to ``path`` without the model weights.
 
         The state is first moved to CPU so the resulting file can be loaded

--- a/src/tabpfn/model_loading.py
+++ b/src/tabpfn/model_loading.py
@@ -661,7 +661,7 @@ def save_fitted_tabpfn_model(estimator: BaseEstimator, path: Path | str) -> None
             for key, value in vars(estimator).items()
             if key.endswith("_") and key not in blacklist
         }
-        # move all tensors to "cpu" before loading, so if fitted & saved on cuda-device
+        # move all tensors to "cpu" before saving, so if fitted & saved on cuda-device
         # and loading on cpu-device does not throw
         # "RuntimeError: Attempting to deserialize object on a CUDA device..."
         fitted_attrs = {

--- a/src/tabpfn/model_loading.py
+++ b/src/tabpfn/model_loading.py
@@ -661,6 +661,11 @@ def save_fitted_tabpfn_model(estimator: BaseEstimator, path: Path | str) -> None
             for key, value in vars(estimator).items()
             if key.endswith("_") and key not in blacklist
         }
+        # move all tensors to "cpu" before loading, so if fitted & saved on cuda-device
+        # and loading on cpu-device does not throw
+        # "RuntimeError: Attempting to deserialize object on a CUDA device..."
+        # fitted_attrs ={k:v.to("cpu") if isinstance(v, torch.nn.Module) else v
+        #                 for k, v in fitted_attrs.items()}
         joblib.dump(fitted_attrs, tmp / "fitted_attrs.joblib")
 
         # 3. Save the InferenceEngine state without the model weights

--- a/src/tabpfn/model_loading.py
+++ b/src/tabpfn/model_loading.py
@@ -664,12 +664,15 @@ def save_fitted_tabpfn_model(estimator: BaseEstimator, path: Path | str) -> None
         # move all tensors to "cpu" before loading, so if fitted & saved on cuda-device
         # and loading on cpu-device does not throw
         # "RuntimeError: Attempting to deserialize object on a CUDA device..."
-        # fitted_attrs ={k:v.to("cpu") if isinstance(v, torch.nn.Module) else v
-        #                 for k, v in fitted_attrs.items()}
+        fitted_attrs = {
+            k: v.to("cpu") if isinstance(v, torch.nn.Module) else v
+            for k, v in fitted_attrs.items()
+        }
+
         joblib.dump(fitted_attrs, tmp / "fitted_attrs.joblib")
 
         # 3. Save the InferenceEngine state without the model weights
-        estimator.executor_.save_state_expect_model_weights(
+        estimator.executor_.save_state_except_model_weights(
             tmp / "executor_state.joblib"
         )
 

--- a/src/tabpfn/model_loading.py
+++ b/src/tabpfn/model_loading.py
@@ -665,7 +665,7 @@ def save_fitted_tabpfn_model(estimator: BaseEstimator, path: Path | str) -> None
         # and loading on cpu-device does not throw
         # "RuntimeError: Attempting to deserialize object on a CUDA device..."
         fitted_attrs = {
-            k: v.to("cpu") if isinstance(v, torch.nn.Module) else v
+            k: v.to("cpu") if isinstance(v, (torch.nn.Module, torch.Tensor)) else v
             for k, v in fitted_attrs.items()
         }
 

--- a/tests/test_save_load_fitted_model.py
+++ b/tests/test_save_load_fitted_model.py
@@ -101,7 +101,7 @@ def test_save_load_happy_path(
     loaded_model = estimator_class.load_from_fit_state(path, device=loading_device)
 
     if loading_device == saving_device:
-        # In transformer.py::add_embeddings we generate random tensors inside a
+        # In transformer.py::add_embeddings we generate() random tensors inside a
         # fixed-seed RNG context.
         # Note: PyTorch uses different random number generators on CPU and CUDA.
         # Even with the same seed, CPU and CUDA will produce different random values.

--- a/tests/test_save_load_fitted_model.py
+++ b/tests/test_save_load_fitted_model.py
@@ -6,7 +6,6 @@ from itertools import product
 from pathlib import Path
 
 import numpy as np
-import pandas
 import pytest
 import torch
 from sklearn.datasets import make_classification, make_regression
@@ -97,12 +96,15 @@ def test_save_load_happy_path(
     loaded_model = estimator_class.load_from_fit_state(path, device=loading_device)
 
     if loading_device == saving_device:
-        # In transformer.py::add_embeddings we generate random tensors inside a fixed-seed RNG context.
+        # In transformer.py::add_embeddings we generate random tensors inside a
+        # fixed-seed RNG context.
         # Note: PyTorch uses different random number generators on CPU and CUDA.
         # Even with the same seed, CPU and CUDA will produce different random values.
         # This means the feature embeddings differ slightly depending on the device,
-        # which in turn leads to small prediction differences between CPU and CUDA models.
-        # This behavior is expected and comes from the transformer architecture, not a bug.
+        # which in turn leads to small prediction differences between CPU and CUDA
+        # models.
+        # This behavior is expected and comes from the transformer architecture,
+        # not a bug.
 
         # We cannot align the two RNG streams, so the only options are either to skip
         # the tests that compare predictions of different saving & loading devices.


### PR DESCRIPTION
## Motivation and Context
Issue [#416](https://github.com/PriorLabs/TabPFN/issues/416) reported a crash when a model saved on a CUDA device was later loaded on a CPU-only machine, due to tensors being serialized as CUDA tensors. This has been fixed by ensuring all tensor-like elements of the predictor are saved as CPU tensors, allowing safe loading on any device. The desired device can be specified (or automatically inferred) at loading time. This adds a negligible one-time overhead (~±10 ms, tested over 10 runs). Corresponding tests now cover all combinations of fitting, saving, and loading devices.
 Further I added uv.lock to the .gitignore file and renamed a function in "src/tabpfn/inference.py" from `save_state_expect_model_weights` to `save_state_except_model_weights`, as it makes more sense with what the function is doing. 

---

## Public API Changes

-   [x] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?
On a cuda-environment & locally. Also added corresponding pytests.
---

## Checklist

-   [x] The changes have been tested locally.
-   [x] Documentation has been updated (if the public API or usage changes).
-   [x] A entry has been added to `CHANGELOG.md` (if relevant for users).
-   [x] The code follows the project's style guidelines.
-   [x] I have considered the impact of these changes on the public API.

---