### PR TITLE
QKV calculation improvements in attention mechanism

### DIFF
--- a/src/tabpfn/architectures/base/attention/full_attention.py
+++ b/src/tabpfn/architectures/base/attention/full_attention.py
@@ -434,13 +434,10 @@ class MultiHeadAttention(Attention):
             batch_shape = x.shape[:-1]  # [..., seq_len]
             j, nhead, d_k, input_size = self._w_qkv.shape
 
-            # [..., seq_len, input_size] -> [batch_flat * seq_len, input_size]
-            x_flat = x.reshape(-1, input_size)
-
             # [j, nhead, d_k, input_size] -> [j * nhead * d_k, input_size]
-            w_flat = self._w_qkv.reshape(j * nhead * d_k, input_size)
+            w_flat = self._w_qkv.reshape(-1, input_size)
 
-            qkv_flat = torch.mm(x_flat, w_flat.T)
+            qkv_flat = torch.matmul(x, w_flat.T)
 
             # Reshape back to desired format: [..., seq_len, j, nhead, d_k]
             qkv = qkv_flat.reshape(*batch_shape, j, nhead, d_k)


### PR DESCRIPTION
## Motivation and Context

This PR has two changes:
1. Replace costly einsum with simple matrix multiplication - this version is faster in both PyTorch and ONNX. IMO, we do miss some of the clarity, but since this happens in every forward pass, it is worth it.
2. Add a fast-path for the `broadcast_kv_across_heads` function - since the use case where we don't have to change anything happens 50% of the time, this simple fix has great performance benefits.



---

## Public API Changes

-   [X] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?

Locally.

---

## Checklist

-   [X] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [ ] A entry has been added to `CHANGELOG.md` (if relevant for users).
-   [X] The code follows the project's style guidelines.
-   [X] I have considered the impact of these changes on the public API.

---