### PR TITLE
Select multiple gpus for inference, if available. Don't use them yet.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - @benraha Improved the inference speed on CPU significantly [#459](https://github.com/PriorLabs/TabPFN/pull/459).
 - @benraha Added a fast-path for the column selection in RemoveEmptyFeaturesEncoderStep [#468](https://github.com/PriorLabs/TabPFN/pull/468).
+- `TabPFNClassifier/Regression.device_` has been replaced with `.devices_` (TODO PR ID)
 
 ### Bug Fixes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ dev = [
   # Test
   "pytest",
   "pytest-xdist",
+  "pytest-mock>=3.14.1",
   "onnx", # required for onnx export tests
   "psutil", # required for testing internal memory tool on windows
   # Docs

--- a/src/tabpfn/base.py
+++ b/src/tabpfn/base.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import warnings
+from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Literal, Union, overload
 
@@ -36,7 +37,7 @@ from tabpfn.preprocessing import (
 )
 from tabpfn.settings import settings
 from tabpfn.utils import (
-    infer_device_and_type,
+    infer_devices,
     infer_fp16_inference_mode,
     infer_random_state,
     split_large_data,
@@ -172,7 +173,7 @@ def initialize_tabpfn_model(
 
 def determine_precision(
     inference_precision: torch.dtype | Literal["autocast", "auto"],
-    device_: torch.device,
+    devices_: Sequence[torch.device],
 ) -> tuple[bool, torch.dtype | None, int]:
     """Decide whether to use autocast or a forced precision dtype.
 
@@ -183,7 +184,7 @@ def determine_precision(
             - If `"autocast"`, explicitly use PyTorch autocast (mixed precision).
             - If a `torch.dtype`, force that precision.
 
-        device_: The device on which inference is run.
+        devices_: The devices which will be used for inference.
 
     Returns:
         use_autocast_:
@@ -195,7 +196,7 @@ def determine_precision(
     """
     if inference_precision in ["autocast", "auto"]:
         use_autocast_ = infer_fp16_inference_mode(
-            device=device_,
+            devices=devices_,
             enable=True if (inference_precision == "autocast") else None,
         )
         forced_inference_dtype_ = None
@@ -220,7 +221,7 @@ def create_inference_engine(  # noqa: PLR0913
     ensemble_configs: Any,
     cat_ix: list[int],
     fit_mode: Literal["low_memory", "fit_preprocessors", "fit_with_cache", "batched"],
-    device_: torch.device,
+    devices_: Sequence[torch.device],
     rng: np.random.Generator,
     n_jobs: int,
     byte_size: int,
@@ -243,7 +244,7 @@ def create_inference_engine(  # noqa: PLR0913
         ensemble_configs: The ensemble configurations to create multiple "prompts".
         cat_ix: Indices of inferred categorical features.
         fit_mode: Determines how we prepare inference (pre-cache or not).
-        device_: The device for inference.
+        devices_: The devices for inference.
         rng: Numpy random generator.
         n_jobs: Number of parallel CPU workers.
         byte_size: Byte size for the chosen inference precision.
@@ -294,7 +295,7 @@ def create_inference_engine(  # noqa: PLR0913
             model=model,
             ensemble_configs=ensemble_configs,
             n_workers=n_jobs,
-            device=device_,
+            devices=devices_,
             dtype_byte_size=byte_size,
             rng=rng,
             force_inference_dtype=forced_inference_dtype_,
@@ -320,7 +321,7 @@ def create_inference_engine(  # noqa: PLR0913
 
 
 def check_cpu_warning(
-    device: str | torch.device,
+    devices: Sequence[torch.device],
     X: np.ndarray | torch.Tensor | pd.DataFrame,
     *,
     allow_cpu_override: bool = False,
@@ -328,7 +329,7 @@ def check_cpu_warning(
     """Check if using CPU with large datasets and warn or error appropriately.
 
     Args:
-        device: The torch device being used
+        devices: The torch devices being used
         X: The input data (NumPy array, Pandas DataFrame, or Torch Tensor)
         allow_cpu_override: If True, allow CPU usage with large datasets.
     """
@@ -337,15 +338,13 @@ def check_cpu_warning(
     if allow_cpu_override:
         return
 
-    device_mapped = infer_device_and_type(device)
-
     # Determine number of samples
     try:
         num_samples = X.shape[0]
     except AttributeError:
         return
 
-    if torch.device(device_mapped).type == "cpu":
+    if any(device.type == "cpu" for device in devices):
         if num_samples > 1000:
             raise RuntimeError(
                 "Running on CPU with more than 1000 samples is not allowed "
@@ -474,15 +473,14 @@ def initialize_model_variables_helper(
     else:
         raise ValueError(f"Invalid model_type: {model_type}")
 
-    calling_instance.device_ = infer_device_and_type(calling_instance.device)
+    calling_instance.devices_ = infer_devices(calling_instance.device)
     (
         calling_instance.use_autocast_,
         calling_instance.forced_inference_dtype_,
         byte_size,
     ) = determine_precision(
-        calling_instance.inference_precision, calling_instance.device_
+        calling_instance.inference_precision, calling_instance.devices_
     )
-    calling_instance.model_.to(calling_instance.device_)
 
     # Build the interface_config
     _config = ModelInterfaceConfig.from_user_input(

--- a/src/tabpfn/classifier.py
+++ b/src/tabpfn/classifier.py
@@ -54,6 +54,7 @@ from tabpfn.preprocessing import (
     default_classifier_preprocessor_configs,
 )
 from tabpfn.utils import (
+    DevicesSpecification,
     fix_dtypes,
     get_embeddings,
     get_ordinal_encoder,
@@ -91,8 +92,13 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
     interface_config_: ModelInterfaceConfig
     """Additional configuration of the interface for expert users."""
 
-    device_: torch.device
-    """The device determined to be used."""
+    devices_: tuple[torch.device, ...]
+    """The devices determined to be used.
+
+    The devices are determined based on the `device` argument to the constructor, and
+    the devices available on the system. If multiple devices are listed, currently only
+    the first is used for inference.
+    """
 
     feature_names_in_: npt.NDArray[Any]
     """The feature names of the input data.
@@ -146,7 +152,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
         balance_probabilities: bool = False,
         average_before_softmax: bool = False,
         model_path: str | Path | Literal["auto"] = "auto",
-        device: str | torch.device | Literal["auto"] = "auto",
+        device: DevicesSpecification = "auto",
         ignore_pretraining_limits: bool = False,
         inference_precision: _dtype | Literal["autocast", "auto"] = "auto",
         fit_mode: Literal[
@@ -461,7 +467,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
         )
 
         check_cpu_warning(
-            self.device, X, allow_cpu_override=self.ignore_pretraining_limits
+            self.devices_, X, allow_cpu_override=self.ignore_pretraining_limits
         )
 
         if feature_names_in is not None:
@@ -584,7 +590,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
             byte_size, rng = self._initialize_model_variables()
         else:
             _, _, byte_size = determine_precision(
-                self.inference_precision, self.device_
+                self.inference_precision, self.devices_
             )
             rng = None
 
@@ -596,7 +602,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
             ensemble_configs=configs,
             cat_ix=cat_ix,
             fit_mode="batched",
-            device_=self.device_,
+            devices_=self.devices_,
             rng=rng,
             n_jobs=self.n_jobs,
             byte_size=byte_size,
@@ -630,7 +636,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
         else:  # already fitted and prompt_tuning mode: no cat. features
             _, rng = infer_random_state(self.random_state)
             _, _, byte_size = determine_precision(
-                self.inference_precision, self.device_
+                self.inference_precision, self.devices_
             )
 
         # Create the inference engine
@@ -641,7 +647,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
             ensemble_configs=ensemble_configs,
             cat_ix=self.inferred_categorical_indices_,
             fit_mode=self.fit_mode,
-            device_=self.device_,
+            devices_=self.devices_,
             rng=rng,
             n_jobs=self.n_jobs,
             byte_size=byte_size,
@@ -750,7 +756,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
     def _apply_balancing(self, probas: torch.Tensor) -> torch.Tensor:
         """Applies class balancing to a probability tensor."""
         class_prob_in_train = self.class_counts_ / self.class_counts_.sum()
-        balanced_probas = probas / torch.Tensor(class_prob_in_train).to(self.device_)
+        balanced_probas = probas / torch.Tensor(class_prob_in_train).to(probas.device)
         return balanced_probas / balanced_probas.sum(dim=-1, keepdim=True)
 
     def forward(  # noqa: C901, PLR0912
@@ -817,7 +823,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
         outputs = []
         for output, config in self.executor_.iter_outputs(
             X,
-            device=self.device_,
+            devices=self.devices_,
             autocast=self.use_autocast_,
         ):
             original_ndim = output.ndim

--- a/src/tabpfn/model_loading.py
+++ b/src/tabpfn/model_loading.py
@@ -641,7 +641,7 @@ def save_fitted_tabpfn_model(estimator: BaseEstimator, path: Path | str) -> None
         raise ValueError("Path must end with .tabpfn_fit")
 
     # Attributes that are handled separately or should not be saved.
-    blacklist = {"model_", "executor_", "config_", "device_"}
+    blacklist = {"model_", "executor_", "config_", "devices_"}
 
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp = Path(tmpdir)
@@ -739,15 +739,15 @@ def load_fitted_tabpfn_model(
             ]
 
         # 5. Move all torch components to the target device
-        est.device_ = torch.device(device)
+        est.devices_ = (torch.device(device),)
         if hasattr(est.executor_, "model") and est.executor_.model is not None:
-            est.executor_.model.to(est.device_)
+            est.executor_.model.to(device)
         if hasattr(est.executor_, "models"):
-            est.executor_.models = [m.to(est.device_) for m in est.executor_.models]
+            est.executor_.models = [m.to(device) for m in est.executor_.models]
 
         # Restore other potential torch objects from fitted_attrs
         for key, value in vars(est).items():
             if key.endswith("_") and hasattr(value, "to"):
-                setattr(est, key, value.to(est.device_))
+                setattr(est, key, value.to(device))
 
         return est

--- a/src/tabpfn/regressor.py
+++ b/src/tabpfn/regressor.py
@@ -56,6 +56,7 @@ from tabpfn.preprocessing import (
     default_regressor_preprocessor_configs,
 )
 from tabpfn.utils import (
+    DevicesSpecification,
     fix_dtypes,
     get_embeddings,
     get_ordinal_encoder,
@@ -136,8 +137,13 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
     interface_config_: ModelInterfaceConfig
     """Additional configuration of the interface for expert users."""
 
-    device_: torch.device
-    """The device determined to be used."""
+    devices_: tuple[torch.device, ...]
+    """The devices determined to be used.
+
+    The devices are determined based on the `device` argument to the constructor, and
+    the devices available on the system. If multiple devices are listed, currently only
+    the first is used for inference.
+    """
 
     feature_names_in_: npt.NDArray[Any]
     """The feature names of the input data.
@@ -187,7 +193,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
         softmax_temperature: float = 0.9,
         average_before_softmax: bool = False,
         model_path: str | Path | Literal["auto"] | RegressorModelSpecs = "auto",
-        device: str | torch.device | Literal["auto"] = "auto",
+        device: DevicesSpecification = "auto",
         ignore_pretraining_limits: bool = False,
         inference_precision: _dtype | Literal["autocast", "auto"] = "auto",
         fit_mode: Literal[
@@ -542,7 +548,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
 
         assert isinstance(X, np.ndarray)
         check_cpu_warning(
-            self.device, X, allow_cpu_override=self.ignore_pretraining_limits
+            self.devices_, X, allow_cpu_override=self.ignore_pretraining_limits
         )
 
         if feature_names_in is not None:
@@ -604,7 +610,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
             random_state=rng,
         )
 
-        self.znorm_space_bardist_ = self.znorm_space_bardist_.to(self.device_)
+        self.znorm_space_bardist_ = self.znorm_space_bardist_.to(self.devices_[0])
 
         assert len(ensemble_configs) == self.n_estimators
 
@@ -647,7 +653,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
             byte_size, rng = self._initialize_model_variables()
         else:
             _, _, byte_size = determine_precision(
-                self.inference_precision, self.device_
+                self.inference_precision, self.devices_
             )
             rng = None
 
@@ -659,7 +665,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
             ensemble_configs=configs,
             cat_ix=cat_ix,
             fit_mode="batched",
-            device_=self.device_,
+            devices_=self.devices_,
             rng=rng,
             n_jobs=self.n_jobs,
             byte_size=byte_size,
@@ -701,7 +707,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
         else:  # already fitted and prompt_tuning mode: no cat. features
             _, rng = infer_random_state(self.random_state)
             _, _, byte_size = determine_precision(
-                self.inference_precision, self.device_
+                self.inference_precision, self.devices_
             )
 
         assert len(ensemble_configs) == self.n_estimators
@@ -734,7 +740,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
             ensemble_configs=ensemble_configs,
             cat_ix=self.inferred_categorical_indices_,
             fit_mode=self.fit_mode,
-            device_=self.device_,
+            devices_=self.devices_,
             rng=rng,
             n_jobs=self.n_jobs,
             byte_size=byte_size,
@@ -853,8 +859,8 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
         transformed_logits = [
             translate_probs_across_borders(
                 logits,
-                frm=torch.as_tensor(borders_t, device=self.device_),
-                to=self.znorm_space_bardist_.borders.to(self.device_),
+                frm=torch.as_tensor(borders_t, device=logits.device),
+                to=self.znorm_space_bardist_.borders.to(logits.device),
             )
             for logits, borders_t in zip(outputs, borders)
         ]
@@ -977,7 +983,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
         # Iterate over estimators
         for output, config in self.executor_.iter_outputs(
             X,
-            device=self.device_,
+            devices=self.devices_,
             autocast=self.use_autocast_,
         ):
             if self.softmax_temperature != 1:

--- a/tests/test_classifier_interface.py
+++ b/tests/test_classifier_interface.py
@@ -24,7 +24,7 @@ from tabpfn import TabPFNClassifier
 from tabpfn.base import ClassifierModelSpecs, initialize_tabpfn_model
 from tabpfn.model_loading import ModelSource
 from tabpfn.preprocessing import PreprocessorConfig
-from tabpfn.utils import infer_device_and_type
+from tabpfn.utils import infer_devices
 
 from .utils import check_cpu_float16_support, get_pytest_devices
 
@@ -380,8 +380,8 @@ def test_sklearn_compatible_estimator(
     estimator: TabPFNClassifier,
     check: Callable[[TabPFNClassifier], None],
 ) -> None:
-    _auto_device = infer_device_and_type(device="auto")
-    if _auto_device.type == "mps":
+    _auto_devices = infer_devices(devices="auto")
+    if any(device.type == "mps" for device in _auto_devices):
         pytest.skip("MPS does not support float64, which is required for this check.")
 
     if check.func.__name__ in (  # type: ignore

--- a/tests/test_regressor_interface.py
+++ b/tests/test_regressor_interface.py
@@ -23,7 +23,7 @@ from tabpfn import TabPFNRegressor
 from tabpfn.base import RegressorModelSpecs, initialize_tabpfn_model
 from tabpfn.model_loading import ModelSource
 from tabpfn.preprocessing import PreprocessorConfig
-from tabpfn.utils import infer_device_and_type
+from tabpfn.utils import infer_devices
 
 from .utils import check_cpu_float16_support, get_pytest_devices
 
@@ -186,8 +186,8 @@ def test_sklearn_compatible_estimator(
     estimator: TabPFNRegressor,
     check: Callable[[TabPFNRegressor], None],
 ) -> None:
-    _auto_device = infer_device_and_type(device="auto")
-    if _auto_device.type == "mps":
+    _auto_devices = infer_devices(devices="auto")
+    if any(device.type == "mps" for device in _auto_devices):
         pytest.skip("MPS does not support float64, which is required for this check.")
 
     if check.func.__name__ in (  # type: ignore

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import os
+from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
+import torch
 
-from tabpfn.utils import infer_categorical_features
+from tabpfn.utils import infer_categorical_features, infer_devices
 
 
 def test_internal_windows_total_memory():
@@ -118,3 +120,79 @@ def test_infer_categorical_with_dict_raises_error():
             max_unique_for_category=2,
             min_unique_for_numerical=2,
         )
+
+
+def test__infer_devices__auto__cuda_and_mps_not_available__selects_cpu(
+    mocker: MagicMock,
+) -> None:
+    mocker.patch("torch.cuda").is_available.return_value = False
+    mocker.patch("torch.backends.mps").is_available.return_value = False
+    assert infer_devices(devices="auto") == (torch.device("cpu"),)
+
+
+def test__infer_devices__auto__single_cuda_gpu_available__selects_it(
+    mocker: MagicMock,
+) -> None:
+    mock_cuda = mocker.patch("torch.cuda")
+    mock_cuda.is_available.return_value = True
+    mock_cuda.device_count.return_value = 1
+    mocker.patch("torch.backends.mps").is_available.return_value = True
+    assert infer_devices(devices="auto") == (torch.device("cuda:0"),)
+
+
+def test__infer_devices__auto__multiple_cuda_gpus_available__selects_all(
+    mocker: MagicMock,
+) -> None:
+    mock_cuda = mocker.patch("torch.cuda")
+    mock_cuda.is_available.return_value = True
+    mock_cuda.device_count.return_value = 3
+    mocker.patch("torch.backends.mps").is_available.return_value = True
+
+    inferred = set(infer_devices(devices="auto"))
+    expected = {torch.device("cuda:0"), torch.device("cuda:1"), torch.device("cuda:2")}
+    assert inferred == expected
+
+
+def test__infer_devices__auto__cuda_and_mps_available_but_excluded__selects_cpu(
+    mocker: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("TABPFN_EXCLUDE_DEVICES", "mps,cuda")
+    mock_cuda = mocker.patch("torch.cuda")
+    mock_cuda.is_available.return_value = True
+    mock_cuda.device_count.return_value = 1
+    mocker.patch("torch.backends.mps").is_available.return_value = True
+    assert infer_devices(devices="auto") == (torch.device("cpu"),)
+
+
+def test__infer_devices__device_specified__selects_it(
+    mocker: MagicMock,
+) -> None:
+    mock_cuda = mocker.patch("torch.cuda")
+    mock_cuda.is_available.return_value = True
+    mock_cuda.device_count.return_value = 3
+    mocker.patch("torch.backends.mps").is_available.return_value = True
+
+    inferred = set(infer_devices(devices="auto"))
+    expected = {torch.device("cuda:0"), torch.device("cuda:1"), torch.device("cuda:2")}
+    assert inferred == expected
+
+
+def test__infer_devices__multiple_devices_specified___selects_them(
+    mocker: MagicMock,
+) -> None:
+    mock_cuda = mocker.patch("torch.cuda")
+    mock_cuda.is_available.return_value = True
+    mock_cuda.device_count.return_value = 3
+    mocker.patch("torch.backends.mps").is_available.return_value = False
+
+    inferred = set(infer_devices(devices=["cuda:0", "cuda:1", "cuda:4"]))
+    expected = {torch.device("cuda:0"), torch.device("cuda:1"), torch.device("cuda:4")}
+    assert inferred == expected
+
+
+def test__infer_devices__device_selected_twice__raises() -> None:
+    with pytest.raises(
+        ValueError,
+        match="The list of devices for inference cannot contain the same device more ",
+    ):
+        infer_devices(devices=["cpu", "cpu"])


### PR DESCRIPTION
If the specified device is "auto" and multiple cuda gpus are available, then select all the gpus. This PR doesn't actually implement multi-gpu inference. Instead, all the inference engines just use the first.

Public API changes:
- `TabPFNClassifier/Regressor.device_` has been renamed to `.devices_`, and is now a tuple rather than a single device.
- The `device` argument of `TabPFNClassifier/Regressor.__init__()` is unchanged, as is the `.device` property. Multiple gpus will only be used when this is set to "auto". An alternative would be to update this to `devices`. I kept it like this as most users probably only want a single device, it avoids changing the api, and we don't actually support multi-device inference in this PR. But maybe it is confusing to have both `device` and `devices_`. What do you think?

Notes:
- `TabPFNRegressor.znorm_space_bardist_` is always placed on the first device, as we're not aiming to parallelise this portion of inference
- `infer_devices()` no longer accepts `device=None`: I couldn't find anywhere using this