### PR TITLE
Add note to softmax_temperature for the classifier

### DIFF
--- a/src/tabpfn/classifier.py
+++ b/src/tabpfn/classifier.py
@@ -187,7 +187,9 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
                 The temperature for the softmax function. This is used to control the
                 confidence of the model's predictions. Lower values make the model's
                 predictions more confident. This is only applied when predicting during
-                a post-processing step. Set `softmax_temperature=1.0` for no effect.
+                a post-processing step. Set `softmax_temperature=1.0` for no effect. Be
+                advised that `.predict()` does not currently sample, so this setting is
+                only relevant for `.predict_proba()` and `.predict_logits()`.
 
             balance_probabilities:
                 Whether to balance the probabilities based on the class distribution


### PR DESCRIPTION
Address possible confusion from the fact that we expose a temperature setting, but use simply `argmax` in `predict`. See https://discord.com/channels/1285598202732482621/1412644840667086939/1414888423965196288