### PR TITLE
chore: fix ruff formatting after version bump

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -236,6 +236,7 @@ exclude = [
   "TCH",
   "N803",
   "C901",  # Too complex
+  "PLC0415",
 ]
 "__init__.py" = ["I002"]
 "examples/*" = ["INP001", "I002", "E741", "D101", "D103", "T20", "D415", "ERA001", "E402", "E501", "BLE001"]
@@ -270,6 +271,8 @@ exclude = [
 "src/tabpfn/*.py" = [
   "D107",
 ]
+"src/tabpfn/misc/_sklearn_compat.py" = ["ALL"]
+"src/tabpfn/misc/debug_versions.py" = ["ALL"]
 
 
 [tool.ruff.lint.isort]

--- a/src/tabpfn/architectures/base/attention/full_attention.py
+++ b/src/tabpfn/architectures/base/attention/full_attention.py
@@ -313,13 +313,13 @@ class MultiHeadAttention(Attention):
         Else, keys and values are attained by applying the respective linear
         transformations to 'x' (self attention).
         """
-        assert not (
-            cache_kv and use_cached_kv
-        ), "Cannot cache and use cached keys and values at the same time."
+        assert not (cache_kv and use_cached_kv), (
+            "Cannot cache and use cached keys and values at the same time."
+        )
 
-        assert not x.requires_grad or (
-            not self.has_cached_kv and not cache_kv
-        ), "Saving keys and values is only supported during inference."
+        assert not x.requires_grad or (not self.has_cached_kv and not cache_kv), (
+            "Saving keys and values is only supported during inference."
+        )
         x, x_kv, x_shape_after_transpose = self._rearrange_inputs_to_flat_batch(x, x_kv)
 
         nhead_kv = 1 if reuse_first_head_kv else self._nhead_kv
@@ -395,9 +395,9 @@ class MultiHeadAttention(Attention):
         torch.Tensor | None,
         torch.Tensor | None,
     ]:
-        assert not (
-            cache_kv and use_cached_kv
-        ), "You cannot both cache new KV and use the cached KV at once."
+        assert not (cache_kv and use_cached_kv), (
+            "You cannot both cache new KV and use the cached KV at once."
+        )
         if reuse_first_head_kv:
             assert x is not x_kv, (
                 "x and x_kv must be different tensors. That means reuse_first_head_kv"
@@ -408,9 +408,9 @@ class MultiHeadAttention(Attention):
 
         k = v = kv = None
         if use_cached_kv:
-            assert (
-                self.has_cached_kv
-            ), "You try to use cached keys and values but the cache is empty."
+            assert self.has_cached_kv, (
+                "You try to use cached keys and values but the cache is empty."
+            )
             k = k_cache
             v = v_cache
             kv = kv_cache

--- a/src/tabpfn/architectures/base/bar_distribution.py
+++ b/src/tabpfn/architectures/base/bar_distribution.py
@@ -70,11 +70,11 @@ class BarDistribution(nn.Module):
         """
         if len(ys.shape) < len(logits.shape) and len(ys.shape) == 1:
             # bring new borders to the same dim as logits up to the last dim
-            ys = ys.repeat(logits.shape[:-1] + (1,))
+            ys = ys.repeat((*logits.shape[:-1], 1))
         else:
-            assert (
-                ys.shape[:-1] == logits.shape[:-1]
-            ), f"ys.shape: {ys.shape} logits.shape: {logits.shape}"
+            assert ys.shape[:-1] == logits.shape[:-1], (
+                f"ys.shape: {ys.shape} logits.shape: {logits.shape}"
+            )
         probs = torch.softmax(logits, dim=-1)
         buckets_of_ys = self.map_to_bucket_idx(ys).clamp(0, self.num_bars - 1)
 
@@ -189,9 +189,9 @@ class BarDistribution(nn.Module):
         ignore_loss_mask = self.ignore_init(y)
         target_sample = self.map_to_bucket_idx(y)
         assert (target_sample >= 0).all()
-        assert (
-            target_sample < self.num_bars
-        ).all(), f"y {y} not in support set for borders (min_y, max_y) {self.borders}"
+        assert (target_sample < self.num_bars).all(), (
+            f"y {y} not in support set for borders (min_y, max_y) {self.borders}"
+        )
 
         last_dim = logits.shape[-1]
         assert last_dim == self.num_bars, f"{last_dim} v {self.num_bars}"
@@ -415,7 +415,7 @@ class BarDistribution(nn.Module):
         **kwargs: Any,
     ) -> plt.Axes:
         """Plots the distribution."""
-        import matplotlib.pyplot as plt
+        import matplotlib.pyplot as plt  # noqa: PLC0415
 
         logits = logits.squeeze()
         assert logits.dim() == 1, "logits should be 1d, at least after squeezing."
@@ -461,9 +461,9 @@ class FullSupportBarDistribution(BarDistribution):
 
     def assert_support(self, *, allow_zero_bucket_left: bool = False) -> None:
         if allow_zero_bucket_left:
-            assert (
-                self.bucket_widths[-1] > 0
-            ), f"Half Normal weight must be > 0 (got -1:{self.bucket_widths[-1]})."
+            assert self.bucket_widths[-1] > 0, (
+                f"Half Normal weight must be > 0 (got -1:{self.bucket_widths[-1]})."
+            )
             # This fixes the distribution if the half normal at zero is width zero
             if self.bucket_widths[0] == 0:
                 self.borders[0] = self.borders[0] - 1
@@ -504,13 +504,13 @@ class FullSupportBarDistribution(BarDistribution):
         target_sample = self.map_to_bucket_idx(y)  # shape: T x B (same as y)
         target_sample.clamp_(0, self.num_bars - 1)
 
-        assert (
-            logits.shape[-1] == self.num_bars
-        ), f"{logits.shape[-1]} vs {self.num_bars}"
+        assert logits.shape[-1] == self.num_bars, (
+            f"{logits.shape[-1]} vs {self.num_bars}"
+        )
         assert (target_sample >= 0).all()
-        assert (
-            target_sample < self.num_bars
-        ).all(), f"y {y} not in support set for borders (min_y, max_y) {self.borders}"
+        assert (target_sample < self.num_bars).all(), (
+            f"y {y} not in support set for borders (min_y, max_y) {self.borders}"
+        )
         last_dim = logits.shape[-1]
         assert last_dim == self.num_bars, f"{last_dim} vs {self.num_bars}"
         # ignore all position with nan values
@@ -543,9 +543,9 @@ class FullSupportBarDistribution(BarDistribution):
         nll_loss = -log_probs
 
         if mean_prediction_logits is not None:  # TO BE REMOVED AFTER BO PAPER IS DONE
-            assert (
-                not ignore_loss_mask.any()
-            ), "Ignoring examples is not implemented with mean pred."
+            assert not ignore_loss_mask.any(), (
+                "Ignoring examples is not implemented with mean pred."
+            )
             if not torch.is_grad_enabled():
                 pass
             nll_loss = torch.cat(
@@ -782,16 +782,16 @@ def get_bucket_limits(
             If set, the bucket limits are widened by this factor.
             This allows to have a slightly larger range than the actual data.
     """
-    assert (ys is None) != (
-        full_range is None
-    ), "Either full_range or ys must be passed."
+    assert (ys is None) != (full_range is None), (
+        "Either full_range or ys must be passed."
+    )
 
     if ys is not None:
         ys = ys.flatten()
         ys = ys[~torch.isnan(ys)]
-        assert (
-            len(ys) > num_outputs
-        ), f"Number of ys :{len(ys)} must be larger than num_outputs: {num_outputs}"
+        assert len(ys) > num_outputs, (
+            f"Number of ys :{len(ys)} must be larger than num_outputs: {num_outputs}"
+        )
         if len(ys) % num_outputs:
             ys = ys[: -(len(ys) % num_outputs)]
         ys_per_bucket = len(ys) // num_outputs

--- a/src/tabpfn/architectures/base/encoders.py
+++ b/src/tabpfn/architectures/base/encoders.py
@@ -187,9 +187,9 @@ def normalize_data(
     Returns:
         The normalized data tensor, or a tuple containing the data and scaling factors.
     """
-    assert (mean is None) == (
-        std is None
-    ), "Either both or none of mean and std must be given"
+    assert (mean is None) == (std is None), (
+        "Either both or none of mean and std must be given"
+    )
     if mean is None:
         if normalize_positions is not None and normalize_positions > 0:
             mean = torch_nanmean(data[:normalize_positions], axis=0)  # type: ignore
@@ -466,7 +466,9 @@ class SeqEncStep(nn.Module):
         assert isinstance(
             out,
             tuple,
-        ), f"out is not a tuple: {out}, type: {type(out)}, class: {self.__class__.__name__}"
+        ), (
+            f"out is not a tuple: {out}, type: {type(out)}, class: {self.__class__.__name__}"
+        )
         assert len(out) == len(self.out_keys)
         state.update({out_key: out[i] for i, out_key in enumerate(self.out_keys)})
         return state
@@ -862,9 +864,9 @@ class InputNormalizationEncoderStep(SeqEncStep):
             x = to_ranking_low_mem(x)
 
         if self.remove_outliers:
-            assert (
-                self.remove_outliers_sigma > 1.0
-            ), "remove_outliers_sigma must be > 1.0"
+            assert self.remove_outliers_sigma > 1.0, (
+                "remove_outliers_sigma must be > 1.0"
+            )
 
             x, _ = remove_outliers(
                 x,
@@ -1048,9 +1050,9 @@ class MulticlassClassificationTargetEncoder(SeqEncStep):
         self, y: torch.Tensor, single_eval_pos: int | None = None
     ) -> tuple[torch.Tensor]:
         assert len(y.shape) == 3 and (y.shape[-1] == 1), "y must be of shape (T, B, 1)"
-        assert not (
-            y.isnan().any() and self.training
-        ), "NaNs are not allowed in the target at this point during training (set to model.eval() if not in training)"
+        assert not (y.isnan().any() and self.training), (
+            "NaNs are not allowed in the target at this point during training (set to model.eval() if not in training)"
+        )
         y_new = y.clone()
         for B in range(y.shape[1]):
             y_new[:, B, :] = self.flatten_targets(y[:, B, :], self.unique_ys_[B])

--- a/src/tabpfn/architectures/base/layer.py
+++ b/src/tabpfn/architectures/base/layer.py
@@ -277,18 +277,18 @@ class PerFeatureEncoderLayer(Module):
         Returns:
             The transformer state passed through the encoder layer.
         """
-        assert (
-            len(state.shape) == 4
-        ), "src must be of shape (batch_size, num_items, num feature blocks, d_model)"
+        assert len(state.shape) == 4, (
+            "src must be of shape (batch_size, num_items, num feature blocks, d_model)"
+        )
         save_peak_mem_factor = self.save_peak_mem_factor
         if cache_trainset_representation and not single_eval_pos:
             assert self.self_attn_between_items.has_cached_kv
             save_peak_mem_factor = None
 
         if att_src is not None:
-            assert (
-                not self.multiquery_item_attention_for_test_set
-            ), "Not implemented yet."
+            assert not self.multiquery_item_attention_for_test_set, (
+                "Not implemented yet."
+            )
             assert not cache_trainset_representation, "Not implemented yet."
             assert not single_eval_pos, (
                 "single_eval_pos should not be set, as the train representation"

--- a/src/tabpfn/architectures/base/memory.py
+++ b/src/tabpfn/architectures/base/memory.py
@@ -63,9 +63,9 @@ def support_save_peak_mem_factor(method: MethodType) -> Callable:
         **kwargs: Any,
     ) -> torch.Tensor:
         assert isinstance(self, torch.nn.Module)
-        assert (
-            save_peak_mem_factor is None or allow_inplace
-        ), "The parameter save_peak_mem_factor only supported with 'allow_inplace' set."
+        assert save_peak_mem_factor is None or allow_inplace, (
+            "The parameter 'save_peak_mem_factor' requires 'allow_inplace' to be set."
+        )
         assert isinstance(x, torch.Tensor)
 
         tensor_inputs = list(tuple(self.parameters()) + tuple(args))
@@ -260,7 +260,7 @@ class MemoryUsageEstimator:
         try:
             # Fallback to using Metal API if torch.mps.recommended_max_memory is
             # not available as it is only available in PyTorch 2.5.0 and later.
-            from Metal import MTLCreateSystemDefaultDevice
+            from Metal import MTLCreateSystemDefaultDevice  # noqa: PLC0415
         except ImportError as err:
             raise ImportError(
                 "pyobjc-framework-Metal is required to access the Metal "
@@ -307,7 +307,7 @@ class MemoryUsageEstimator:
                     os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES") / 1e9
                 )
             except AttributeError:
-                from tabpfn.utils import get_total_memory_windows
+                from tabpfn.utils import get_total_memory_windows  # noqa: PLC0415
 
                 if os.name == "nt":
                     free_memory = get_total_memory_windows()
@@ -398,10 +398,10 @@ class MemoryUsageEstimator:
     @classmethod
     def reset_peak_memory_if_required(
         cls,
+        *,
         save_peak_mem: bool | Literal["auto"] | float | int,
         model: torch.nn.Module,
         X: torch.Tensor,
-        *,
         cache_kv: bool,
         device: torch.device,
         dtype_byte_size: int,

--- a/src/tabpfn/architectures/base/preprocessing.py
+++ b/src/tabpfn/architectures/base/preprocessing.py
@@ -186,7 +186,7 @@ def _yeojohnson(x, lmbda=None):
 
     if np.issubdtype(x.dtype, np.complexfloating):
         raise ValueError(
-            "Yeo-Johnson transformation is not defined for " "complex numbers."
+            "Yeo-Johnson transformation is not defined for complex numbers."
         )
 
     if np.issubdtype(x.dtype, np.integer):
@@ -563,9 +563,9 @@ class SequentialFeatureTransformer(UserList):
             X: 2d array of shape (n_samples, n_features)
             categorical_features: list of indices of categorical feature.
         """
-        assert (
-            len(self) > 0
-        ), "The SequentialFeatureTransformer must have at least one step."
+        assert len(self) > 0, (
+            "The SequentialFeatureTransformer must have at least one step."
+        )
         self.fit_transform(X, categorical_features)
         return self
 
@@ -575,9 +575,9 @@ class SequentialFeatureTransformer(UserList):
         Args:
             X: 2d array of shape (n_samples, n_features).
         """
-        assert (
-            len(self) > 0
-        ), "The SequentialFeatureTransformer must have at least one step."
+        assert len(self) > 0, (
+            "The SequentialFeatureTransformer must have at least one step."
+        )
         assert self.categorical_features_ is not None, (
             "The SequentialFeatureTransformer must be fit before it"
             " can be used to transform."
@@ -742,9 +742,9 @@ class ShuffleFeaturesStep(FeaturePreprocessingTransformerStep):
     @override
     def _transform(self, X: np.ndarray, *, is_test: bool = False) -> np.ndarray:
         assert self.index_permutation_ is not None, "You must call fit first"
-        assert (
-            len(self.index_permutation_) == X.shape[1]
-        ), "The number of features must not change after fit"
+        assert len(self.index_permutation_) == X.shape[1], (
+            "The number of features must not change after fit"
+        )
         return X[:, self.index_permutation_]
 
 
@@ -1375,7 +1375,7 @@ class EncodeCategoricalFeaturesStep(FeaturePreprocessingTransformerStep):
         if self.categorical_transformer_ is None:
             return X
 
-        import warnings
+        import warnings  # noqa: PLC0415
 
         with warnings.catch_warnings():
             warnings.filterwarnings(

--- a/src/tabpfn/architectures/base/transformer.py
+++ b/src/tabpfn/architectures/base/transformer.py
@@ -610,9 +610,9 @@ class PerFeatureTransformer(Architecture):
         use_cached_embeddings: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         if use_cached_embeddings and self.cached_embeddings is not None:
-            assert (
-                data_dags is None
-            ), "Caching embeddings is not supported with data_dags at this point."
+            assert data_dags is None, (
+                "Caching embeddings is not supported with data_dags at this point."
+            )
             x += self.cached_embeddings[None, None]
             return x, y
 
@@ -662,9 +662,9 @@ class PerFeatureTransformer(Architecture):
 
         self.cached_embeddings = None
         if cache_embeddings and embs is not None:
-            assert (
-                data_dags is None
-            ), "Caching embeddings is not supported with data_dags at this point."
+            assert data_dags is None, (
+                "Caching embeddings is not supported with data_dags at this point."
+            )
             self.cached_embeddings = embs
 
         # TODO(old) should this go into encoder?
@@ -784,7 +784,7 @@ def _add_pos_emb(
     is_undirected: bool = False,
     k: int = 20,
 ) -> None:
-    from scipy.sparse.linalg import eigs, eigsh
+    from scipy.sparse.linalg import eigs, eigsh  # noqa: PLC0415
 
     eig_fn = eigs if not is_undirected else eigsh
 

--- a/src/tabpfn/misc/_sklearn_compat.py
+++ b/src/tabpfn/misc/_sklearn_compat.py
@@ -1,4 +1,3 @@
-# ruff: noqa
 # mypy: ignore-errors
 # taken from https://github.com/sklearn-compat/sklearn-compat
 """Ease developer experience to support multiple versions of scikit-learn.

--- a/src/tabpfn/misc/debug_versions.py
+++ b/src/tabpfn/misc/debug_versions.py
@@ -1,4 +1,3 @@
-# ruff: noqa
 """This file is taken from PyTorch and modified to work with TabPFN, also
 inspired from sklearn's show_versions function. This collects useful debug
 information that can be used to report issues.

--- a/src/tabpfn/model_loading.py
+++ b/src/tabpfn/model_loading.py
@@ -128,7 +128,7 @@ def _try_huggingface_downloads(
     """
     """Try to download models and config using the HuggingFace Hub API."""
     try:
-        from huggingface_hub import hf_hub_download
+        from huggingface_hub import hf_hub_download  # noqa: PLC0415
     except ImportError as e:
         raise ImportError(
             "Please install huggingface_hub: pip install huggingface-hub",
@@ -674,7 +674,7 @@ def save_fitted_tabpfn_model(estimator: BaseEstimator, path: Path | str) -> None
 
 
 def _extract_archive(path: Path, tmp: Path) -> None:
-    import zipfile
+    import zipfile  # noqa: PLC0415
 
     with zipfile.ZipFile(path, "r") as archive:
         for member in archive.namelist():
@@ -688,8 +688,8 @@ def load_fitted_tabpfn_model(
     path: Path | str, *, device: str | torch.device = "cpu"
 ) -> BaseEstimator:
     """Load a fitted TabPFN estimator saved with ``save_fitted_tabpfn_model``."""
-    from copy import deepcopy
-    from importlib import import_module
+    from copy import deepcopy  # noqa: PLC0415
+    from importlib import import_module  # noqa: PLC0415
 
     path = Path(path)
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/src/tabpfn/regressor.py
+++ b/src/tabpfn/regressor.py
@@ -830,9 +830,9 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
         if quantiles is None:
             quantiles = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
         else:
-            assert all(
-                (0 <= q <= 1) and (isinstance(q, float)) for q in quantiles
-            ), "All quantiles must be between 0 and 1 and floats."
+            assert all((0 <= q <= 1) and (isinstance(q, float)) for q in quantiles), (
+                "All quantiles must be between 0 and 1 and floats."
+            )
         if output_type not in _USABLE_OUTPUT_TYPES:
             raise ValueError(f"Invalid output type: {output_type}")
 

--- a/src/tabpfn/utils.py
+++ b/src/tabpfn/utils.py
@@ -94,7 +94,10 @@ def get_embeddings(
     selected_data = data_map[data_source]
 
     # Avoid circular imports
-    from tabpfn.preprocessing import ClassifierEnsembleConfig, RegressorEnsembleConfig
+    from tabpfn.preprocessing import (  # noqa: PLC0415
+        ClassifierEnsembleConfig,
+        RegressorEnsembleConfig,
+    )
 
     X = validate_X_predict(X, model)
     X = fix_dtypes(X, cat_indices=model.categorical_features_indices)
@@ -635,7 +638,7 @@ def _map_to_bucket_ix(y: torch.Tensor, borders: torch.Tensor) -> torch.Tensor:
 # However we don't really need the full BarDistribution class and this was
 # put here to make that a bit more obvious in terms of what was going on.
 def _cdf(logits: torch.Tensor, borders: torch.Tensor, ys: torch.Tensor) -> torch.Tensor:
-    ys = ys.repeat(logits.shape[:-1] + (1,))
+    ys = ys.repeat((*logits.shape[:-1], 1))
     n_bars = len(borders) - 1
     y_buckets = _map_to_bucket_ix(ys, borders).clamp(0, n_bars - 1).to(logits.device)
 
@@ -806,7 +809,7 @@ def get_total_memory_windows() -> float:
     Returns:
         The total memory of the system in GB.
     """
-    import platform
+    import platform  # noqa: PLC0415
 
     if platform.system() != "Windows":
         return 0.0  # Function should not be called on non-Windows platforms

--- a/tests/test_classifier_interface.py
+++ b/tests/test_classifier_interface.py
@@ -281,9 +281,9 @@ def test_softmax_temperature_impact_on_logits_magnitude(
     model_high_temp.fit(X, y)
     logits_high_temp = model_high_temp.predict_logits(X)
 
-    assert np.mean(np.abs(logits_low_temp)) > np.mean(
-        np.abs(logits_high_temp)
-    ), "Low softmax temperature did not result in more extreme logits."
+    assert np.mean(np.abs(logits_low_temp)) > np.mean(np.abs(logits_high_temp)), (
+        "Low softmax temperature did not result in more extreme logits."
+    )
 
     model_temp_one = TabPFNClassifier(
         softmax_temperature=1.0, n_estimators=1, device="cpu", random_state=42
@@ -291,12 +291,12 @@ def test_softmax_temperature_impact_on_logits_magnitude(
     model_temp_one.fit(X, y)
     logits_temp_one = model_temp_one.predict_logits(X)
 
-    assert not np.allclose(
-        logits_temp_one, logits_low_temp, atol=1e-6
-    ), "Logits did not change with low temperature."
-    assert not np.allclose(
-        logits_temp_one, logits_high_temp, atol=1e-6
-    ), "Logits did not change with high temperature."
+    assert not np.allclose(logits_temp_one, logits_low_temp, atol=1e-6), (
+        "Logits did not change with low temperature."
+    )
+    assert not np.allclose(logits_temp_one, logits_high_temp, atol=1e-6), (
+        "Logits did not change with high temperature."
+    )
 
 
 def test_balance_probabilities_alters_proba_output(
@@ -334,9 +334,9 @@ def test_balance_probabilities_alters_proba_output(
     model_balance.fit(X_subset, y_imbalanced)
     proba_balance = model_balance.predict_proba(X_subset)
 
-    assert not np.allclose(
-        proba_no_balance, proba_balance, atol=1e-5
-    ), "Probabilities did not change when balance_probabilities was toggled."
+    assert not np.allclose(proba_no_balance, proba_balance, atol=1e-5), (
+        "Probabilities did not change when balance_probabilities was toggled."
+    )
 
 
 @pytest.mark.skip(
@@ -768,13 +768,13 @@ def test_initialize_model_variables_classifier_sets_required_attributes() -> Non
     assert classifier.model_ is not None, "model_ should be initialized for classifier"
 
     assert hasattr(classifier, "config_"), "classifier should have config_ attribute"
-    assert (
-        classifier.config_ is not None
-    ), "config_ should be initialized for classifier"
+    assert classifier.config_ is not None, (
+        "config_ should be initialized for classifier"
+    )
 
-    assert not hasattr(
-        classifier, "bardist_"
-    ), "classifier should not have bardist_ attribute"
+    assert not hasattr(classifier, "bardist_"), (
+        "classifier should not have bardist_ attribute"
+    )
 
     # 3) Reuse via ClassifierModelSpecs
     new_model_state = classifier.model_
@@ -785,15 +785,15 @@ def test_initialize_model_variables_classifier_sets_required_attributes() -> Non
     classifier2._initialize_model_variables()
 
     assert hasattr(classifier2, "model_"), "classifier2 should have model_ attribute"
-    assert (
-        classifier2.model_ is not None
-    ), "model_ should be initialized for classifier2"
+    assert classifier2.model_ is not None, (
+        "model_ should be initialized for classifier2"
+    )
 
     assert hasattr(classifier2, "config_"), "classifier2 should have config_ attribute"
-    assert (
-        classifier2.config_ is not None
-    ), "config_ should be initialized for classifier2"
+    assert classifier2.config_ is not None, (
+        "config_ should be initialized for classifier2"
+    )
 
-    assert not hasattr(
-        classifier2, "bardist_"
-    ), "classifier2 should not have bardist_ attribute"
+    assert not hasattr(classifier2, "bardist_"), (
+        "classifier2 should not have bardist_ attribute"
+    )

--- a/tests/test_finetuning_classifier.py
+++ b/tests/test_finetuning_classifier.py
@@ -297,9 +297,9 @@ def test_datasetcollectionwithpreprocessing_classification_single_dataset(
     processed_dataset_item = dataset_collection[item_index]
 
     assert isinstance(processed_dataset_item, tuple)
-    assert (
-        len(processed_dataset_item) == 6
-    ), "Item tuple should have 4 elements for classification"
+    assert len(processed_dataset_item) == 6, (
+        "Item tuple should have 4 elements for classification"
+    )
 
     (
         X_trains_preprocessed,
@@ -339,16 +339,16 @@ def test_datasetcollectionwithpreprocessing_classification_multiple_datasets(
     )
 
     assert isinstance(dataset_collection, DatasetCollectionWithPreprocessing)
-    assert len(dataset_collection) == len(
-        datasets
-    ), "Collection should contain one item per dataset"
+    assert len(dataset_collection) == len(datasets), (
+        "Collection should contain one item per dataset"
+    )
 
     for item_index in range(len(datasets)):
         processed_dataset_item = dataset_collection[item_index]
         assert isinstance(processed_dataset_item, tuple)
-        assert (
-            len(processed_dataset_item) == 6
-        ), "Item tuple should have 6 elements for classification"
+        assert len(processed_dataset_item) == 6, (
+            "Item tuple should have 6 elements for classification"
+        )
         (
             X_trains_preprocessed,
             X_tests_preprocessed,
@@ -385,14 +385,14 @@ def test_dataset_and_collator_with_dataloader_uniform(
         assert isinstance(batch, tuple)
         X_trains, X_tests, y_trains, y_tests, cat_ixs, confs = batch
         for est_tensor in X_trains:
-            assert isinstance(
-                est_tensor, torch.Tensor
-            ), "Each estimator's batch should be a tensor."
+            assert isinstance(est_tensor, torch.Tensor), (
+                "Each estimator's batch should be a tensor."
+            )
             assert est_tensor.shape[0] == batch_size
         for est_tensor in y_trains:
-            assert isinstance(
-                est_tensor, torch.Tensor
-            ), "Each estimator's batch should be a tensor for labels."
+            assert isinstance(est_tensor, torch.Tensor), (
+                "Each estimator's batch should be a tensor for labels."
+            )
             assert est_tensor.shape[0] == batch_size
         break  # Only check one batch
 
@@ -469,9 +469,9 @@ def test_forward_runs(classifier_instance, classification_data):
     assert preds.shape[0] == X_test.shape[0], "Mismatch in test sample count"
     assert preds.shape[1] == clf.n_classes_, "Mismatch in class count"
     probs_sum = preds.sum(dim=1)
-    assert torch.allclose(
-        probs_sum, torch.ones_like(probs_sum), atol=1e-5
-    ), "Probabilities do not sum to 1"
+    assert torch.allclose(probs_sum, torch.ones_like(probs_sum), atol=1e-5), (
+        "Probabilities do not sum to 1"
+    )
 
 
 def test_fit_from_preprocessed_runs(classifier_instance, classification_data) -> None:
@@ -501,9 +501,9 @@ def test_fit_from_preprocessed_runs(classifier_instance, classification_data) ->
 
         # TODO: verify number of classes, "Mismatch in class count"
         probs_sum = preds.sum(dim=1)
-        assert torch.allclose(
-            probs_sum, torch.ones_like(probs_sum), atol=1e-5
-        ), "Probabilities do not sum to 1"
+        assert torch.allclose(probs_sum, torch.ones_like(probs_sum), atol=1e-5), (
+            "Probabilities do not sum to 1"
+        )
         break  # Only need to check one batch for this test
 
 
@@ -577,9 +577,9 @@ class TestTabPFNClassifierPreprocessingInspection(unittest.TestCase):
 
             # Capture the tensor input 'x' (usually the second positional argument)
             call_args_list = mock_forward_p1.call_args_list
-            assert (
-                len(call_args_list) > 0
-            ), "No calls recorded for standard model_.forward."
+            assert len(call_args_list) > 0, (
+                "No calls recorded for standard model_.forward."
+            )
             if len(call_args_list[0].args) > 1:
                 tensor_p1_full = call_args_list[0].args[0]
                 tensor_p1_full = mock_forward_p1.call_args.args[0]
@@ -590,9 +590,9 @@ class TestTabPFNClassifierPreprocessingInspection(unittest.TestCase):
                     f"unexpected arguments: {call_args_list[0].args}"
                 )
 
-        assert (
-            tensor_p1_full is not None
-        ), "Failed to capture tensor from standard path."
+        assert tensor_p1_full is not None, (
+            "Failed to capture tensor from standard path."
+        )
         # Shape might be [1, N_Total, Features+1] or similar. Check the actual shape.
         # Example assertion: Check if the sequence length matches n_total
         assert tensor_p1_full.shape[0] == n_total, (
@@ -654,9 +654,9 @@ class TestTabPFNClassifierPreprocessingInspection(unittest.TestCase):
 
             # Capture the tensor input 'x' (assuming same argument position as Path 1)
             call_args_list = mock_forward_p2.call_args_list
-            assert (
-                len(call_args_list) > 0
-            ), "No calls recorded for batched model_.forward."
+            assert len(call_args_list) > 0, (
+                "No calls recorded for batched model_.forward."
+            )
             if len(call_args_list[0].args) > 1:
                 tensor_p2_full = mock_forward_p2.call_args.args[0]
             else:
@@ -693,9 +693,9 @@ class TestTabPFNClassifierPreprocessingInspection(unittest.TestCase):
             p2_squeezed = tensor_p2_full
 
         # Final check of shapes after potential squeeze
-        assert (
-            p1_squeezed.shape == p2_squeezed.shape
-        ), "Shapes of final model input tensors mismatch after squeeze. "
+        assert p1_squeezed.shape == p2_squeezed.shape, (
+            "Shapes of final model input tensors mismatch after squeeze. "
+        )
 
         # Visual inspection snippet
 

--- a/tests/test_finetuning_regressor.py
+++ b/tests/test_finetuning_regressor.py
@@ -260,9 +260,9 @@ def test_tabpfn_regressor_finetuning_loop(
             averaged_pred_logits, _, _ = reg.forward(X_tests_preprocessed)
 
             # --- Basic Shape Checks ---
-            assert (
-                averaged_pred_logits.ndim == 3
-            ), f"Expected 3D output, got {averaged_pred_logits.shape}"
+            assert averaged_pred_logits.ndim == 3, (
+                f"Expected 3D output, got {averaged_pred_logits.shape}"
+            )
 
             # Batch Size
             assert averaged_pred_logits.shape[0] == batch_y_test_raw.shape[0]
@@ -284,15 +284,15 @@ def test_tabpfn_regressor_finetuning_loop(
             assert len(X_trains_preprocessed) == reg.n_estimators
             assert len(y_trains_preprocessed) == reg.n_estimators
             assert reg.model_ is not None, "Model not initialized after fit"
-            assert hasattr(
-                reg, "znorm_space_bardist_"
-            ), "Regressor missing 'znorm_space_bardist_' attribute after fit"
-            assert hasattr(
-                reg, "raw_space_bardist_"
-            ), "Regressor missing 'raw_space_bardist_' attribute after fit"
-            assert (
-                reg.znorm_space_bardist_ is not None
-            ), "reg.znorm_space_bardist_ is None"
+            assert hasattr(reg, "znorm_space_bardist_"), (
+                "Regressor missing 'znorm_space_bardist_' attribute after fit"
+            )
+            assert hasattr(reg, "raw_space_bardist_"), (
+                "Regressor missing 'raw_space_bardist_' attribute after fit"
+            )
+            assert reg.znorm_space_bardist_ is not None, (
+                "reg.znorm_space_bardist_ is None"
+            )
 
             lossfn = None
             if optimization_space == "raw_label_space":
@@ -569,9 +569,9 @@ class TestTabPFNPreprocessingInspection(unittest.TestCase):
         p1_squeezed = tensor_p1_full.squeeze()
         p3_squeezed = tensor_p3_full.squeeze()
 
-        assert (
-            p1_squeezed.shape == p3_squeezed.shape
-        ), "Shapes of final model input tensors mismatch."
+        assert p1_squeezed.shape == p3_squeezed.shape, (
+            "Shapes of final model input tensors mismatch."
+        )
 
         atol = 1e-6
         tensors_match = torch.allclose(p1_squeezed, p3_squeezed, atol=atol)

--- a/tests/test_ft_utils.py
+++ b/tests/test_ft_utils.py
@@ -14,17 +14,17 @@ def test_pad_tensors_2d_and_1d():
     # 2D tensors (features)
     tensors_2d = [torch.ones((2, 3)), torch.ones((3, 2)), torch.ones((1, 4))]
     padded = pad_tensors(tensors_2d, padding_val=-1, labels=False)
-    assert all(
-        t.shape == (3, 4) for t in padded
-    ), f"Expected shape (3, 4), got {[t.shape for t in padded]}"
+    assert all(t.shape == (3, 4) for t in padded), (
+        f"Expected shape (3, 4), got {[t.shape for t in padded]}"
+    )
     assert padded[0][2, 3] == -1, "Padding value not set correctly for 2D case."
 
     # 1D tensors (labels)
     tensors_1d = [torch.arange(3), torch.arange(5), torch.arange(2)]
     padded_1d = pad_tensors(tensors_1d, padding_val=99, labels=True)
-    assert all(
-        t.shape == (5,) for t in padded_1d
-    ), f"Expected shape (5,), got {[t.shape for t in padded_1d]}"
+    assert all(t.shape == (5,) for t in padded_1d), (
+        f"Expected shape (5,), got {[t.shape for t in padded_1d]}"
+    )
     assert padded_1d[0][3] == 99, "Padding value not set correctly for 1D case."
 
 

--- a/tests/test_model/test_encoders.py
+++ b/tests/test_model/test_encoders.py
@@ -118,13 +118,13 @@ def test_input_normalization():
     )
 
     out = encoder({"main": x}, single_eval_pos=-1)["main"]
-    assert torch.isclose(
-        out.var(dim=0), torch.tensor([1.0]), atol=1e-05
-    ).all(), "Variance should be 1.0 for all features and batch samples."
+    assert torch.isclose(out.var(dim=0), torch.tensor([1.0]), atol=1e-05).all(), (
+        "Variance should be 1.0 for all features and batch samples."
+    )
 
-    assert torch.isclose(
-        out.mean(dim=0), torch.tensor([0.0]), atol=1e-05
-    ).all(), "Mean should be 0.0 for all features and batch samples."
+    assert torch.isclose(out.mean(dim=0), torch.tensor([0.0]), atol=1e-05).all(), (
+        "Mean should be 0.0 for all features and batch samples."
+    )
 
     out = encoder({"main": x}, single_eval_pos=5)["main"]
     assert torch.isclose(out[0:5].var(dim=0), torch.tensor([1.0]), atol=1e-03).all(), (
@@ -141,12 +141,12 @@ def test_input_normalization():
     x[:, 1, :] = 100.0
     x[:, 2, 6:] = 100.0
     out = encoder({"main": x}, single_eval_pos=5)["main"]
-    assert (
-        out[:, 0, :] == out_ref[:, 0, :]
-    ).all(), "Changing one batch should not affeect the others."
-    assert (
-        out[:, 2, 0:5] == out_ref[:, 2, 0:5]
-    ).all(), "Changing unnormalized part of the batch should not affect the others."
+    assert (out[:, 0, :] == out_ref[:, 0, :]).all(), (
+        "Changing one batch should not affeect the others."
+    )
+    assert (out[:, 2, 0:5] == out_ref[:, 2, 0:5]).all(), (
+        "Changing unnormalized part of the batch should not affect the others."
+    )
 
 
 def test_remove_empty_feats():
@@ -164,21 +164,21 @@ def test_remove_empty_feats():
 
     x[0, 1, 1] = 0.0
     out = encoder({"main": x}, single_eval_pos=-1)["main"]
-    assert (
-        out[:, 1, -1] != 0
-    ).all(), "Should not change anything if no column is entirely empty."
+    assert (out[:, 1, -1] != 0).all(), (
+        "Should not change anything if no column is entirely empty."
+    )
 
     x[:, 1, 1] = 0.0
     out = encoder({"main": x}, single_eval_pos=-1)["main"]
-    assert (
-        out[:, 1, -1] == 0
-    ).all(), "Empty column should be removed and shifted to the end."
-    assert (
-        out[:, 1, 1] != 0
-    ).all(), "The place of the empty column should be filled with the next column."
-    assert (
-        out[:, 2, 1] != 0
-    ).all(), "Non empty columns should not be changed in their position."
+    assert (out[:, 1, -1] == 0).all(), (
+        "Empty column should be removed and shifted to the end."
+    )
+    assert (out[:, 1, 1] != 0).all(), (
+        "The place of the empty column should be filled with the next column."
+    )
+    assert (out[:, 2, 1] != 0).all(), (
+        "Non empty columns should not be changed in their position."
+    )
 
 
 def test_variable_num_features():
@@ -192,9 +192,9 @@ def test_variable_num_features():
     )
 
     out = encoder({"main": x}, single_eval_pos=-1)["main"]
-    assert (
-        out.shape[-1] == fixed_out
-    ), "Features were not extended to the requested number of features."
+    assert out.shape[-1] == fixed_out, (
+        "Features were not extended to the requested number of features."
+    )
     assert torch.isclose(
         out[:, :, 0 : x.shape[-1]] / x, torch.tensor([math.sqrt(fixed_out / F)])
     ).all(), "Normalization is not correct."
@@ -213,9 +213,9 @@ def test_variable_num_features():
         VariableNumFeaturesEncoderStep(**kwargs), output_key=None
     )
     out = encoder({"main": x}, single_eval_pos=-1)["main"]
-    assert (
-        out[:, :, : x.shape[-1]] == x
-    ).all(), "Features should be unchanged when not normalizing."
+    assert (out[:, :, : x.shape[-1]] == x).all(), (
+        "Features should be unchanged when not normalizing."
+    )
 
 
 def test_nan_handling_encoder():
@@ -301,12 +301,12 @@ def test_combination():
     x[:, 1, :] = 100.0
     x[6:, 2, 2] = 100.0
     out = encoder({"main": x}, single_eval_pos=5)["main"]
-    assert (
-        out[:, 0, :] == out_ref[:, 0, :]
-    ).all(), "Changing one batch should not affeect the others."
-    assert (
-        out[0:5, 2, 2] == out_ref[0:5, 2, 2]
-    ).all(), "Changing unnormalized part of the batch should not affect the others."
+    assert (out[:, 0, :] == out_ref[:, 0, :]).all(), (
+        "Changing one batch should not affeect the others."
+    )
+    assert (out[0:5, 2, 2] == out_ref[0:5, 2, 2]).all(), (
+        "Changing unnormalized part of the batch should not affect the others."
+    )
 
     x = torch.randn([N, B, F])
     x[1, 0, 2] = np.inf
@@ -332,12 +332,12 @@ def test_combination():
         {"main": x_param, "domain_indicator": domain_indicator}, single_eval_pos=5
     )["main"].sum()
     s.backward()
-    assert (
-        x_param.grad is not None
-    ), "the encoder is not differentiable, i.e. the gradients are None."
-    assert not torch.isnan(
-        x_param.grad
-    ).any(), "the encoder is not differentiable, i.e. the gradients are nan."
+    assert x_param.grad is not None, (
+        "the encoder is not differentiable, i.e. the gradients are None."
+    )
+    assert not torch.isnan(x_param.grad).any(), (
+        "the encoder is not differentiable, i.e. the gradients are nan."
+    )
 
 
 def test_multiclass_encoder():

--- a/tests/test_model/test_seperate_train_inference.py
+++ b/tests/test_model/test_seperate_train_inference.py
@@ -82,6 +82,6 @@ def test_separate_train_inference(multiquery_item_attention_for_test_set: bool):
     torch.manual_seed(12345)
     logits1a = model(x=torch.concat([x_train, x_test]), y=y)
 
-    assert logits1.float() == pytest.approx(
-        logits1a.float(), abs=1e-5
-    ), f"{logits1} != {logits1a}"
+    assert logits1.float() == pytest.approx(logits1a.float(), abs=1e-5), (
+        f"{logits1} != {logits1a}"
+    )

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -210,9 +210,9 @@ def test_reshape_step_append_original_logic(
     assert Xt.shape[1] == expected_output_features
 
 
-def _get_preprocessing_steps() -> (
-    list[Callable[..., FeaturePreprocessingTransformerStep]]
-):
+def _get_preprocessing_steps() -> list[
+    Callable[..., FeaturePreprocessingTransformerStep]
+]:
     defaults: list[Callable[..., FeaturePreprocessingTransformerStep]] = [
         cls
         for cls in preprocessing.__dict__.values()
@@ -284,16 +284,16 @@ def test__preprocessing_steps__transform__no_sample_interdependence():
         # Test 1: Shuffling samples should give correspondingly shuffled results
         result_normal = obj.transform(x2)
         result_reversed = obj.transform(x2[::-1])
-        assert np.allclose(
-            result_reversed.X[::-1], result_normal.X
-        ), f"Transform depends on sample order for {cls}"
+        assert np.allclose(result_reversed.X[::-1], result_normal.X), (
+            f"Transform depends on sample order for {cls}"
+        )
 
         # Test 2: Transforming a subset should match the subset of full transformation
         result_full = obj.transform(x2)
         result_subset = obj.transform(x2[:4])
-        assert np.allclose(
-            result_full.X[:4], result_subset.X
-        ), f"Transform depends on other samples in batch for {cls}"
+        assert np.allclose(result_full.X[:4], result_subset.X), (
+            f"Transform depends on other samples in batch for {cls}"
+        )
 
         # Test 3: Categorical features should remain the same
         assert result_full.categorical_features == result_subset.categorical_features
@@ -393,9 +393,9 @@ def test__safe_power_transformer__power_transformer_fails__no_error():
     )
 
     # check if result contains nan or inf
-    assert np.all(
-        np.isfinite(safe_result)
-    ), "SafePowerTransformer produced non-finite values"
+    assert np.all(np.isfinite(safe_result)), (
+        "SafePowerTransformer produced non-finite values"
+    )
 
 
 def test__safe_power_transformer__transform_then_inverse_transform__returns_original():

--- a/tests/test_regressor_interface.py
+++ b/tests/test_regressor_interface.py
@@ -225,21 +225,21 @@ def test_regressor_in_pipeline(X_y: tuple[np.ndarray, np.ndarray]) -> None:
 
     # Test different prediction modes through the pipeline
     predictions_median = pipeline.predict(X, output_type="median")
-    assert predictions_median.shape == (
-        X.shape[0],
-    ), "Median predictions shape is incorrect"
+    assert predictions_median.shape == (X.shape[0],), (
+        "Median predictions shape is incorrect"
+    )
 
     predictions_mode = pipeline.predict(X, output_type="mode")
-    assert predictions_mode.shape == (
-        X.shape[0],
-    ), "Mode predictions shape is incorrect"
+    assert predictions_mode.shape == (X.shape[0],), (
+        "Mode predictions shape is incorrect"
+    )
 
     quantiles = pipeline.predict(X, output_type="quantiles", quantiles=[0.1, 0.9])
     assert isinstance(quantiles, list)
     assert len(quantiles) == 2
-    assert quantiles[0].shape == (
-        X.shape[0],
-    ), "Quantile predictions shape is incorrect"
+    assert quantiles[0].shape == (X.shape[0],), (
+        "Quantile predictions shape is incorrect"
+    )
 
 
 def test_dict_vs_object_preprocessor_config(X_y: tuple[np.ndarray, np.ndarray]) -> None:
@@ -559,35 +559,35 @@ def test_constant_target(X_y: tuple[np.ndarray, np.ndarray]) -> None:
 
     # Test different output types
     predictions_median = model.predict(X, output_type="median")
-    assert np.all(
-        predictions_median == 5.0
-    ), "Median predictions are not constant as expected"
+    assert np.all(predictions_median == 5.0), (
+        "Median predictions are not constant as expected"
+    )
 
     predictions_mode = model.predict(X, output_type="mode")
-    assert np.all(
-        predictions_mode == 5.0
-    ), "Mode predictions are not constant as expected"
+    assert np.all(predictions_mode == 5.0), (
+        "Mode predictions are not constant as expected"
+    )
 
     quantiles = model.predict(X, output_type="quantiles", quantiles=[0.1, 0.9])
     for quantile_prediction in quantiles:
-        assert np.all(
-            quantile_prediction == 5.0
-        ), "Quantile predictions are not constant as expected"
+        assert np.all(quantile_prediction == 5.0), (
+            "Quantile predictions are not constant as expected"
+        )
 
     full_output = model.predict(X, output_type="full")
-    assert np.all(
-        full_output["mean"] == 5.0
-    ), "Mean predictions are not constant as expected for full output"
-    assert np.all(
-        full_output["median"] == 5.0
-    ), "Median predictions are not constant as expected for full output"
-    assert np.all(
-        full_output["mode"] == 5.0
-    ), "Mode predictions are not constant as expected for full output"
+    assert np.all(full_output["mean"] == 5.0), (
+        "Mean predictions are not constant as expected for full output"
+    )
+    assert np.all(full_output["median"] == 5.0), (
+        "Median predictions are not constant as expected for full output"
+    )
+    assert np.all(full_output["mode"] == 5.0), (
+        "Mode predictions are not constant as expected for full output"
+    )
     for quantile_prediction in full_output["quantiles"]:
-        assert np.all(
-            quantile_prediction == 5.0
-        ), "Quantile predictions are not constant as expected for full output"
+        assert np.all(quantile_prediction == 5.0), (
+            "Quantile predictions are not constant as expected for full output"
+        )
 
 
 def test_initialize_model_variables_regressor_sets_required_attributes() -> None:
@@ -599,9 +599,9 @@ def test_initialize_model_variables_regressor_sets_required_attributes() -> None
     )
     assert model is not None, "model should be initialized for regressor"
     assert config is not None, "config should be initialized for regressor"
-    assert (
-        norm_criterion is not None
-    ), "norm_criterion should be initialized for regressor"
+    assert norm_criterion is not None, (
+        "norm_criterion should be initialized for regressor"
+    )
 
     # 2) Test the sklearn-style wrapper on TabPFNRegressor
     regressor = TabPFNRegressor(device="cpu", random_state=42)
@@ -613,12 +613,12 @@ def test_initialize_model_variables_regressor_sets_required_attributes() -> None
     assert hasattr(regressor, "config_"), "regressor should have config_ attribute"
     assert regressor.config_ is not None, "config_ should be initialized for regressor"
 
-    assert hasattr(
-        regressor, "znorm_space_bardist_"
-    ), "regressor should have znorm_space_bardist_ attribute"
-    assert (
-        regressor.znorm_space_bardist_ is not None
-    ), "znorm_space_bardist_ should be initialized for regressor"
+    assert hasattr(regressor, "znorm_space_bardist_"), (
+        "regressor should have znorm_space_bardist_ attribute"
+    )
+    assert regressor.znorm_space_bardist_ is not None, (
+        "znorm_space_bardist_ should be initialized for regressor"
+    )
 
     # 3) Reuse via RegressorModelSpecs
     spec = RegressorModelSpecs(
@@ -635,9 +635,9 @@ def test_initialize_model_variables_regressor_sets_required_attributes() -> None
     assert hasattr(reg2, "config_"), "regressor2 should have config_ attribute"
     assert reg2.config_ is not None, "config_ should be initialized for regressor2"
 
-    assert hasattr(
-        reg2, "znorm_space_bardist_"
-    ), "regressor2 should have znorm_space_bardist_ attribute"
-    assert (
-        reg2.znorm_space_bardist_ is not None
-    ), "znorm_space_bardist_ should be initialized for regressor2"
+    assert hasattr(reg2, "znorm_space_bardist_"), (
+        "regressor2 should have znorm_space_bardist_ attribute"
+    )
+    assert reg2.znorm_space_bardist_ is not None, (
+        "znorm_space_bardist_ should be initialized for regressor2"
+    )

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -65,13 +65,13 @@ def test_dependency_script_generation(
     # ASSERT
     # The assertion logic remains exactly the same.
     output_file = tmp_path / "requirements.txt"
-    assert (
-        output_file.is_file()
-    ), f"Script did not create requirements.txt in '{mode}' mode."
+    assert output_file.is_file(), (
+        f"Script did not create requirements.txt in '{mode}' mode."
+    )
 
     with output_file.open() as f:
         actual_requirements = sorted(line.strip() for line in f if line.strip())
 
-    assert (
-        actual_requirements == expected_requirements
-    ), f"Output in '{mode}' mode did not match expectations."
+    assert actual_requirements == expected_requirements, (
+        f"Output in '{mode}' mode did not match expectations."
+    )


### PR DESCRIPTION
## Summary
- fix formatting and linting for ruff 0.12.12
- ignore vendored files via per-file-ignores and update test lint config

## Testing
- `ruff check --fix .`
- `pre-commit run --files src/tabpfn/architectures/base/bar_distribution.py src/tabpfn/architectures/base/memory.py src/tabpfn/architectures/base/preprocessing.py src/tabpfn/architectures/base/transformer.py src/tabpfn/model_loading.py src/tabpfn/utils.py src/tabpfn/misc/debug_versions.py src/tabpfn/misc/_sklearn_compat.py pyproject.toml` *(fails: fatal: unable to access 'https://github.com/pre-commit/pre-commit-hooks/': CONNECT tunnel failed, response 403)*
- `pytest` *(fails: Failed to download model to /root/.cache/tabpfn/tabpfn-v2-classifier-finetuned-zk73skhh.ckpt)*

------
https://chatgpt.com/codex/tasks/task_b_68c000ee5c688333a3c109c9156e2f43