### PR TITLE
If device="auto" and multiple GPUs are present, only select the first.

### DIFF
--- a/src/tabpfn/classifier.py
+++ b/src/tabpfn/classifier.py
@@ -233,8 +233,8 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
             device:
                 The device to use for inference with TabPFN. If set to "auto", the
                 device is selected based on availability in the following order of
-                priority: "cuda", "mps", and then "cpu". You can also set the device
-                manually to one of these options.
+                priority: "cuda:0", "mps", and then "cpu". You can also set the device
+                manually to a PyTorch device string e.g. "cuda:1".
 
                 See PyTorch's documentation on devices for more information about
                 supported devices.

--- a/src/tabpfn/regressor.py
+++ b/src/tabpfn/regressor.py
@@ -264,8 +264,8 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
             device:
                 The device to use for inference with TabPFN. If set to "auto", the
                 device is selected based on availability in the following order of
-                priority: "cuda", "mps", and then "cpu". You can also set the device
-                manually to one of these options.
+                priority: "cuda:0", "mps", and then "cpu". You can also set the device
+                manually to a PyTorch device string e.g. "cuda:1".
 
                 See PyTorch's documentation on devices for more information about
                 supported devices.

--- a/src/tabpfn/utils.py
+++ b/src/tabpfn/utils.py
@@ -184,7 +184,7 @@ def infer_devices(devices: DevicesSpecification) -> tuple[torch.device, ...]:
     """Selects the appropriate PyTorch devices for inference.
 
     If `device` is "auto" then the devices are selected as follows:
-    1. If CUDA is available and not excluded, returns all "cuda" devices
+    1. If CUDA is available and not excluded, returns the first "cuda" device
     2. Otherwise, if MPS is available and not excluded, returns the "mps" device
     3. Otherwise, returns the "cpu" device
 
@@ -212,9 +212,7 @@ def infer_devices(devices: DevicesSpecification) -> tuple[torch.device, ...]:
 
     if devices == "auto":
         if "cuda" not in exclude_devices and torch.cuda.is_available():
-            return tuple(
-                torch.device(f"cuda:{i}") for i in range(torch.cuda.device_count())
-            )
+            return (torch.device("cuda:0"),)
 
         if torch.backends.mps.is_available() and "mps" not in exclude_devices:
             return (torch.device("mps"),)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -140,7 +140,7 @@ def test__infer_devices__auto__single_cuda_gpu_available__selects_it(
     assert infer_devices(devices="auto") == (torch.device("cuda:0"),)
 
 
-def test__infer_devices__auto__multiple_cuda_gpus_available__selects_all(
+def test__infer_devices__auto__multiple_cuda_gpus_available__selects_first(
     mocker: MagicMock,
 ) -> None:
     mock_cuda = mocker.patch("torch.cuda")
@@ -148,9 +148,7 @@ def test__infer_devices__auto__multiple_cuda_gpus_available__selects_all(
     mock_cuda.device_count.return_value = 3
     mocker.patch("torch.backends.mps").is_available.return_value = True
 
-    inferred = set(infer_devices(devices="auto"))
-    expected = {torch.device("cuda:0"), torch.device("cuda:1"), torch.device("cuda:2")}
-    assert inferred == expected
+    assert infer_devices(devices="auto") == (torch.device("cuda:0"),)
 
 
 def test__infer_devices__auto__cuda_and_mps_available_but_excluded__selects_cpu(


### PR DESCRIPTION
We're seeing prediction errors when multiple GPUs are used. Switch to only using multiple GPUs if explicitly enabled, while we debug.

Tested manually on a machine with 2 GPUs and a dataset exhibiting the issue:
- current main: inference does not work
- this PR with device=auto: inference works
- this PR with device=["cuda:0","cuda:1"]: inference does not work

Also, update the device docstring. Don't include multi-gpu inference for now, until we've fixed it.