### PR TITLE
Run the tests on merge to main in addition to in PRs.

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,6 +1,9 @@
-name: In pull request
+name: Run tests
 on:
   pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
 
 jobs:
   check_python_linting:


### PR DESCRIPTION
To help catch interactions between concurrent PRs, and to make it easier to determine which commit caused a failure.

Also add a "workflow_dispatch" trigger in case we want to run the tests manually (might be useful for flakes). This can only be used by people with write access to the repository, see
https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manually-run-a-workflow