### PR TITLE
[Resolved Merge Conflicts from PR 312] Remove shell download script and fix fallback URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,9 +225,9 @@ This script will download the main classifier and regressor models, as well as a
 
 **Manual Download**
 
-1. Download the model files manually from HuggingFace:
-   - Classifier: [tabpfn-v2-classifier-finetuned-zk73skhh.ckpt](https://huggingface.co/Prior-Labs/TabPFN-v2-clf/resolve/main/tabpfn-v2-classifier-finetuned-zk73skhh.ckpt)
-   - Regressor: [tabpfn-v2-regressor.ckpt](https://huggingface.co/Prior-Labs/TabPFN-v2-reg/resolve/main/tabpfn-v2-regressor.ckpt)
+1. Download the model files manually from HuggingFace (or use the S3 fallback if HuggingFace is unavailable):
+   - Classifier: [tabpfn-v2-classifier.ckpt](https://huggingface.co/Prior-Labs/TabPFN-v2-clf/resolve/main/tabpfn-v2-classifier.ckpt) ([S3 fallback](https://storage.googleapis.com/tabpfn-v2-model-files/05152025/tabpfn-v2-classifier.ckpt))
+   - Regressor: [tabpfn-v2-regressor.ckpt](https://huggingface.co/Prior-Labs/TabPFN-v2-reg/resolve/main/tabpfn-v2-regressor.ckpt) ([S3 fallback](https://storage.googleapis.com/tabpfn-v2-model-files/05152025/tabpfn-v2-regressor.ckpt))
 
 2. Place the file in one of these locations:
    - Specify directly: `TabPFNClassifier(model_path="/path/to/model.ckpt")`

--- a/src/tabpfn/model_loading.py
+++ b/src/tabpfn/model_loading.py
@@ -40,6 +40,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Public fallback base URL for model downloads
+FALLBACK_S3_BASE_URL = "https://storage.googleapis.com/tabpfn-v2-model-files/05152025"
+
 
 class ModelType(str, Enum):  # noqa: D101
     CLASSIFIER = "classifier"
@@ -92,11 +95,12 @@ class ModelSource:  # noqa: D101
             filenames=filenames,
         )
 
-    def get_fallback_urls(self) -> list[str]:  # noqa: D102
+    def get_fallback_urls(self) -> list[str]:
+        """Return list of fallback URLs for model downloads."""
         return [
             f"https://huggingface.co/{self.repo_id}/resolve/main/{filename}?download=true"
             for filename in self.filenames
-        ]
+        ] + [f"{FALLBACK_S3_BASE_URL}/{filename}" for filename in self.filenames]
 
 
 def _get_model_source(version: ModelVersion, model_type: ModelType) -> ModelSource:
@@ -203,38 +207,42 @@ def _try_direct_downloads(
         if filename not in source.filenames:
             source.filenames.append(filename)
 
-    model_url = (
-        f"https://huggingface.co/{source.repo_id}/resolve/main/{filename}?download=true"
-    )
-    config_url = f"https://huggingface.co/{source.repo_id}/resolve/main/config.json?download=true"
+    url_pairs = [
+        (
+            f"https://huggingface.co/{source.repo_id}/resolve/main/{filename}?download=true",
+            f"https://huggingface.co/{source.repo_id}/resolve/main/config.json?download=true",
+        ),
+        (f"{FALLBACK_S3_BASE_URL}/{filename}", f"{FALLBACK_S3_BASE_URL}/config.json"),
+    ]
 
-    # Create parent directory if it doesn't exist
+    last_error: Exception | None = None
     base_path.parent.mkdir(parents=True, exist_ok=True)
 
-    logger.info(f"Attempting download from {model_url}")
-
-    try:
-        # Download model checkpoint
-        with urllib.request.urlopen(model_url) as response:  # noqa: S310
-            if response.status != 200:
-                raise URLError(
-                    f"HTTP {response.status} when downloading from {model_url}",
-                )
-            base_path.write_bytes(response.read())
-
-        # Try to download config.json
-        config_path = base_path.parent / "config.json"
+    for model_url, config_url in url_pairs:
+        logger.info(f"Attempting download from {model_url}")
         try:
-            with urllib.request.urlopen(config_url) as response:  # noqa: S310
-                if response.status == 200:
-                    config_path.write_bytes(response.read())
-        except Exception:  # noqa: BLE001
-            logger.warning("Failed to download config.json!")
-            # Continue even if config.json download fails
+            with urllib.request.urlopen(model_url) as response:  # noqa: S310
+                if response.status != 200:
+                    raise URLError(
+                        f"HTTP {response.status} when downloading from {model_url}",
+                    )
+                base_path.write_bytes(response.read())
 
-        logger.info(f"Successfully downloaded to {base_path}")
-    except Exception as e:
-        raise Exception("Direct download failed!") from e
+            config_path = base_path.parent / "config.json"
+            try:
+                with urllib.request.urlopen(config_url) as response:  # noqa: S310
+                    if response.status == 200:
+                        config_path.write_bytes(response.read())
+            except Exception:  # noqa: BLE001
+                logger.warning("Failed to download config.json!")
+
+            logger.info(f"Successfully downloaded to {base_path}")
+            return
+        except Exception as e:  # noqa: BLE001
+            last_error = e
+            logger.warning(f"Failed download from {model_url}: {e!s}")
+
+    raise Exception("Direct download failed!") from last_error
 
 
 def download_model(

--- a/tests/test_download_fallbacks.py
+++ b/tests/test_download_fallbacks.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import urllib.error
+import urllib.request
+from pathlib import Path
+from unittest.mock import patch
+
+from tabpfn.model_loading import (
+    FALLBACK_S3_BASE_URL,
+    ModelSource,
+    _try_direct_downloads,
+)
+
+
+class DummyResponse:
+    """Simple context manager mimicking ``urllib`` responses."""
+
+    def __init__(self, status: int = 200, data: bytes = b"ok") -> None:
+        """Create a dummy response with a given status and payload."""
+        self.status = status
+        self._data = data
+
+    def read(self) -> bytes:
+        return self._data
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+
+def test_direct_download_fallback(tmp_path: Path):
+    src = ModelSource.get_classifier_v2()
+    base_path = tmp_path / src.default_filename
+
+    attempted_urls: list[str] = []
+
+    def fake_urlopen(url: str, *_args, **_kwargs) -> DummyResponse:
+        attempted_urls.append(url)
+        if "huggingface.co" in url:
+            raise urllib.error.URLError("HF down")
+        return DummyResponse()
+
+    with patch.object(urllib.request, "urlopen", side_effect=fake_urlopen):
+        _try_direct_downloads(base_path, src)
+
+    assert any(url.startswith("https://huggingface.co") for url in attempted_urls)
+    assert any(url.startswith(FALLBACK_S3_BASE_URL) for url in attempted_urls)


### PR DESCRIPTION
## Motivation and Context
PR 312 had merging conflicts, due to out of date main branch. I resolved these issues and merged with up-to-date main branch code. 
 - moved code from `src/tabpfn/model/loading.py` (deprecated) to `src/tabpfn/model_loading.py`, and test imports accordingly. Also solved merge conflict in Readme.md
---

## Public API Changes

-   [x] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?
locally with Mock test and verified that download links work. 
---

## Checklist

-   [x] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [ ] A entry has been added to `CHANGELOG.md` (if relevant for users).
-   [x] The code follows the project's style guidelines.
-   [x] I have considered the impact of these changes on the public API.

---