### PR TITLE
Disable all telemetry in pytest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Disable all telemetry in unit tests.
+
 ## [2.2.1] - 2025-09-17
 
 ### Changed

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+"""Pytest configuration for TabPFN tests.
+
+This module sets up global test configuration, including disabling telemetry
+for all tests to ensure consistent behavior and avoid external dependencies
+during testing.
+"""
+
+import os
+import pytest
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Configure pytest with global settings."""
+    # Disable telemetry for all tests to ensure consistent behavior
+    os.environ["TABPFN_DISABLE_TELEMETRY"] = "1"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,12 +4,14 @@ This module sets up global test configuration, including disabling telemetry
 for all tests to ensure consistent behavior and avoid external dependencies
 during testing.
 """
+from __future__ import annotations
 
 import os
+
 import pytest
 
 
-def pytest_configure(config: pytest.Config) -> None:
+def pytest_configure(_: pytest.Config) -> None:
     """Configure pytest with global settings."""
     # Disable telemetry for all tests to ensure consistent behavior
     os.environ["TABPFN_DISABLE_TELEMETRY"] = "1"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ import os
 import pytest
 
 
-def pytest_configure(_: pytest.Config) -> None:
+def pytest_configure(config: pytest.Config) -> None:  # noqa: ARG001
     """Configure pytest with global settings."""
     # Disable telemetry for all tests to ensure consistent behavior
     os.environ["TABPFN_DISABLE_TELEMETRY"] = "1"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ This module sets up global test configuration, including disabling telemetry
 for all tests to ensure consistent behavior and avoid external dependencies
 during testing.
 """
+
 from __future__ import annotations
 
 import os

--- a/tests/test_telemetry_disabled.py
+++ b/tests/test_telemetry_disabled.py
@@ -1,4 +1,5 @@
 """Test to verify that telemetry is disabled during test execution."""
+from __future__ import annotations
 
 import os
 

--- a/tests/test_telemetry_disabled.py
+++ b/tests/test_telemetry_disabled.py
@@ -1,4 +1,5 @@
 """Test to verify that telemetry is disabled during test execution."""
+
 from __future__ import annotations
 
 import os

--- a/tests/test_telemetry_disabled.py
+++ b/tests/test_telemetry_disabled.py
@@ -1,0 +1,11 @@
+"""Test to verify that telemetry is disabled during test execution."""
+
+import os
+
+
+def test_telemetry_disabled():
+    """Verify that TABPFN_DISABLE_TELEMETRY is set to 1 during tests."""
+    assert os.environ.get("TABPFN_DISABLE_TELEMETRY") == "1", (
+        "TABPFN_DISABLE_TELEMETRY should be set to '1' during test execution. "
+        "This ensures telemetry is disabled for all tests."
+    )


### PR DESCRIPTION
## Motivation and Context

- Disable all telemetry in tests using `conftest` and a global PyTest configuration.

---

## Public API Changes

-   [x] No Public API changes

---

## How Has This Been Tested?

- Running all tests
- Manual validation across all events in our product analytics store

---

## Checklist

-   [x] The changes have been tested locally.
-   [x] Documentation has been updated (if the public API or usage changes).
-   [x] A entry has been added to `CHANGELOG.md` (if relevant for users).
-   [x] The code follows the project's style guidelines.
-   [x] I have considered the impact of these changes on the public API.

---