### PR TITLE
relax type for features_per_group

### DIFF
--- a/src/tabpfn/architectures/base/config.py
+++ b/src/tabpfn/architectures/base/config.py
@@ -8,7 +8,7 @@ from typing import Any, Literal, Optional
 from typing_extensions import Self
 
 import pydantic
-from pydantic import Field
+from pydantic import PositiveInt
 from pydantic.dataclasses import dataclass
 
 from tabpfn.architectures.interface import ArchitectureConfig
@@ -27,7 +27,7 @@ class ModelConfig(ArchitectureConfig):
     # ------ Actual variation across configs
     emsize: int = 192
     """The embedding dimension."""
-    features_per_group: int = Field(default=2, gt=0)
+    features_per_group: PositiveInt = 2
     """If > 1, the features will be grouped into groups of this size and the attention
     is across groups."""
     nhead: int = 6


### PR DESCRIPTION
## Motivation and Context

---

## Public API Changes

-   [ ] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?

---

## Checklist

-   [ ] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [ ] A entry has been added to `CHANGELOG.md` (if relevant for users).
-   [ ] The code follows the project's style guidelines.
-   [ ] I have considered the impact of these changes on the public API.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Expands `ModelConfig.features_per_group` from `Literal[1, 2]` to `PositiveInt`, importing `PositiveInt` accordingly.
> 
> - **Config (`src/tabpfn/architectures/base/config.py`)**:
>   - `ModelConfig.features_per_group`: type widened from `Literal[1, 2]` to `PositiveInt`.
>   - Add `from pydantic import PositiveInt` import.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66b0061f2dd849d86c8492f5da176a8667c7fa40. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->