### PR TITLE
Manage CI dependencies in pyproject and specify numpy dependency.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,9 +66,7 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: |
-          uv pip install --system --resolution ${{ matrix.dependency-set }} .
-          uv pip install --system pytest pytest-mock psutil onnx
+        run: uv pip install --system --resolution ${{ matrix.dependency-set }} ".[ci]"
         shell: bash
 
       - name: Initialize submodules
@@ -102,9 +100,7 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: |
-          uv pip install --system --resolution highest .
-          uv pip install --system pytest pytest-mock psutil onnx
+        run: uv pip install --system --resolution highest ".[ci]"
         shell: bash
 
       - name: Initialize submodules
@@ -150,9 +146,7 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: |
-          uv pip install --system --resolution ${{ matrix.dependency-set }} .
-          uv pip install --system pytest pytest-mock psutil onnx
+        run: uv pip install --system --resolution ${{ matrix.dependency-set }} ".[ci]"
         shell: bash
 
       - name: Initialize submodules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,14 @@ dev = [
   # docs.
   "black>=25.9.0",
 ]
+# The minimum subset of the dev dependencies required to run the tests on the CI.
+# The idea is to be as close to the deployment environment as possible.
+ci = [
+  "pytest>=8.4.2",
+  "pytest-mock>=3.14.1",
+  "onnx>=1.19.0",
+  "psutil>=7.1.0",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]  # Where the tests are located


### PR DESCRIPTION
The CI is currently failing, see 
https://github.com/PriorLabs/TabPFN/actions/runs/18370843390/job/52333508672.

The issue is that we get numpy>2 but an older version of scikit-learn, which is incompatible. There are two reasons for this:
1. Older versions of scikit-learn don't specify a maximum numpy version but are incompatible with numpy>2. When using uv's lowest-direct mode, as in the CI, scikit-learn is resolved to an old version (as it is a direct dependency) but numpy is resolved to the newest specified compatible version, which is >2. However, this is actually incompatible.
2. We install onnx in a separate command on the CI, which upgrades numpy to >2 even if (1) is fixed.

I fix (1) by specifying numpy as a direct dependency with a minimum version <2. Thus the lowest-direct resolution now chooses a compatible version <2. I selected the minimum version as the current minimum version required by our dependencies, so there should be no effect on compatibility.

I fix (2) by creating a new "ci" optional dependency group, and installing this rather than using a separate `uv pip install` command.

Note that (1) could still be a problem for users, but this problem has existed forever and we haven't had any complaints. It's also common to any package that depends on scikit-learn.