### PR TITLE
Explicitly disable Dynamo onnx exports to fix CI.

### DIFF
--- a/tests/test_classifier_interface.py
+++ b/tests/test_classifier_interface.py
@@ -614,7 +614,7 @@ def test_onnx_exportable_cpu(X_y: tuple[np.ndarray, np.ndarray]) -> None:
         }
         _patch_layernorm_no_affine(classifier.model_)
 
-        # From 2.9 PyTorch changed the default export mode form TorchScript to
+        # From 2.9 PyTorch changed the default export mode from TorchScript to
         # Dynamo. We don't support Dynamo, so disable it. The `dynamo` flag is only
         # available in newer PyTorch versions, hence we don't always include it.
         export_kwargs = {"dynamo": False} if torch.__version__ >= "2.9" else {}

--- a/tests/test_regressor_interface.py
+++ b/tests/test_regressor_interface.py
@@ -355,7 +355,7 @@ def test_onnx_exportable_cpu(X_y: tuple[np.ndarray, np.ndarray]) -> None:
             "y": {0: "num_labels"},
         }
 
-        # From 2.9 PyTorch changed the default export mode form TorchScript to
+        # From 2.9 PyTorch changed the default export mode from TorchScript to
         # Dynamo. We don't support Dynamo, so disable it. The `dynamo` flag is only
         # available in newer PyTorch versions, hence we don't always include it.
         export_kwargs = {"dynamo": False} if torch.__version__ >= "2.9" else {}


### PR DESCRIPTION
torch 2.9 came out and changed dynamo to be the default onnx export mode (see https://docs.pytorch.org/docs/stable/onnx.html#functions). We don't work with the dynamo export, and this requires the onnxscript dependency, which we don't have, so the CI broke. Instead, set `dynamo=False` so it uses the torchscript export, which does work.

onnx export is not supported for users (we just have the tests to avoid our wip support regressing), so this was just a ci problem.