### PR TITLE
Check that inference_config is actually set when loading.

### DIFF
--- a/src/tabpfn/model_loading.py
+++ b/src/tabpfn/model_loading.py
@@ -682,7 +682,7 @@ def _get_inference_config_from_checkpoint(
     #     v2: "architecture_name" not present, as added after the v2 release
     #   v2.5: "architecture_name" present, but "inference_config" not present
     #  >v2.5: "inference_config" present, so don't need to guess a default config
-    if "inference_config" in checkpoint:
+    if "inference_config" in checkpoint and checkpoint["inference_config"] is not None:
         return InferenceConfig(**checkpoint["inference_config"])
     if "architecture_name" not in checkpoint:
         model_version = ModelVersion.V2

--- a/src/tabpfn/model_loading.py
+++ b/src/tabpfn/model_loading.py
@@ -682,8 +682,8 @@ def _get_inference_config_from_checkpoint(
     #     v2: "architecture_name" not present, as added after the v2 release
     #   v2.5: "architecture_name" present, but "inference_config" not present
     #  >v2.5: "inference_config" present, so don't need to guess a default config
-    if "inference_config" in checkpoint and checkpoint["inference_config"] is not None:
-        return InferenceConfig(**checkpoint["inference_config"])
+    if inference_config := checkpoint.get("inference_config"):
+        return InferenceConfig(**inference_config)
     if "architecture_name" not in checkpoint:
         model_version = ModelVersion.V2
     else:


### PR DESCRIPTION
Previously, if the checkpoint is loaded and re-exported, the inference config is set, but to None.

## Issue
Please link the corresponding GitHub issue. If an issue does not already exist,
please open one to describe the bug or feature request before creating a pull request.

This allows us to discuss the proposal and helps avoid unnecessary work.

## Motivation and Context

---

## Public API Changes

-   [ ] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?

---

## Checklist

-   [ ] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [ ] A entry has been added to `CHANGELOG.md` (if relevant for users).
-   [ ] The code follows the project's style guidelines.
-   [ ] I have considered the impact of these changes on the public API.

---
