### PR TITLE
More robust performance test

### DIFF
--- a/tests/test_classifier_interface.py
+++ b/tests/test_classifier_interface.py
@@ -229,10 +229,10 @@ def test_predict_logits_and_consistency(
     pipeline.
     """
     X, y = sklearn.datasets.make_classification(
-        n_samples=100,
+        n_samples=60,
         n_classes=2,
-        n_features=5,
-        n_informative=5,
+        n_features=3,
+        n_informative=3,
         n_redundant=0,
         n_clusters_per_class=1,
         random_state=42,

--- a/tests/test_classifier_interface.py
+++ b/tests/test_classifier_interface.py
@@ -229,7 +229,7 @@ def test_predict_logits_and_consistency(
     pipeline.
     """
     X, y = sklearn.datasets.make_classification(
-        n_samples=60,
+        n_samples=80,
         n_classes=3,
         n_features=3,
         n_informative=3,

--- a/tests/test_classifier_interface.py
+++ b/tests/test_classifier_interface.py
@@ -230,7 +230,7 @@ def test_predict_logits_and_consistency(
     """
     X, y = sklearn.datasets.make_classification(
         n_samples=60,
-        n_classes=2,
+        n_classes=3,
         n_features=3,
         n_informative=3,
         n_redundant=0,

--- a/tests/test_classifier_interface.py
+++ b/tests/test_classifier_interface.py
@@ -219,7 +219,6 @@ def test_fit(
     ),
 )
 def test_predict_logits_and_consistency(
-    X_y: tuple[np.ndarray, np.ndarray],
     n_estimators,
     device,
     softmax_temperature,
@@ -229,7 +228,15 @@ def test_predict_logits_and_consistency(
     under various configuration permutations that affect the post-processing
     pipeline.
     """
-    X, y = X_y
+    X, y = sklearn.datasets.make_classification(
+        n_samples=100,
+        n_classes=2,
+        n_features=5,
+        n_informative=5,
+        n_redundant=0,
+        n_clusters_per_class=1,
+        random_state=42,
+    )
 
     # Ensure y is int64 for consistency with classification tasks
     y = y.astype(np.int64)


### PR DESCRIPTION
## Issue

Previously, the test was prone to statistical fluctuations because we were fitting a very small dataset.
This creates a dataset specific to the test and uses a few more samples to make the test more robust.
