### PR TITLE
Add additional classifier checkpoint filename

### DIFF
--- a/src/tabpfn/model_loading.py
+++ b/src/tabpfn/model_loading.py
@@ -108,6 +108,7 @@ class ModelSource:  # noqa: D101
     def get_classifier_v2_5(cls) -> ModelSource:  # noqa: D102
         filenames = [
             "tabpfn-v2.5-classifier-v2.5_default.ckpt",
+            "tabpfn-v2.5-classifier-v2.5_default-2.ckpt",
             "tabpfn-v2.5-classifier-v2.5_large-features-L.ckpt",
             "tabpfn-v2.5-classifier-v2.5_large-features-XL.ckpt",
             "tabpfn-v2.5-classifier-v2.5_large-samples.ckpt",


### PR DESCRIPTION
## Issue
Please link the corresponding GitHub issue. If an issue does not already exist,
please open one to describe the bug or feature request before creating a pull request.

This allows us to discuss the proposal and helps avoid unnecessary work.

## Motivation and Context

---

## Public API Changes

-   [ ] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?

---

## Checklist

-   [ ] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [ ] A entry has been added to `CHANGELOG.md` (if relevant for users).
-   [ ] The code follows the project's style guidelines.
-   [ ] I have considered the impact of these changes on the public API.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds support for the 'tabpfn-v2.5-classifier-v2.5_default-2.ckpt' checkpoint in v2.5 classifier model sources.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f2e2afbde84c7b717c98a783dfdfa13d8fdca13. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->