### PR TITLE
Don't try to hf.login() in the example notebook.

### DIFF
--- a/examples/notebooks/TabPFN_Demo_Local.ipynb
+++ b/examples/notebooks/TabPFN_Demo_Local.ipynb
@@ -244,7 +244,7 @@
       "source": [
         "\n",
         "TabPFN can be run in two ways: locally on your machine (if you have a GPU) or by using the TabPFN client, which sends the data to a server for computation.\n",
-        "In your project you would either use the **local** version (which requires a GPU) with :\n",
+        "In your project you would either use the **local** version (which requires a GPU) with:\n",
         "```python\n",
         "# Simple import for TabPFN\n",
         "from tabpfn import TabPFNClassifier\n",
@@ -265,11 +265,10 @@
         "print(\"TabPFNClassifier imported successfully.\")\n",
         "```\n",
         "\n",
+        "If you select **local** and it's your first time using the model, you'll need to accept the license agreement and log into Hugging Face.\n",
+        "You'll be prompted with instructions on how to do this the first time you fit the model.\n",
         "\n",
-        "**Note**: If you choose the local version, then you will first need to accept the model license and log in to Hugging Face. Follow the instructions here: https://docs.priorlabs.ai/how-to-access-gated-models\n",
-        "\n",
-        "\n",
-        "For demonstration purposes, the cell below provides an interactive way to switch between those:\n"
+        "For demonstration purposes, the cell below provides an interactive way to switch between local mode and the client:\n"
       ]
     },
     {
@@ -693,16 +692,9 @@
         "        \"[bold green]✅ GPU is available.[/bold green] Importing local TabPFN library...\"\n",
         "    )\n",
         "\n",
-        "    from google.colab import userdata\n",
-        "    try:\n",
-        "        userdata.get('HF_TOKEN')\n",
+        "    from tabpfn import TabPFNClassifier, TabPFNRegressor\n",
         "\n",
-        "        from tabpfn import TabPFNClassifier, TabPFNRegressor\n",
-        "        console.print(\"[bold green]✅ TabPFN (local) imported successfully.[/bold green]\")\n",
-        "    except userdata.SecretNotFoundError:\n",
-        "        console.print(\"[bold red]Error:[/bold red] Not logged into Hugging Face\")\n",
-        "        console.print(\"Please follow the instructions at https://docs.priorlabs.ai/how-to-access-gated-models\")\n",
-        "\n",
+        "    console.print(\"[bold green]✅ TabPFN (local) imported successfully.[/bold green]\")\n",
         "elif backend == \"client\":\n",
         "    console.print(\"Attempting client backend setup...\")\n",
         "    console.print(\"Importing TabPFN client library...\")\n",


### PR DESCRIPTION
Because it's confusing to ask for the token without explaining? Instead the users will just hit the standard error about this when they try and fit, which is probably okay? I add a note to the text explaining this.

part of RES-847