### PR TITLE
Move kditransform warning to fit method

### DIFF
--- a/src/tabpfn/preprocessors/kdi_transformer.py
+++ b/src/tabpfn/preprocessors/kdi_transformer.py
@@ -65,7 +65,7 @@ class KDITransformerWithNaN(KDITransformer):
             warnings.warn(
                 "Cannot use KDITransformer because `kditransform` is not installed. "
                 "Using `PowerTransformer` as fallback. This warning is only shown "
-                "once per session.",
+                "once per Python interpreter instance.",
                 UserWarning,
                 stacklevel=2,
             )

--- a/src/tabpfn/preprocessors/kdi_transformer.py
+++ b/src/tabpfn/preprocessors/kdi_transformer.py
@@ -16,6 +16,8 @@ try:
 except ImportError:
     KDITransformer = PowerTransformer  # fallback to avoid error
 
+# Track whether we've warned the user about missing kditransform
+_warned_about_missing_kditransform = False
 
 ALPHAS = (
     0.05,
@@ -44,13 +46,6 @@ class KDITransformerWithNaN(KDITransformer):
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        if KDITransformer is PowerTransformer:
-            warnings.warn(
-                "Cannot use KDITransformer because `kditransform` is not installed. "
-                "Using `PowerTransformer` as fallback.",
-                UserWarning,
-                stacklevel=2,
-            )
         super().__init__(*args, **kwargs)
 
     def _more_tags(self) -> dict:
@@ -62,6 +57,19 @@ class KDITransformerWithNaN(KDITransformer):
         y: Any | None = None,
     ) -> KDITransformerWithNaN:
         """Fit the transformer."""
+        global _warned_about_missing_kditransform  # noqa: PLW0603
+        if (
+            KDITransformer is PowerTransformer
+            and not _warned_about_missing_kditransform
+        ):
+            warnings.warn(
+                "Cannot use KDITransformer because `kditransform` is not installed. "
+                "Using `PowerTransformer` as fallback.",
+                UserWarning,
+                stacklevel=2,
+            )
+            _warned_about_missing_kditransform = True
+
         if isinstance(X, torch.Tensor):
             X = X.cpu().numpy()
 

--- a/src/tabpfn/preprocessors/kdi_transformer.py
+++ b/src/tabpfn/preprocessors/kdi_transformer.py
@@ -64,7 +64,8 @@ class KDITransformerWithNaN(KDITransformer):
         ):
             warnings.warn(
                 "Cannot use KDITransformer because `kditransform` is not installed. "
-                "Using `PowerTransformer` as fallback.",
+                "Using `PowerTransformer` as fallback. This warning is only shown "
+                "once per session.",
                 UserWarning,
                 stacklevel=2,
             )


### PR DESCRIPTION
We initialize the kditransformer class in the list of all preproessors; so the warning introduced in #629 would been thrown multiple times, even though the transformer is not used. Therefore, move the warning to the fit method and throw it only once.