### PR TITLE
Remove submodule init from CI, as we don't have any submodules.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,9 +81,6 @@ jobs:
             --show-only-failing \
             -0
 
-      - name: Initialize submodules
-        run: git submodule update --init --recursive
-
       - name: Run Tests (all tests)
         if: ${{ matrix.dependency-set != 'lowest-direct' && github.event_name != 'pull_request' }}
         env:
@@ -147,9 +144,6 @@ jobs:
             --show-only-failing \
             -0
 
-      - name: Initialize submodules
-        run: git submodule update --init --recursive
-
       - name: Run Tests
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
@@ -192,9 +186,6 @@ jobs:
       - name: Install dependencies
         run: uv pip install --system --resolution ${{ matrix.dependency-set }} ".[ci]"
         shell: bash
-
-      - name: Initialize submodules
-        run: git submodule update --init --recursive
 
       - name: Run GPU Test Suite
         env:


### PR DESCRIPTION
Mostly it takes a few seconds, but sometimes 10s of seconds for some
reason.
