### PR TITLE
Switch to `uv sync`, rather than "dev" optional dependencies.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,13 +70,12 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv pip install --system --resolution ${{ matrix.dependency-set }} ".[ci]"
-        shell: bash
+        run: uv sync --group ci --resolution ${{ matrix.dependency-set }}
 
       - name: "Check for forbidden licenses"
         shell: bash
         run: |
-          licensecheck \
+          uv run --no-sync licensecheck \
             --requirements-paths pyproject.toml \
             --show-only-failing \
             -0
@@ -88,13 +87,13 @@ jobs:
         if: ${{ matrix.dependency-set != 'lowest-direct' && github.event_name != 'pull_request' }}
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        run: pytest tests/
+        run: uv run --no-sync pytest tests/
 
       - name: Run Tests (PR tests only)
         if: ${{ matrix.dependency-set != 'lowest-direct' && github.event_name == 'pull_request' }}
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        run: pytest -m "not slow" tests/
+        run: uv run --no-sync pytest -m "not slow" tests/
 
       # We don't support MPS below PyTorch 2.5 (see tabpfn.utils.infer_devices()), thus
       # disable MPS for the lowest-direct dependency set.
@@ -104,14 +103,14 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           TABPFN_EXCLUDE_DEVICES: mps
-        run: pytest tests/
+        run: uv run --no-sync pytest tests/
 
       - name: Run Tests (PR tests only, MPS disabled)
         if: ${{ matrix.dependency-set == 'lowest-direct' && github.event_name == 'pull_request' }}
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           TABPFN_EXCLUDE_DEVICES: mps
-        run: pytest -m "not slow" tests/
+        run: uv run --no-sync pytest -m "not slow" tests/
 
   # -------------------------------------------------------------------
   # Single Ubuntu-latest + Python 3.13 test (the gate for GPU)
@@ -136,13 +135,13 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv pip install --system --resolution highest ".[ci]"
+        run: uv sync --group ci --resolution highest
         shell: bash
 
       - name: "Check for forbidden licenses"
         shell: bash
         run: |
-          licensecheck \
+          uv run --no-sync licensecheck \
             --requirements-paths pyproject.toml \
             --show-only-failing \
             -0
@@ -153,7 +152,7 @@ jobs:
       - name: Run Tests
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        run: pytest tests/
+        run: uv run --no-sync pytest tests/
 
   # -------------------------------------------------------------------
   # GPU: To save compute we only want to execute this workflow once
@@ -190,8 +189,7 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv pip install --system --resolution ${{ matrix.dependency-set }} ".[ci]"
-        shell: bash
+        run: uv sync --group ci --resolution ${{ matrix.dependency-set }}
 
       - name: Initialize submodules
         run: git submodule update --init --recursive
@@ -202,4 +200,4 @@ jobs:
           CUDA_VISIBLE_DEVICES: "0"
           # skip cpu based tests that were run separately
           TABPFN_EXCLUDE_DEVICES: "cpu,cpu:0,mps"
-        run: pytest tests/
+        run: uv run --no-sync pytest tests/

--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ OR installation from source
 ```bash
 pip install "tabpfn @ git+https://github.com/PriorLabs/TabPFN.git"
 ```
-OR local development installation
+OR local development installation: First [install uv](https://docs.astral.sh/uv/getting-started/installation), which we use for development, then run
 ```bash
-
 git clone https://github.com/PriorLabs/TabPFN.git --depth 1
-pip install -e "TabPFN[dev]"
+cd TabPFN
+uv sync
 ```
 
 ### Basic Usage
@@ -447,22 +447,22 @@ Not effective:
 
 ## Development
 
-1. Setup environment:
+1. Install [uv](https://docs.astral.sh/uv/)
+2. Setup environment:
 ```bash
-python -m venv venv
-source venv/bin/activate  # On Windows: venv\Scripts\activate
 git clone https://github.com/PriorLabs/TabPFN.git
 cd TabPFN
-pip install -e ".[dev]"
+uv sync
+source venv/bin/activate  # On Windows: venv\Scripts\activate
 pre-commit install
 ```
 
-2. Before committing:
+3. Before committing:
 ```bash
 pre-commit run --all-files
 ```
 
-3. Run tests:
+4. Run tests:
 ```bash
 pytest tests/
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,18 +71,15 @@ license = { file = "LICENSE" }
 documentation = "https://priorlabs.ai/docs"
 source = "https://github.com/priorlabs/tabpfn"
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
+  {include-group = "ci"},
   # Lint/format
   "pre-commit>=4.3.0",
   "ruff==0.14.0", # This version must be the same as in .pre-commit-config.yaml
   "mypy==1.18.2", # This version must be the same as in .pre-commit-config.yaml
   # Test
-  "pytest>=8.4.2",
   "pytest-xdist>=3.8.0",
-  "pytest-mock>=3.14.1",
-  "onnx>=1.19.0", # required for onnx export tests
-  "psutil>=7.1.0", # required for testing internal memory tool on windows
   # Docs
   "mkdocs>=1.6.1",
   "mkdocs-material>=9.6.21",
@@ -101,8 +98,7 @@ dev = [
 # The idea is to be as close to the deployment environment as possible.
 ci = [
   "licensecheck>=2025.1.0",
-  "onnx>=1.19.0",
-  "psutil>=7.1.0",
+  "onnx>=1.19.0",  # We run onnx export in the tests, but not in the production package.
   "pytest-mock>=3.14.1",
   "pytest>=8.4.2",
 ]


### PR DESCRIPTION
This is consistent with how uv is meant to be used, and our other repositories.

Also, remove duplication between dev and ci optional dependency groups.