### PR TITLE
Fix config.json behavior when calling download_model directly

### DIFF
--- a/src/tabpfn/model_loading.py
+++ b/src/tabpfn/model_loading.py
@@ -212,6 +212,8 @@ def _try_huggingface_downloads(
             warnings.filterwarnings("ignore")
 
         try:
+            should_download_config = not base_path.exists()
+
             # Download model checkpoint
             local_path = hf_hub_download(
                 repo_id=source.repo_id,
@@ -226,12 +228,13 @@ def _try_huggingface_downloads(
             # Note that we also handle model caching ourselves, so we don't double
             # count, even with removing the config.json afterwards.
             try:
-                config_local_path = hf_hub_download(
-                    repo_id=source.repo_id,
-                    filename="config.json",
-                    local_dir=base_path.parent,
-                )
-                Path(config_local_path).unlink(missing_ok=True)
+                if should_download_config:
+                    config_local_path = hf_hub_download(
+                        repo_id=source.repo_id,
+                        filename="config.json",
+                        local_dir=base_path.parent,
+                    )
+                    Path(config_local_path).unlink(missing_ok=True)
             except Exception as e:  # noqa: BLE001
                 logger.warning(f"Failed to download config.json: {e!s}")
                 # Continue even if config.json download fails

--- a/src/tabpfn/model_loading.py
+++ b/src/tabpfn/model_loading.py
@@ -334,7 +334,7 @@ def download_model(
     """Download a TabPFN model, trying all available sources.
 
     Args:
-        to: The directory to download the model to.
+        to: The file path to download the model to.
         version: The version of the model to download.
         which: The type of model to download.
         model_name: Optional specific model name to download.


### PR DESCRIPTION
Previously we handled checking for the cached model artifact only at a higher level, but we do have some direct callers to `download_model` that expect it to behave similarly