### PR TITLE
Switch to different token for TabPFN-2.5.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,13 +82,13 @@ jobs:
       - name: Run Tests (all tests)
         if: ${{ matrix.dependency-set != 'lowest-direct' && github.event_name != 'pull_request' }}
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_TOKEN: ${{ vars.TABPFN_2_5_HF_TOKEN }}
         run: uv run --no-sync pytest tests/
 
       - name: Run Tests (PR tests only)
         if: ${{ matrix.dependency-set != 'lowest-direct' && github.event_name == 'pull_request' }}
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_TOKEN: ${{ vars.TABPFN_2_5_HF_TOKEN }}
         run: uv run --no-sync pytest -m "not slow" tests/
 
       # We don't support MPS below PyTorch 2.5 (see tabpfn.utils.infer_devices()), thus
@@ -97,14 +97,14 @@ jobs:
       - name: Run Tests (all tests, MPS disabled)
         if: ${{ matrix.dependency-set == 'lowest-direct' && github.event_name != 'pull_request' }}
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_TOKEN: ${{ vars.TABPFN_2_5_HF_TOKEN }}
           TABPFN_EXCLUDE_DEVICES: mps
         run: uv run --no-sync pytest tests/
 
       - name: Run Tests (PR tests only, MPS disabled)
         if: ${{ matrix.dependency-set == 'lowest-direct' && github.event_name == 'pull_request' }}
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_TOKEN: ${{ vars.TABPFN_2_5_HF_TOKEN }}
           TABPFN_EXCLUDE_DEVICES: mps
         run: uv run --no-sync pytest -m "not slow" tests/
 
@@ -144,7 +144,7 @@ jobs:
 
       - name: Run Tests
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_TOKEN: ${{ vars.TABPFN_2_5_HF_TOKEN }}
         run: uv run --no-sync pytest tests/
 
   # -------------------------------------------------------------------
@@ -186,7 +186,7 @@ jobs:
 
       - name: Run GPU Test Suite
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_TOKEN: ${{ vars.TABPFN_2_5_HF_TOKEN }}
           CUDA_VISIBLE_DEVICES: "0"
           # skip cpu based tests that were run separately
           TABPFN_EXCLUDE_DEVICES: "cpu,cpu:0,mps"

--- a/.github/workflows/first_party_compatibility.yml
+++ b/.github/workflows/first_party_compatibility.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Install dependencies and run tests
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_TOKEN: ${{ vars.TABPFN_2_5_HF_TOKEN }}
           FAST_TEST_MODE: 1 # Configures -extensions to run a smaller set of tests.
         run: |
           cd ${{ matrix.repo-name }}


### PR DESCRIPTION
This will allow public contributions to access the model weights.

The token has read access to the 2.5 hf repo, and nothing else.