### PR TITLE
Add BibTeX citation for TabPFN-2.5 paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,16 +311,16 @@ You can read our paper explaining TabPFNv2 [here](https://doi.org/10.1038/s41586
 
 ```bibtex
 @misc{grinsztajn2025tabpfn,
-      title={TabPFN-2.5: Advancing the State of the Art in Tabular Foundation Models}, 
-      author={Léo Grinsztajn and Klemens Flöge and Oscar Key and Felix Birkel and Philipp Jund and Brendan Roof and
-              Benjamin Jäger and Dominik Safaric and Simone Alessi and Adrian Hayler and Mihir Manium and Rosen Yu and
-              Felix Jablonski and Shi Bin Hoo and Anurag Garg and Jake Robertson and Magnus Bühler and Vladyslav Moroshan and
-              Lennart Purucker and Clara Cornu and Lilly Charlotte Wehrhahn and Alessandro Bonetto and
-              Bernhard Schölkopf and Sauraj Gambhir and Noah Hollmann and Frank Hutter},
-      year={2025},
-      eprint={2511.08667},
-      archivePrefix={arXiv},
-      url={https://arxiv.org/abs/2511.08667}, 
+  title={TabPFN-2.5: Advancing the State of the Art in Tabular Foundation Models},
+  author={Léo Grinsztajn and Klemens Flöge and Oscar Key and Felix Birkel and Philipp Jund and Brendan Roof and
+          Benjamin Jäger and Dominik Safaric and Simone Alessi and Adrian Hayler and Mihir Manium and Rosen Yu and
+          Felix Jablonski and Shi Bin Hoo and Anurag Garg and Jake Robertson and Magnus Bühler and Vladyslav Moroshan and
+          Lennart Purucker and Clara Cornu and Lilly Charlotte Wehrhahn and Alessandro Bonetto and
+          Bernhard Schölkopf and Sauraj Gambhir and Noah Hollmann and Frank Hutter},
+  year={2025},
+  eprint={2511.08667},
+  archivePrefix={arXiv},
+  url={https://arxiv.org/abs/2511.08667},
 }
 
 @article{hollmann2025tabpfn,


### PR DESCRIPTION
Added BibTeX citation entries for TabPFN paper.

## Issue
Please link the corresponding GitHub issue. If an issue does not already exist,
please open one to describe the bug or feature request before creating a pull request.

This allows us to discuss the proposal and helps avoid unnecessary work.

## Motivation and Context

---

## Public API Changes

-   [ ] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?

---

## Checklist

-   [ ] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [ ] A entry has been added to `CHANGELOG.md` (if relevant for users).
-   [ ] The code follows the project's style guidelines.
-   [ ] I have considered the impact of these changes on the public API.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds TabPFN-2.5 arXiv BibTeX entry and updates README citation text with links to TabPFNv2 paper and TabPFN-2.5 model report.
> 
> - **Documentation**:
>   - **`README.md` citation section**:
>     - Update text to reference TabPFNv2 paper and add link to the TabPFN-2.5 model report.
>     - Add new BibTeX entry `@misc{grinsztajn2025tabpfn}` for the TabPFN-2.5 arXiv preprint.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d461f0027abea4046bf264acd17e87d93037728. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->