### PR TITLE
Release 6.2.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+### Changed
+
+## [6.2.0] - 2025-12-18
+
+### Added
 - Add a `.to()` method to `TabPFNClassifier` and `TabPFNRegressor`, allowing the device to be changed after `.fit()` has been called. This change also stores the model on the GPU between `.fit()` and `.predict()` calls, use `.to("cpu")` to release this GPU memory. [#685](https://github.com/PriorLabs/TabPFN/pull/685)
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tabpfn"
-version = "6.1.0"
+version = "6.2.0"
 dependencies = [
   "torch>=2.1,<3",
   "numpy>=1.21.6,<3",


### PR DESCRIPTION
See benchmark comparison: [Neptune link](https://scale.neptune.ai/o/PriorLabs/org/Benchmarking/runs/compare?viewId=a0307dbb-90ed-4335-95f3-9629aa5b348c&dash=charts&compare=uCO89bJVfMMn9KCvzbKLuG_JhjZFf4XplVCvMtw1tOt0&showOnlySelectedRuns=true)
"-6.2.0" shows the results for that version, no suffix shows 6.1.0.

