### PR TITLE
Improve error message when downloading gated model on HF

### DIFF
--- a/src/tabpfn/errors.py
+++ b/src/tabpfn/errors.py
@@ -15,3 +15,24 @@ class TabPFNUserError(TabPFNError):
 
 class TabPFNValidationError(ValueError, TabPFNUserError):
     """User provided invalid data (shape, NaNs, categories, etc.)."""
+
+
+class TabPFNHuggingFaceGatedRepoError(TabPFNError):
+    """Error raised when a model is gated and requires user to accept terms."""
+
+    def __init__(self, repo_id: str):
+        message = (
+            f"HuggingFace authentication error downloading from '{repo_id}'.\n"
+            "This model is gated and requires you to accept its terms.\n\n"
+            "Please follow these steps:\n"
+            f"1. Visit https://huggingface.co/{repo_id} in your browser and"
+            f" accept the terms of use.\n"
+            "2. Log in to your Hugging Face account via"
+            " the command line by running:\n"
+            "   hf auth login\n"
+            "   (Alternatively, you can set the HF_TOKEN environment variable"
+            "   with a read token.)\n\n"
+            "For detailed instructions, see "
+            "https://docs.priorlabs.ai/how-to-access-gated-models"
+        )
+        super().__init__(message)


### PR DESCRIPTION
Improves the error message when downloading a 2.5 model from HF without being authenticated.

Error message goes from (where the instructions on how to fix things can be missed because they are in the stack trace)
<img width="1323" height="604" alt="Screenshot 2026-01-09 at 14 33 41" src="https://github.com/user-attachments/assets/6f2c609f-b337-426b-bf87-7adc189baf70" />

to this, where we add the commercial message to the exception.
<img width="1323" height="604" alt="Screenshot 2026-01-09 at 15 34 48" src="https://github.com/user-attachments/assets/1cf27156-62fe-4097-a415-24883b8d19cb" />
