### PR TITLE
Workflows for automated release pipeline

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,6 @@
 * @PriorLabs/opensource-review-team
+
+# Release automation – only release maintainers can modify these workflows
+.github/workflows/release-create-pr.yml  @PriorLabs/release-maintainers
+.github/workflows/release-tag-on-merge.yml       @PriorLabs/release-maintainers
+.github/workflows/release-publish.yml    @PriorLabs/release-maintainers

--- a/.github/workflows/release-create-pr.yml
+++ b/.github/workflows/release-create-pr.yml
@@ -6,8 +6,11 @@ on:
       version:
         description: "Version to release (e.g. 6.3.2)"
         required: true
+      base_ref:
+        description: "Commit SHA to release from"
+        required: true
       base_branch:
-        description: "Branch to release from"
+        description: "Branch to open the PR against"
         required: false
         default: "main"
 
@@ -18,7 +21,15 @@ permissions:
 jobs:
   release_pr:
     runs-on: ubuntu-latest
+    environment: release
     steps:
+      - name: Guard base_ref, must be a full 40-char commit SHA
+        run: |
+          echo "${{ inputs.base_ref }}" | grep -Eq '^[0-9a-f]{40}$' || {
+              echo "base_ref must be a full 40-char commit SHA (got: ${{ inputs.base_ref }})"
+              exit 1
+          }
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -38,13 +49,14 @@ jobs:
       - name: Set variables
         run: |
           echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV
+          echo "BASE_REF=${{ inputs.base_ref }}" >> $GITHUB_ENV
           echo "BASE_BRANCH=${{ inputs.base_branch }}" >> $GITHUB_ENV
           echo "RELEASE_BRANCH=release/v${{ inputs.version }}" >> $GITHUB_ENV
 
-      - name: Create release branch
+      - name: Create release branch from base ref
         run: |
-          git checkout "${BASE_BRANCH}"
-          git pull --ff-only
+          git fetch --all --tags
+          git checkout --detach "${BASE_REF}"
           git checkout -b "${RELEASE_BRANCH}"
 
       - name: Bump version in pyproject.toml
@@ -93,7 +105,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr create \
-            --base "${BASE_BRANCH}" \
-            --head "${RELEASE_BRANCH}" \
-            --title "Release v${VERSION}" \
-            --body "Automated release PR for v${VERSION}."
+          --base "${BASE_BRANCH}" \
+          --head "${RELEASE_BRANCH}" \
+          --title "Release v${VERSION}" \
+          --body "Automated release PR for v${VERSION}." \
+          --reviewer "PriorLabs/release-maintainers"

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: release
     outputs:
       version: ${{ steps.ver.outputs.version }}
     steps:

--- a/.github/workflows/release-tag-on-merge.yml
+++ b/.github/workflows/release-tag-on-merge.yml
@@ -13,6 +13,7 @@ jobs:
       github.event.pull_request.merged == true &&
       startsWith(github.event.pull_request.head.ref, 'release/v')
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - name: Checkout merge commit
         uses: actions/checkout@v4


### PR DESCRIPTION
## Issue

No automated process for releasing the TabPFN package to PyPI.

## Motivation and Context

With this PR we automate the release process. This includes:
- Pushing the package to test PyPI and verifying its installable.
- Uploading the package to PyPI.
- Tagging the main branch with the latest release.
- Creating a GitHub Release with notes merged by `towncrier` - thanks @LeoGrin.

We set this up using three separate GitHub Workflows:
- Release PR Workflow - this runs on `workflow_dispatch` (manual via GH UI) with an input version, creates a release branch, bumps version, runs `towncrier, commits, and opens a release PR.
- On merge of the Release PR, we automatically create a push a tag (e.g. v6.3.2)
- On tag push, the last workflow kicks in, building the artifacts and automatically generating the GitHub Release Notes from `CHANGELOG.md`. This workflow would include a manual approval step for publishing to PyPI - we most certainly don't want releases to be automatically flying in to PyPI 🔥 

🎥 Loom walkthrough: https://www.loom.com/share/0343c738875d44319c3561c61b350829

## Public API Changes

-   [x] No Public API changes

## How Has This Been Tested?

In a forked TabPFN repository, end-to-end.

## Checklist

-   [x] The changes have been tested locally.
-   [x] Documentation has been updated (if the public API or usage changes).
-   [x] A changelog entry has been added (see `changelog/README.md`), or "no changelog needed" label requested.
-   [x] The code follows the project's style guidelines.
-   [x] I have considered the impact of these changes on the public API.

---
