### PR TITLE
Skip the changelog check for dependabot PRs.

### DIFF
--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   check:
     name: Changelog entry
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
I'm slightly unsure if a skipped check will meet the branch protection rules, but we will find out...