### PR TITLE
Fix bug in demo notebook where backend input selection did not appear.

### DIFF
--- a/examples/notebooks/TabPFN_Demo_Local.ipynb
+++ b/examples/notebooks/TabPFN_Demo_Local.ipynb
@@ -665,7 +665,7 @@
     "backend = None\n",
     "while backend is None:\n",
     "  console.print(\n",
-    "      \"\\n[bold]Choose your backend[/bold]:\",\n",
+    "      \"\\n[bold]Choose your backend[/bold]: - If no text box is shown, restart the cell.\",\n",
     "  )\n",
     "  user_input = input(\"Enter 'local' or 'client' and press return:\")\n",
     "  if user_input not in [\"local\", \"client\"]:\n",


### PR DESCRIPTION
Use console.print() + input() rather than Prompt.ask().

I tried this out in Colab, and now the input box always appears.

This is how it looks in colab:
<img width="758" height="148" alt="Screenshot 2026-01-19 at 14 09 22" src="https://github.com/user-attachments/assets/d840fc14-c62a-4995-85c3-8d0026e28297" />

and in local jupyter:
<img width="862" height="413" alt="Screenshot 2026-01-19 at 14 09 50" src="https://github.com/user-attachments/assets/3f58f916-e0ff-4dd5-946f-29c19e999d14" />

and in vscode (not so good, but it was the same before):
<img width="1409" height="649" alt="Screenshot 2026-01-19 at 14 10 34" src="https://github.com/user-attachments/assets/0cd6cfc9-3b89-4625-b383-971892443af6" />