### PR TITLE
FeatureModalityDetector to support also categorical dtypes

### DIFF
--- a/src/tabpfn/preprocessing/modality_detection.py
+++ b/src/tabpfn/preprocessing/modality_detection.py
@@ -118,7 +118,9 @@ def _detect_feature_modality(
         ):
             return FeatureModality.CATEGORICAL
         return FeatureModality.NUMERICAL
-    if pd.api.types.is_string_dtype(s.dtype):
+    if pd.api.types.is_string_dtype(s.dtype) or isinstance(
+        s.dtype, pd.CategoricalDtype
+    ):
         if nunique <= max_unique_for_category:
             return FeatureModality.CATEGORICAL
         return FeatureModality.TEXT

--- a/tests/test_feature_modality_detection.py
+++ b/tests/test_feature_modality_detection.py
@@ -173,6 +173,12 @@ def test__detected_categorical_without_reporting():
     assert result == FeatureModality.CATEGORICAL
 
 
+def test__detect_for_categorical_with_category_dtype():
+    s = pd.Series(["a", "b", "c", "a", "b", "c"], dtype="category")
+    result = _for_test_detect_with_defaults(s)
+    assert result == FeatureModality.CATEGORICAL
+
+
 def test__detect_textual_feature():
     s = pd.Series(["a", "b", "c", "a", "b", "c"])
     result = _for_test_detect_with_defaults(s, max_unique_for_category=2)


### PR DESCRIPTION
## Motivation and Context

Expanding the modality detector to support the detection of pandas series of categorical types

---

## Public API Changes

-   [x] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?

Added a test.

---

## Checklist

-   [x] The changes have been tested locally.
-   [x] Documentation has been updated (if the public API or usage changes).
-   [x] A changelog entry has been added (see `changelog/README.md`), or "no changelog needed" label requested.
-   [x] The code follows the project's style guidelines.
-   [x] I have considered the impact of these changes on the public API.

---
