### PR TITLE
Fix issue with permissions for release PRs

### DIFF
--- a/.github/workflows/release-create-pr.yml
+++ b/.github/workflows/release-create-pr.yml
@@ -108,5 +108,4 @@ jobs:
           --base "${BASE_BRANCH}" \
           --head "${RELEASE_BRANCH}" \
           --title "Release v${VERSION}" \
-          --body "Automated release PR for v${VERSION}." \
-          --reviewer "PriorLabs/release-maintainers"
+          --body "Automated release PR for v${VERSION}."


### PR DESCRIPTION
## Issue

Drop the requirement for Release Maintainers as Open Source is selected by default, and Release Maintainers still need to approve the flow.

## Public API Changes

-   [x] No Public API changes

---
