### PR TITLE
Stab at ensuring we run checks in the merge queue too

### DIFF
--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -3,11 +3,15 @@ name: Check Changelog
 on:
   pull_request:
     types: [opened, synchronize, labeled, unlabeled]
+  merge_group:
 
 jobs:
   check:
     name: Changelog entry
-    if: github.actor != 'dependabot[bot]' && !startsWith(github.head_ref, 'release/v')
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.actor != 'dependabot[bot]' &&
+      !startsWith(github.head_ref, 'release/v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
   push:
     branches: [main]
+  merge_group:
   workflow_dispatch:
 
 concurrency:
@@ -107,24 +108,24 @@ jobs:
           enableCrossOsArchive: true
 
       - name: Run Tests (all tests)
-        if: ${{ matrix.dependency-set != 'lowest-direct' && github.event_name != 'pull_request' }}
+        if: ${{ matrix.dependency-set != 'lowest-direct' && github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
         run: uv run --no-sync pytest tests/
 
       - name: Run Tests (PR tests only)
-        if: ${{ matrix.dependency-set != 'lowest-direct' && github.event_name == 'pull_request' }}
+        if: ${{ matrix.dependency-set != 'lowest-direct' && (github.event_name == 'pull_request' || github.event_name == 'merge_group') }}
         run: uv run --no-sync pytest -m "not slow" tests/
 
       # We don't support MPS below PyTorch 2.5 (see tabpfn.utils.infer_devices()), thus
       # disable MPS for the lowest-direct dependency set.
 
       - name: Run Tests (all tests, MPS disabled)
-        if: ${{ matrix.dependency-set == 'lowest-direct' && github.event_name != 'pull_request' }}
+        if: ${{ matrix.dependency-set == 'lowest-direct' && github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
         env:
           TABPFN_EXCLUDE_DEVICES: mps
         run: uv run --no-sync pytest tests/
 
       - name: Run Tests (PR tests only, MPS disabled)
-        if: ${{ matrix.dependency-set == 'lowest-direct' && github.event_name == 'pull_request' }}
+        if: ${{ matrix.dependency-set == 'lowest-direct' && (github.event_name == 'pull_request' || github.event_name == 'merge_group') }}
         env:
           TABPFN_EXCLUDE_DEVICES: mps
         run: uv run --no-sync pytest -m "not slow" tests/


### PR DESCRIPTION
It looks like the merge queue gets stuck with our current workflows where we specify `pull_request` specifically in a few places. This might fix it...

<img width="1018" height="630" alt="Screenshot 2026-02-23 at 17 48 44" src="https://github.com/user-attachments/assets/53d84e7d-b06b-4d6d-beb1-f42977fc8076" />
