### PR TITLE
fix: shaky test due to pandas version dependency

### DIFF
--- a/tests/test_preprocessing/test_modality_detection.py
+++ b/tests/test_preprocessing/test_modality_detection.py
@@ -186,14 +186,10 @@ def test__numerical_series_from_strings():
 
 
 def test__detect_numerical_as_string_with_nulls():
-    # Use enough distinct numeric values to exceed min_unique_for_numerical=5.
-
-    # Previously [None, np.nan, "1.0", "2.0", "3.0"] worked in pandas 2.x because
-    # None and np.nan were counted as two separate unique values in object dtype,
-    # giving n_unique=5. In pandas 3.0 they both become pd.NA (n_unique=4 < 5),
-    # triggering the categorical heuristic. Be explicit about the value count.
-    s = pd.Series([None, np.nan, "1.0", "2.0", "3.0", "4.0", "5.0"])
-    result = _for_test_detect_with_defaults(s)
+    # Note that in pandas 3.0, None and np.nan both become pd.NA, so n_unique=4.
+    # Ideally tests shouldn't depend on pandas version
+    s = pd.Series([None, np.nan, "1.0", "2.0", "3.0"])
+    result = _for_test_detect_with_defaults(s, min_unique_for_numerical=4)
     assert result == FeatureModality.NUMERICAL
 
 


### PR DESCRIPTION
## Issue
Please link the corresponding GitHub issue. If an issue does not already exist,
please open one to describe the bug or feature request before creating a pull request.

This allows us to discuss the proposal and helps avoid unnecessary work.

## Motivation and Context

We are fixing a shaky test that was affected by different behavior of pandas v3.

---

## Public API Changes

-   [X ] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?

This is a test fix.

---

## Checklist

-   [ X] The changes have been tested locally.
-   [ X] Documentation has been updated (if the public API or usage changes).
-   [ X] A changelog entry has been added (see `changelog/README.md`), or "no changelog needed" label requested.
-   [X ] The code follows the project's style guidelines.
-   [ X] I have considered the impact of these changes on the public API.

---
