### PR TITLE
UV exclude newer

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ OR installation from source
 ```bash
 pip install "tabpfn @ git+https://github.com/PriorLabs/TabPFN.git"
 ```
-OR local development installation: First [install uv](https://docs.astral.sh/uv/getting-started/installation) (version 0.10.0 or higher), which we use for development, then run
+OR local development installation: First [install uv](https://docs.astral.sh/uv/getting-started/installation) (version 0.10.0 or higher recommended), which we use for development, then run
 ```bash
 git clone https://github.com/PriorLabs/TabPFN.git --depth 1
 cd TabPFN

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ OR installation from source
 ```bash
 pip install "tabpfn @ git+https://github.com/PriorLabs/TabPFN.git"
 ```
-OR local development installation: First [install uv](https://docs.astral.sh/uv/getting-started/installation), which we use for development, then run
+OR local development installation: First [install uv](https://docs.astral.sh/uv/getting-started/installation) (version 0.10.0 or higher), which we use for development, then run
 ```bash
 git clone https://github.com/PriorLabs/TabPFN.git --depth 1
 cd TabPFN

--- a/changelog/847.added.md
+++ b/changelog/847.added.md
@@ -1,0 +1,1 @@
+Exclude very recent package release in environment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ ci = [
 
 [tool.uv]
 exclude-newer = "7 days"
+exclude-newer-package = {torch = false} 
 
 [tool.setuptools.package-data]
 "tabpfn.architectures.shared" = ["tabpfn_col_embedding.pt"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,9 @@ ci = [
   "pytest>=8.4.2",
 ]
 
+[tool.uv]
+exclude-newer = "7 days"
+
 [tool.setuptools.package-data]
 "tabpfn.architectures.shared" = ["tabpfn_col_embedding.pt"]
 


### PR DESCRIPTION
Adds `exclude-newer = "7 days"` to `pyproj.toml` for ignoring fresh packages on pypi. 

Only real caveat is that the relative date will only work with newer `uv` versions.