### PR TITLE
Fix V2.5 showing manual download instructions that bypass license check

### DIFF
--- a/src/tabpfn/model_loading.py
+++ b/src/tabpfn/model_loading.py
@@ -363,7 +363,7 @@ def download_all_models(to: Path) -> None:
 
 def _version_has_direct_download_option(version: ModelVersion) -> bool:
     """Determine if a version has a direct download option."""
-    return version in (ModelVersion.V2, ModelVersion.V2_5)
+    return version in (ModelVersion.V2,)
 
 
 def get_cache_dir() -> Path:  # noqa: PLR0911


### PR DESCRIPTION
## Summary
- `_version_has_direct_download_option` incorrectly included `ModelVersion.V2_5`, which requires license acceptance and has no direct download
- This caused download failures for V2.5 to show a manual HuggingFace URL, contradicting and effectively bypassing the `TabPFNLicenseError` raised earlier in the stack
- Fix: remove `V2_5` from the function so the original license error propagates cleanly

## Test plan
- [ ] Trigger a V2.5 download failure in a non-interactive environment (no `TABPFN_TOKEN` set) and confirm only the `TabPFNLicenseError` with auth instructions is shown, not the manual download URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)