### PR TITLE
Suppress internal finetuning fit telemetry

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -20,7 +20,7 @@ Here's the full list:
 - `ping` – sent when models initialize, used to check liveness  
 - `fit_called` – sent when you call `fit`  
 - `predict_called` – sent when you call `predict`
-- `session` - sent whenever a user initializes a TabPFN estimator.
+- `session` - sent once per Python process when telemetry is initialized by a TabPFN estimator.
 
 ### Metadata (all events)
 - `python_version` – version of Python you're running

--- a/src/tabpfn/base.py
+++ b/src/tabpfn/base.py
@@ -14,7 +14,6 @@ import torch
 from sklearn.base import (
     check_is_fitted,
 )
-from tabpfn_common_utils.telemetry.interactive import capture_session, ping
 
 # --- TabPFN imports ---
 from tabpfn.constants import (
@@ -33,6 +32,7 @@ from tabpfn.inference import (
 )
 from tabpfn.model_loading import load_model_criterion_config, resolve_model_version
 from tabpfn.preprocessing.clean import fix_dtypes
+from tabpfn.telemetry import initialize_telemetry as _initialize_telemetry
 from tabpfn.utils import (
     DevicesSpecification,
     infer_devices,
@@ -419,13 +419,8 @@ def estimator_to_device(
 
 
 def initialize_telemetry() -> None:
-    """Initialize telemetry and acknowledge anonymous session.
-
-    If user opted out of telemetry using `TABPFN_DISABLE_TELEMETRY`,
-    no action is taken.
-    """
-    ping()
-    capture_session()
+    """Initialize telemetry and acknowledge an anonymous process session."""
+    _initialize_telemetry()
 
 
 def get_embeddings(

--- a/src/tabpfn/classifier.py
+++ b/src/tabpfn/classifier.py
@@ -19,6 +19,7 @@
 from __future__ import annotations
 
 import copy
+import inspect
 import logging
 import warnings
 from collections.abc import Callable, Sequence
@@ -81,6 +82,7 @@ from tabpfn.preprocessing.datamodel import Feature, FeatureModality, FeatureSche
 from tabpfn.preprocessing.ensemble import TabPFNEnsemblePreprocessor
 from tabpfn.preprocessing.label_encoder import TabPFNLabelEncoder
 from tabpfn.preprocessing.modality_detection import detect_feature_modalities
+from tabpfn.telemetry import is_telemetry_suppressed, suppress_telemetry
 from tabpfn.utils import (
     DevicesSpecification,
     balance_probas_by_class_counts,
@@ -108,6 +110,19 @@ if TYPE_CHECKING:
         from sklearn.base import Tags
     except ImportError:
         Tags = Any
+
+
+def _call_without_telemetry(
+    bound_method: Callable[..., Any],
+    /,
+    *args: Any,
+    **kwargs: Any,
+) -> Any:
+    """Call a TabPFN method without its outer telemetry decorators."""
+    method = inspect.unwrap(bound_method)
+    self = bound_method.__self__  # type: ignore[attr-defined]
+    return method(self, *args, **kwargs)
+
 
 DEFAULT_CLASSIFICATION_EVAL_METRIC = ClassifierEvalMetrics.ACCURACY
 
@@ -485,7 +500,8 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
         initialize_telemetry()
 
         # Only anonymously record `fit_mode` usage
-        log_model_init_params(self, {"fit_mode": self.fit_mode})
+        if not is_telemetry_suppressed():
+            log_model_init_params(self, {"fit_mode": self.fit_mode})
 
     @classmethod
     def create_default_for_version(cls, version: ModelVersion, **overrides) -> Self:
@@ -723,7 +739,8 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
         params.update(forced)
         params.update(overwrite_kwargs)
 
-        return TabPFNClassifier(**params)
+        with suppress_telemetry():
+            return TabPFNClassifier(**params)
 
     @config_context(transform_output="default")  # type: ignore
     @track_model_call(model_method="fit", param_names=["X", "y"])
@@ -1033,10 +1050,17 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
                     message=".*haven't specified any tuning configuration*",
                     category=UserWarning,
                 )
-                calibration_classifier.fit(X_train_NtF, y_train_Nt)
+                _call_without_telemetry(
+                    calibration_classifier.fit,
+                    X_train_NtF,
+                    y_train_Nt,
+                )
 
             # E=num estimators, Nh=num holdout samples, C=num classes
-            raw_logits_ENhC = calibration_classifier.predict_raw_logits(X=X_holdout_NhF)
+            raw_logits_ENhC = _call_without_telemetry(
+                calibration_classifier.predict_raw_logits,
+                X=X_holdout_NhF,
+            )
             holdout_raw_logits.append(raw_logits_ENhC)
 
         holdout_raw_logits_all = np.concatenate(holdout_raw_logits, axis=1)

--- a/src/tabpfn/finetuning/finetuned_base.py
+++ b/src/tabpfn/finetuning/finetuned_base.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import copy
 import datetime
+import inspect
 import logging
 import os
 import time
@@ -45,6 +46,7 @@ from tabpfn.finetuning.train_util import (
     get_cosine_schedule_with_warmup,
     save_checkpoint,
 )
+from tabpfn.telemetry import suppress_telemetry
 from tabpfn.utils import infer_devices, infer_random_state
 from tabpfn.validation import ensure_compatible_fit_inputs_sklearn
 
@@ -145,6 +147,33 @@ def _move_tabpfn_cached_contexts_to_device(estimator: Any, device: str) -> None:
         executor.y_trains = [
             t.to(target) if t.device != target else t for t in y_trains
         ]
+
+
+def _fit_finetuned_estimator_from_preprocessed(
+    estimator: Any,
+    batch: ClassifierBatch | RegressorBatch,
+) -> None:
+    """Run the internal per-batch fit without emitting public fit telemetry."""
+    bound_fit_from_preprocessed = estimator.fit_from_preprocessed
+    fit_from_preprocessed = inspect.unwrap(bound_fit_from_preprocessed)
+
+    with suppress_telemetry():
+        if inspect.ismethod(fit_from_preprocessed):
+            fit_from_preprocessed(
+                batch.X_context,
+                batch.y_context,
+                batch.cat_indices,
+                batch.configs,
+            )
+            return
+
+        fit_from_preprocessed(
+            bound_fit_from_preprocessed.__self__,  # type: ignore[attr-defined]
+            batch.X_context,
+            batch.y_context,
+            batch.cat_indices,
+            batch.configs,
+        )
 
 
 class _TabPFNDDPWrapper(torch.nn.Module):
@@ -843,11 +872,9 @@ class FinetunedTabPFNBase(BaseEstimator, ABC):
 
                 self._setup_batch(batch)
 
-                self.finetuned_estimator_.fit_from_preprocessed(
-                    batch.X_context,
-                    batch.y_context,
-                    batch.cat_indices,
-                    batch.configs,
+                _fit_finetuned_estimator_from_preprocessed(
+                    self.finetuned_estimator_,
+                    batch,
                 )
 
                 if using_ddp:

--- a/src/tabpfn/regressor.py
+++ b/src/tabpfn/regressor.py
@@ -70,6 +70,7 @@ from tabpfn.preprocessing.modality_detection import detect_feature_modalities
 from tabpfn.preprocessing.steps import (
     get_all_reshape_feature_distribution_preprocessors,
 )
+from tabpfn.telemetry import is_telemetry_suppressed
 from tabpfn.utils import (
     DevicesSpecification,
     convert_batch_of_cat_ix_to_schema,
@@ -469,7 +470,8 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
         initialize_telemetry()
 
         # Only anonymously record `fit_mode` usage
-        log_model_init_params(self, {"fit_mode": self.fit_mode})
+        if not is_telemetry_suppressed():
+            log_model_init_params(self, {"fit_mode": self.fit_mode})
 
     @classmethod
     def create_default_for_version(cls, version: ModelVersion, **overrides) -> Self:

--- a/src/tabpfn/telemetry.py
+++ b/src/tabpfn/telemetry.py
@@ -1,0 +1,93 @@
+"""Telemetry helpers for TabPFN-owned call paths."""
+
+from __future__ import annotations
+
+import contextlib
+import contextvars
+import os
+import threading
+from collections.abc import Callable, Iterator
+from pathlib import Path
+
+from filelock import FileLock, Timeout
+from tabpfn_common_utils.telemetry.interactive import capture_session, ping
+
+_user_config_dir: Callable[[str, str], str] | None
+try:
+    from platformdirs import user_config_dir as _platformdirs_user_config_dir
+except ImportError:  # pragma: no cover - platformdirs is a telemetry dependency
+    _user_config_dir = None
+else:
+    _user_config_dir = _platformdirs_user_config_dir
+
+_SUPPRESS_TELEMETRY = contextvars.ContextVar(
+    "tabpfn_suppress_telemetry",
+    default=False,
+)
+_INITIALIZE_TELEMETRY_LOCK = threading.Lock()
+_TELEMETRY_SESSION_CAPTURED = False
+
+
+def _telemetry_state_path() -> Path | None:
+    """Return the common telemetry state path when it can be resolved."""
+    if p := os.getenv("TABPFN_STATE_PATH"):
+        return Path(p).expanduser()
+    if d := os.getenv("TABPFN_STATE_DIR"):
+        return Path(d).expanduser() / "state.json"
+    if _user_config_dir is None:
+        return None
+    return Path(_user_config_dir(".tabpfn", "priorlabs")) / "state.json"
+
+
+def _ping_with_lock() -> None:
+    """Run ping under a cross-process lock when the telemetry state path exists."""
+    state_path = _telemetry_state_path()
+    if state_path is None:
+        ping()
+        return
+
+    lock = FileLock(state_path.with_suffix(".ping.lock"), timeout=10)
+    try:
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        lock.acquire()
+    except (OSError, Timeout):
+        ping()
+        return
+
+    try:
+        ping()
+    finally:
+        with contextlib.suppress(Exception):
+            lock.release()
+
+
+def is_telemetry_suppressed() -> bool:
+    """Return whether telemetry is suppressed for the current context."""
+    return _SUPPRESS_TELEMETRY.get()
+
+
+@contextlib.contextmanager
+def suppress_telemetry() -> Iterator[None]:
+    """Suppress telemetry emitted by TabPFN-owned internal calls."""
+    token = _SUPPRESS_TELEMETRY.set(True)
+    try:
+        yield
+    finally:
+        _SUPPRESS_TELEMETRY.reset(token)
+
+
+def initialize_telemetry() -> None:
+    """Initialize telemetry and acknowledge an anonymous process session.
+
+    If user opted out of telemetry using `TABPFN_DISABLE_TELEMETRY`, the
+    downstream telemetry package does not emit events.
+    """
+    if is_telemetry_suppressed():
+        return
+
+    global _TELEMETRY_SESSION_CAPTURED  # noqa: PLW0603
+    with _INITIALIZE_TELEMETRY_LOCK:
+        _ping_with_lock()
+        if not _TELEMETRY_SESSION_CAPTURED:
+            capture_session()
+            _TELEMETRY_SESSION_CAPTURED = True

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,231 @@
+"""Tests for TabPFN-owned telemetry emission behavior."""
+
+from __future__ import annotations
+
+from collections import Counter
+from types import SimpleNamespace
+from typing import Any
+
+import numpy as np
+import tabpfn_common_utils.telemetry.core.decorators as telemetry_decorators
+import torch
+
+import tabpfn.classifier as classifier_module
+import tabpfn.finetuning.finetuned_base as finetuned_base_module
+from tabpfn import TabPFNClassifier, telemetry
+
+
+def _disable_ping_file_lock(monkeypatch) -> None:
+    monkeypatch.setattr(telemetry, "_telemetry_state_path", lambda: None)
+
+
+def test__initialize_telemetry__captures_session_once_per_process(
+    monkeypatch,
+) -> None:
+    events: list[str] = []
+    _disable_ping_file_lock(monkeypatch)
+    monkeypatch.setattr(telemetry, "_TELEMETRY_SESSION_CAPTURED", False)
+    monkeypatch.setattr(telemetry, "ping", lambda: events.append("ping"))
+    monkeypatch.setattr(
+        telemetry,
+        "capture_session",
+        lambda: events.append("session"),
+    )
+
+    telemetry.initialize_telemetry()
+    telemetry.initialize_telemetry()
+
+    assert events == ["ping", "session", "ping"]
+
+
+def test__initialize_telemetry__respects_suppression(
+    monkeypatch,
+) -> None:
+    events: list[str] = []
+    _disable_ping_file_lock(monkeypatch)
+    monkeypatch.setattr(telemetry, "_TELEMETRY_SESSION_CAPTURED", False)
+    monkeypatch.setattr(telemetry, "ping", lambda: events.append("ping"))
+    monkeypatch.setattr(
+        telemetry,
+        "capture_session",
+        lambda: events.append("session"),
+    )
+
+    with telemetry.suppress_telemetry():
+        telemetry.initialize_telemetry()
+
+    assert events == []
+
+
+def test__classifier_tuning__does_not_emit_internal_telemetry(
+    monkeypatch,
+) -> None:
+    events: list[str] = []
+
+    _disable_ping_file_lock(monkeypatch)
+    monkeypatch.setattr(telemetry, "_TELEMETRY_SESSION_CAPTURED", False)
+    monkeypatch.setattr(telemetry, "ping", lambda: events.append("ping"))
+    monkeypatch.setattr(
+        telemetry,
+        "capture_session",
+        lambda: events.append("session"),
+    )
+    monkeypatch.setattr(
+        telemetry_decorators,
+        "capture_event",
+        lambda event: events.append(event.name),
+    )
+
+    class DummyPreprocessor:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+    def fake_initialize_model_variables(self: TabPFNClassifier) -> int:
+        self.models_ = [object()]
+        self.devices_ = (torch.device("cpu"),)
+        self.use_autocast_ = False
+        self.forced_inference_dtype_ = None
+        self.inference_config_ = object()
+        return 4
+
+    def fake_initialize_dataset_preprocessing(
+        self: TabPFNClassifier,
+        X: np.ndarray,
+        y: np.ndarray,
+        random_state: int | np.random.Generator,
+    ) -> tuple[list, np.ndarray, np.ndarray]:
+        del random_state
+        X = np.asarray(X)
+        y = np.asarray(y)
+        self.classes_ = np.array(sorted(set(y.tolist())))
+        self.n_classes_ = len(self.classes_)
+        self.class_counts_ = np.array([(y == c).sum() for c in self.classes_])
+        self.inferred_feature_schema_ = object()
+        return [], X, y
+
+    def fake_raw_predict(
+        self: TabPFNClassifier,
+        X: np.ndarray,
+        *,
+        return_logits: bool,
+        return_raw_logits: bool = False,
+    ) -> torch.Tensor:
+        del return_logits, return_raw_logits
+        return torch.zeros((self.n_estimators, len(X), self.n_classes_))
+
+    def fake_create_inference_engine(**_kwargs: Any) -> object:
+        return object()
+
+    def fake_get_calibrated_softmax_temperature(
+        self: TabPFNClassifier,
+        holdout_raw_logits: np.ndarray,
+        holdout_y_true: np.ndarray,
+    ) -> float:
+        del self, holdout_raw_logits, holdout_y_true
+        return 1.0
+
+    monkeypatch.setattr(
+        classifier_module,
+        "TabPFNEnsemblePreprocessor",
+        DummyPreprocessor,
+    )
+    monkeypatch.setattr(
+        classifier_module,
+        "create_inference_engine",
+        fake_create_inference_engine,
+    )
+    monkeypatch.setattr(
+        TabPFNClassifier,
+        "_initialize_model_variables",
+        fake_initialize_model_variables,
+    )
+    monkeypatch.setattr(
+        TabPFNClassifier,
+        "_initialize_dataset_preprocessing",
+        fake_initialize_dataset_preprocessing,
+    )
+    monkeypatch.setattr(TabPFNClassifier, "_raw_predict", fake_raw_predict)
+    monkeypatch.setattr(
+        TabPFNClassifier,
+        "_get_calibrated_softmax_temperature",
+        fake_get_calibrated_softmax_temperature,
+    )
+
+    classifier = TabPFNClassifier(
+        n_estimators=1,
+        tuning_config={
+            "calibrate_temperature": True,
+            "tuning_holdout_frac": 0.5,
+            "tuning_n_folds": 2,
+        },
+    )
+    X = np.zeros((600, 3))
+    y = np.array([0, 1] * 300)
+
+    classifier.fit(X, y)
+
+    event_counts = Counter(events)
+    assert event_counts["session"] == 1
+    assert event_counts["fit_called"] == 1
+    assert event_counts["predict_called"] == 0
+
+
+def test__finetuning_training_loop_fit__does_not_emit_per_batch_fit_telemetry(
+    monkeypatch,
+) -> None:
+    events: list[str] = []
+    calls: list[str] = []
+    monkeypatch.setattr(
+        telemetry_decorators,
+        "capture_event",
+        lambda event: events.append(event.name),
+    )
+
+    def fake_fit_from_preprocessed(
+        self: object,
+        X_preprocessed: list[torch.Tensor],
+        y_preprocessed: list[torch.Tensor],
+        cat_ix: list[list[list[int]]],
+        configs: list[Any],
+    ) -> object:
+        del X_preprocessed, y_preprocessed, cat_ix, configs
+        calls.append("fit")
+        return self
+
+    fake_fit_from_preprocessed.__module__ = "tabpfn.classifier"
+
+    class FakeEstimator:
+        fit_from_preprocessed: Any
+
+    FakeEstimator.fit_from_preprocessed = telemetry_decorators.track_model_call(
+        "fit",
+        param_names=["X_preprocessed", "y_preprocessed"],
+    )(fake_fit_from_preprocessed)
+
+    estimator = FakeEstimator()
+    batch = SimpleNamespace(
+        X_context=[torch.zeros((4, 3))],
+        y_context=[torch.zeros(4)],
+        cat_indices=[[]],
+        configs=[[]],
+    )
+
+    estimator.fit_from_preprocessed(
+        batch.X_context,
+        batch.y_context,
+        batch.cat_indices,
+        batch.configs,
+    )
+    assert calls == ["fit"]
+    assert events == ["fit_called"]
+
+    calls.clear()
+    events.clear()
+
+    finetuned_base_module._fit_finetuned_estimator_from_preprocessed(
+        estimator,
+        batch,
+    )
+
+    assert calls == ["fit"]
+    assert events == []


### PR DESCRIPTION
Avoid emitting a FitEvent for every finetuning batch by unwrapping the decorated fit_from_preprocessed call inside the training loop. Add regression coverage to verify the internal path still runs without producing per-batch fit telemetry.

## Issue
https://github.com/PriorLabs/terraform-gcp-tabpfn-aas/issues/20
