### PR TITLE
Fix bool-typed DataFrame columns not being cast to float64

### DIFF
--- a/changelog/880.fixed.md
+++ b/changelog/880.fixed.md
@@ -1,0 +1,1 @@
+Fix bool-typed DataFrame columns not being cast to float64 in `fix_dtypes()`, which caused downstream sklearn errors.

--- a/src/tabpfn/preprocessing/clean.py
+++ b/src/tabpfn/preprocessing/clean.py
@@ -126,6 +126,10 @@ def fix_dtypes(  # noqa: D103
     if convert_dtype:
         X = X.convert_dtypes()
 
+    bool_columns = X.select_dtypes(include=["bool"]).columns
+    if len(bool_columns) > 0:
+        X[bool_columns] = X[bool_columns].astype(numeric_dtype)
+
     numerical_columns = X.select_dtypes(include=["number"]).columns
     if len(numerical_columns) > 0:
         X[numerical_columns] = X[numerical_columns].astype(numeric_dtype)

--- a/src/tabpfn/preprocessing/clean.py
+++ b/src/tabpfn/preprocessing/clean.py
@@ -126,11 +126,7 @@ def fix_dtypes(  # noqa: D103
     if convert_dtype:
         X = X.convert_dtypes()
 
-    bool_columns = X.select_dtypes(include=["bool"]).columns
-    if len(bool_columns) > 0:
-        X[bool_columns] = X[bool_columns].astype(numeric_dtype)
-
-    numerical_columns = X.select_dtypes(include=["number"]).columns
+    numerical_columns = X.select_dtypes(include=["number", "bool"]).columns
     if len(numerical_columns) > 0:
         X[numerical_columns] = X[numerical_columns].astype(numeric_dtype)
     return X


### PR DESCRIPTION
## Problem

Fitting TabPFN on a DataFrame with bool-typed columns fails:

```python
from tabpfn import TabPFNClassifier
import pandas as pd

X = pd.DataFrame({"flag": [True, False, True, False], "value": [1.0, 2.0, 3.0, 4.0]})
y = [0, 1, 0, 1]

clf = TabPFNClassifier()
clf.fit(X, y)
# ValueError: The output of the 'remainder' transformer for column 'flag'
#   has dtype boolean and uses pandas.NA ...
```

**Root cause:** `fix_dtypes()` uses `select_dtypes(include=["number"])` to find columns to cast to `float64`, but pandas excludes `bool`/`BooleanDtype` from `"number"`. Bool columns pass through unconverted and cause sklearn's `ColumnTransformer` to error on `pd.NA` values downstream.

Numpy bool arrays are unaffected — they already match `NUMERIC_DTYPE_KINDS` and get cast at DataFrame creation time.

## Fix

Add `"bool"` to the existing `select_dtypes` call (one-line change):

```python
# Before
numerical_columns = X.select_dtypes(include=["number"]).columns

# After
numerical_columns = X.select_dtypes(include=["number", "bool"]).columns
```

Bool columns are now cast to `float64` (True→1.0, False→0.0, None→NaN). Downstream modality detection will auto-infer these 2-unique-value columns as categorical when appropriate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)