### PR TITLE
Default SUBSAMPLE_SAMPLES to 500K

### DIFF
--- a/src/tabpfn/inference_config.py
+++ b/src/tabpfn/inference_config.py
@@ -116,7 +116,7 @@ class InferenceConfig:
         - If an int, determines the maximal number of polynomial features to add to the
          original data.
     """
-    SUBSAMPLE_SAMPLES: int | float | list | None = None
+    SUBSAMPLE_SAMPLES: int | float | list | None = 500_000
     """Subsample the input data sample/row-wise before performing any preprocessing
     and the TabPFN forward pass.
         - If None, no subsampling is done.

--- a/src/tabpfn/inference_config.py
+++ b/src/tabpfn/inference_config.py
@@ -116,7 +116,7 @@ class InferenceConfig:
         - If an int, determines the maximal number of polynomial features to add to the
          original data.
     """
-    SUBSAMPLE_SAMPLES: int | float | list | None = 500_000
+    SUBSAMPLE_SAMPLES: int | float | list | None = None
     """Subsample the input data sample/row-wise before performing any preprocessing
     and the TabPFN forward pass.
         - If None, no subsampling is done.

--- a/src/tabpfn/model_loading.py
+++ b/src/tabpfn/model_loading.py
@@ -944,11 +944,9 @@ def load_model(
         model.load_state_dict(full_state)
         model.eval()
         inference_config_dict = dict(checkpoint["inference_config"])
-        if (
-            architecture_name == "tabpfn_v3"
-            and inference_config_dict.get("SUBSAMPLE_SAMPLES") is None
-        ):
-            # Default v3 checkpoints to per-estimator row subsampling of 500K.
+        if inference_config_dict.get("SUBSAMPLE_SAMPLES") is None:
+            # Default to per-estimator row subsampling of 500K when the checkpoint
+            # did not pin a value.
             inference_config_dict["SUBSAMPLE_SAMPLES"] = 500_000
         inference_config = InferenceConfig(**inference_config_dict)
         empty_criterion = None

--- a/src/tabpfn/model_loading.py
+++ b/src/tabpfn/model_loading.py
@@ -943,7 +943,14 @@ def load_model(
         # checkpoint.
         model.load_state_dict(full_state)
         model.eval()
-        inference_config = InferenceConfig(**(checkpoint["inference_config"]))
+        inference_config_dict = dict(checkpoint["inference_config"])
+        if (
+            architecture_name == "tabpfn_v3"
+            and inference_config_dict.get("SUBSAMPLE_SAMPLES") is None
+        ):
+            # Default v3 checkpoints to per-estimator row subsampling of 500K.
+            inference_config_dict["SUBSAMPLE_SAMPLES"] = 500_000
+        inference_config = InferenceConfig(**inference_config_dict)
         empty_criterion = None
         return model, empty_criterion, model_config, inference_config
 

--- a/src/tabpfn/model_loading.py
+++ b/src/tabpfn/model_loading.py
@@ -897,6 +897,16 @@ def _load_checkpoint(path: str) -> dict:
         return torch.load(path, map_location="cpu", weights_only=None)
 
 
+def _set_fallback_defaults(inference_config: dict) -> dict:
+    """Fill in fallback defaults for inference config values."""
+    inference_config_dict = dict(inference_config)
+    if inference_config_dict.get("SUBSAMPLE_SAMPLES") is None:
+        # Default to per-estimator row subsampling of 500K when the checkpoint
+        # did not pin a value.
+        inference_config_dict["SUBSAMPLE_SAMPLES"] = 500_000
+    return inference_config_dict
+
+
 def load_model(
     *,
     path: Path,
@@ -943,12 +953,9 @@ def load_model(
         # checkpoint.
         model.load_state_dict(full_state)
         model.eval()
-        inference_config_dict = dict(checkpoint["inference_config"])
-        if inference_config_dict.get("SUBSAMPLE_SAMPLES") is None:
-            # Default to per-estimator row subsampling of 500K when the checkpoint
-            # did not pin a value.
-            inference_config_dict["SUBSAMPLE_SAMPLES"] = 500_000
-        inference_config = InferenceConfig(**inference_config_dict)
+        inference_config = InferenceConfig(
+            **_set_fallback_defaults(checkpoint["inference_config"])
+        )
         empty_criterion = None
         return model, empty_criterion, model_config, inference_config
 


### PR DESCRIPTION
## Summary
- In `load_model`, when the stored `inference_config` has `SUBSAMPLE_SAMPLES=None`, coerce it to `500_000` before constructing the `InferenceConfig`.
- v2 and v2.5 take the separate `_get_inference_config_from_checkpoint` path and are unchanged.
- Users can still override at call time via `TabPFNClassifier(inference_config={\"SUBSAMPLE_SAMPLES\": ...})` — the existing `override_with_user_input_and_resolve_auto` step runs after the load-time coercion.

## Why not just change the dataclass field default?
The training-side `Checkpoint.save` uses `dataclasses.asdict` on the pydantic `InferenceConfig`, which writes every field — including `SUBSAMPLE_SAMPLES: null` — into the checkpoint file. So `InferenceConfig(**checkpoint[\"inference_config\"])` receives `None` as an explicit kwarg and the field default never kicks in. Hence the load-time coercion.

## Test plan
- [ ] Load a v2.6 checkpoint and assert the same.
- [ ] Pass `inference_config={\"SUBSAMPLE_SAMPLES\": 100_000}` and confirm the user value wins.
- [ ] Confirm v2 / v2.5 checkpoints still load with `SUBSAMPLE_SAMPLES=None`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small load-time config coercion that only affects checkpoints where `inference_config.SUBSAMPLE_SAMPLES` is explicitly `None`, with user overrides still applied later.
> 
> **Overview**
> Ensures newer checkpoints that store `inference_config` load with a usable `SUBSAMPLE_SAMPLES` value by coercing `None` to `500_000` before constructing `InferenceConfig`.
> 
> Adds a small helper (`_set_fallback_defaults`) and applies it only on the post-v2.5 `load_model` path that reads `checkpoint["inference_config"]`; older v2/v2.5 fallback inference-config logic is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07cb083082176d730fc7e734e9de40905f83180b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->