### PR TITLE
Reduce regressor peak memory by chunking translate_probs_across_borders

### DIFF
--- a/changelog/882.fixed.md
+++ b/changelog/882.fixed.md
@@ -1,0 +1,1 @@
+Reduce TabPFNRegressor peak GPU memory at large test-set sizes by chunking the row dimension inside `translate_probs_across_borders`. Output is unchanged; peak drops ~60% at `n_test=250k` (57.6 GB → 22.8 GB on an H100).

--- a/changelog/PR.fixed.md
+++ b/changelog/PR.fixed.md
@@ -1,1 +1,0 @@
-Reduce TabPFNRegressor peak GPU memory at large test-set sizes by chunking the row dimension inside `translate_probs_across_borders`. Output is unchanged; peak drops ~60% at `n_test=250k` (57.6 GB → 22.8 GB on an H100). (NOTE: rename this file to `<PR_NUMBER>.fixed.md` when opening the PR.)

--- a/changelog/PR.fixed.md
+++ b/changelog/PR.fixed.md
@@ -1,0 +1,1 @@
+Reduce TabPFNRegressor peak GPU memory at large test-set sizes by chunking the row dimension inside `translate_probs_across_borders`. Output is unchanged; peak drops ~60% at `n_test=250k` (57.6 GB → 22.8 GB on an H100). (NOTE: rename this file to `<PR_NUMBER>.fixed.md` when opening the PR.)

--- a/src/tabpfn/utils.py
+++ b/src/tabpfn/utils.py
@@ -337,6 +337,25 @@ def _cdf(logits: torch.Tensor, borders: torch.Tensor, ys: torch.Tensor) -> torch
     return prob_left_of_ys.clip(0.0, 1.0)
 
 
+def _translate_probs_across_borders_unchunked(
+    logits: torch.Tensor,
+    *,
+    frm: torch.Tensor,
+    to: torch.Tensor,
+) -> torch.Tensor:
+    prob_left = _cdf(logits, borders=frm, ys=to)
+    prob_left[..., 0] = 0.0
+    prob_left[..., -1] = 1.0
+    return (prob_left[..., 1:] - prob_left[..., :-1]).clamp_min(0.0)
+
+
+# `_cdf` allocates ~8 intermediate tensors of shape (batch, len(to)). Targeting
+# `chunk_size * len(to) <= _TRANSLATE_CHUNK_BUDGET_ELEMENTS` keeps each transient
+# around ~80 MB (fp32) and the total under ~1 GB, which holds translate_probs's
+# contribution to peak memory roughly constant in n_test.
+_TRANSLATE_CHUNK_BUDGET_ELEMENTS = 20_000_000
+
+
 def translate_probs_across_borders(
     logits: torch.Tensor,
     *,
@@ -344,6 +363,11 @@ def translate_probs_across_borders(
     to: torch.Tensor,
 ) -> torch.Tensor:
     """Translate the probabilities across the borders.
+
+    For large batches the computation is chunked along the leading
+    dimension so that the peak memory footprint of the intermediate
+    ``(batch, len(to))`` tensors allocated inside ``_cdf`` stays bounded.
+    The output is numerically identical to the unchunked version.
 
     Args:
         logits: The logits defining the distribution to translate.
@@ -353,11 +377,27 @@ def translate_probs_across_borders(
     Returns:
         The translated probabilities.
     """
-    prob_left = _cdf(logits, borders=frm, ys=to)
-    prob_left[..., 0] = 0.0
-    prob_left[..., -1] = 1.0
+    batch_shape = logits.shape[:-1]
+    if len(batch_shape) == 0:
+        return _translate_probs_across_borders_unchunked(logits, frm=frm, to=to)
 
-    return (prob_left[..., 1:] - prob_left[..., :-1]).clamp_min(0.0)
+    batch_size = 1
+    for dim in batch_shape:
+        batch_size *= dim
+    chunk_size = max(1, _TRANSLATE_CHUNK_BUDGET_ELEMENTS // max(len(to), 1))
+    leading = batch_shape[0]
+    if batch_size <= chunk_size or leading <= 1:
+        return _translate_probs_across_borders_unchunked(logits, frm=frm, to=to)
+
+    # Chunk the leading (typically "test row") dimension.
+    rows_per_chunk = max(1, chunk_size * leading // batch_size)
+    pieces = [
+        _translate_probs_across_borders_unchunked(
+            logits[i : i + rows_per_chunk], frm=frm, to=to
+        )
+        for i in range(0, leading, rows_per_chunk)
+    ]
+    return torch.cat(pieces, dim=0)
 
 
 def remove_non_differentiable_preprocessing_from_models(

--- a/src/tabpfn/utils.py
+++ b/src/tabpfn/utils.py
@@ -361,6 +361,7 @@ def translate_probs_across_borders(
     *,
     frm: torch.Tensor,
     to: torch.Tensor,
+    chunk_budget_elements: int = _TRANSLATE_CHUNK_BUDGET_ELEMENTS,
 ) -> torch.Tensor:
     """Translate the probabilities across the borders.
 
@@ -372,9 +373,17 @@ def translate_probs_across_borders(
     output is numerically identical to the unchunked version.
 
     Args:
-        logits: The logits defining the distribution to translate.
+        logits: The logits defining the distribution to translate. The last
+            dimension indexes buckets from ``frm``; all leading dimensions
+            are treated as independent batch rows. Typical shapes are
+            ``(num_rows, num_buckets)`` (used by ``TabPFNRegressor.predict``)
+            or ``(n_estimators, num_rows, num_buckets)``.
         frm: The borders to translate from.
         to: The borders to translate to.
+        chunk_budget_elements: Maximum number of ``logits[..., -1]`` elements
+            processed per chunk. Defaults to a value that keeps each
+            ``_cdf`` transient near ~80 MB (fp32). Lower values reduce peak
+            memory at a small time cost; primarily useful for testing.
 
     Returns:
         The translated probabilities.
@@ -389,7 +398,7 @@ def translate_probs_across_borders(
     # Flatten batch dims so chunking is independent of which dim is large.
     logits_flat = logits.reshape(-1, num_buckets_frm)
     num_rows = logits_flat.shape[0]
-    chunk_size = max(1, _TRANSLATE_CHUNK_BUDGET_ELEMENTS // max(num_buckets_to, 1))
+    chunk_size = max(1, chunk_budget_elements // max(num_buckets_to, 1))
     if num_rows <= chunk_size:
         return _translate_probs_across_borders_unchunked(logits, frm=frm, to=to)
 

--- a/src/tabpfn/utils.py
+++ b/src/tabpfn/utils.py
@@ -364,10 +364,12 @@ def translate_probs_across_borders(
 ) -> torch.Tensor:
     """Translate the probabilities across the borders.
 
-    For large batches the computation is chunked along the leading
-    dimension so that the peak memory footprint of the intermediate
-    ``(batch, len(to))`` tensors allocated inside ``_cdf`` stays bounded.
-    The output is numerically identical to the unchunked version.
+    For large batches the computation is chunked so that the peak memory
+    footprint of the intermediate ``(batch, len(to))`` tensors allocated
+    inside ``_cdf`` stays bounded. All batch dimensions are flattened
+    before chunking, so the memory cap holds regardless of which batch
+    dimension is large (e.g. `(n_estimators, n_test, num_buckets)`). The
+    output is numerically identical to the unchunked version.
 
     Args:
         logits: The logits defining the distribution to translate.
@@ -378,26 +380,32 @@ def translate_probs_across_borders(
         The translated probabilities.
     """
     batch_shape = logits.shape[:-1]
+    num_buckets_frm = logits.shape[-1]
+    num_buckets_to = to.shape[0]
+
     if len(batch_shape) == 0:
         return _translate_probs_across_borders_unchunked(logits, frm=frm, to=to)
 
-    batch_size = 1
-    for dim in batch_shape:
-        batch_size *= dim
-    chunk_size = max(1, _TRANSLATE_CHUNK_BUDGET_ELEMENTS // max(len(to), 1))
-    leading = batch_shape[0]
-    if batch_size <= chunk_size or leading <= 1:
+    # Flatten batch dims so chunking is independent of which dim is large.
+    logits_flat = logits.reshape(-1, num_buckets_frm)
+    num_rows = logits_flat.shape[0]
+    chunk_size = max(1, _TRANSLATE_CHUNK_BUDGET_ELEMENTS // max(num_buckets_to, 1))
+    if num_rows <= chunk_size:
         return _translate_probs_across_borders_unchunked(logits, frm=frm, to=to)
 
-    # Chunk the leading (typically "test row") dimension.
-    rows_per_chunk = max(1, chunk_size * leading // batch_size)
-    pieces = [
-        _translate_probs_across_borders_unchunked(
-            logits[i : i + rows_per_chunk], frm=frm, to=to
+    # Preallocate output and write chunks in-place to avoid the transient
+    # `torch.cat` would create (which would double peak memory).
+    out_flat = torch.empty(
+        num_rows,
+        num_buckets_to - 1,
+        dtype=logits.dtype,
+        device=logits.device,
+    )
+    for i in range(0, num_rows, chunk_size):
+        out_flat[i : i + chunk_size] = _translate_probs_across_borders_unchunked(
+            logits_flat[i : i + chunk_size], frm=frm, to=to
         )
-        for i in range(0, leading, rows_per_chunk)
-    ]
-    return torch.cat(pieces, dim=0)
+    return out_flat.reshape(*batch_shape, num_buckets_to - 1)
 
 
 def remove_non_differentiable_preprocessing_from_models(

--- a/src/tabpfn/utils.py
+++ b/src/tabpfn/utils.py
@@ -390,7 +390,8 @@ def translate_probs_across_borders(
     """
     batch_shape = logits.shape[:-1]
     num_buckets_frm = logits.shape[-1]
-    num_buckets_to = to.shape[0]
+    num_borders_to = to.shape[0]
+    num_buckets_to = num_borders_to - 1
 
     if len(batch_shape) == 0:
         return _translate_probs_across_borders_unchunked(logits, frm=frm, to=to)
@@ -398,7 +399,9 @@ def translate_probs_across_borders(
     # Flatten batch dims so chunking is independent of which dim is large.
     logits_flat = logits.reshape(-1, num_buckets_frm)
     num_rows = logits_flat.shape[0]
-    chunk_size = max(1, chunk_budget_elements // max(num_buckets_to, 1))
+    # The dominant intermediates inside `_cdf` are of shape
+    # `(batch, num_borders_to)`, so budget against borders, not buckets.
+    chunk_size = max(1, chunk_budget_elements // max(num_borders_to, 1))
     if num_rows <= chunk_size:
         return _translate_probs_across_borders_unchunked(logits, frm=frm, to=to)
 
@@ -406,7 +409,7 @@ def translate_probs_across_borders(
     # `torch.cat` would create (which would double peak memory).
     out_flat = torch.empty(
         num_rows,
-        num_buckets_to - 1,
+        num_buckets_to,
         dtype=logits.dtype,
         device=logits.device,
     )
@@ -414,7 +417,7 @@ def translate_probs_across_borders(
         out_flat[i : i + chunk_size] = _translate_probs_across_borders_unchunked(
             logits_flat[i : i + chunk_size], frm=frm, to=to
         )
-    return out_flat.reshape(*batch_shape, num_buckets_to - 1)
+    return out_flat.reshape(*batch_shape, num_buckets_to)
 
 
 def remove_non_differentiable_preprocessing_from_models(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,8 +9,10 @@ import torch
 from torch.torch_version import TorchVersion
 
 from tabpfn.utils import (
+    _translate_probs_across_borders_unchunked,
     balance_probas_by_class_counts,
     infer_devices,
+    translate_probs_across_borders,
 )
 
 
@@ -205,3 +207,21 @@ def test_balance_probas_by_class_counts():
 
     expected_balanced = torch.tensor([[1 / 3, 2 / 3], [0.75, 0.25], [2 / 3, 1 / 3]])
     assert torch.allclose(balanced, expected_balanced, rtol=1e-4, atol=1e-4)
+
+
+@pytest.mark.parametrize("batch", [1, 32, 4097])
+def test__translate_probs_across_borders__matches_unchunked(batch: int) -> None:
+    """Chunked path must produce identical output to the unchunked reference."""
+    torch.manual_seed(0)
+    num_buckets = 5000
+    logits = torch.randn(batch, num_buckets)
+    frm = torch.linspace(-3.0, 3.0, num_buckets + 1)
+    to = torch.linspace(-3.0, 3.0, num_buckets + 1)
+
+    out_unchunked = _translate_probs_across_borders_unchunked(logits, frm=frm, to=to)
+    out_public = translate_probs_across_borders(logits, frm=frm, to=to)
+
+    assert out_public.shape == out_unchunked.shape
+    # Chunking over the leading dim is per-row independent, so results should
+    # be numerically identical up to kernel-dispatch jitter.
+    assert torch.allclose(out_public, out_unchunked, atol=0.0, rtol=0.0)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -232,9 +232,9 @@ def test__translate_probs_across_borders__forces_chunking(
 ) -> None:
     """Force the chunked path and verify it runs across arbitrary batch shapes.
 
-    Monkey-patches the chunk budget down to a single row so every batch row
-    goes through the chunked dispatch, and spies on the unchunked helper to
-    confirm it is invoked once per chunk.
+    Passes a tiny ``chunk_budget_elements`` (= ``num_buckets``) so every batch
+    row triggers its own chunked call, and spies on the unchunked helper to
+    confirm the chunked dispatch is actually used.
     """
     torch.manual_seed(1)
     num_buckets = shape[-1]
@@ -244,8 +244,6 @@ def test__translate_probs_across_borders__forces_chunking(
 
     out_unchunked = _translate_probs_across_borders_unchunked(logits, frm=frm, to=to)
 
-    # Force many tiny chunks: budget per chunk becomes 1 row worth of elements.
-    monkeypatch.setattr("tabpfn.utils._TRANSLATE_CHUNK_BUDGET_ELEMENTS", num_buckets)
     call_counter = {"n": 0}
     orig = _translate_probs_across_borders_unchunked
 
@@ -257,7 +255,9 @@ def test__translate_probs_across_borders__forces_chunking(
         "tabpfn.utils._translate_probs_across_borders_unchunked",
         counting_unchunked,
     )
-    out_chunked = translate_probs_across_borders(logits, frm=frm, to=to)
+    out_chunked = translate_probs_across_borders(
+        logits, frm=frm, to=to, chunk_budget_elements=num_buckets
+    )
 
     total_rows = 1
     for d in shape[:-1]:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -226,14 +226,16 @@ def test__translate_probs_across_borders__matches_unchunked(batch: int) -> None:
     assert torch.equal(out_public, out_unchunked)
 
 
-@pytest.mark.parametrize(
-    "shape", [(128, 200), (3, 128, 200), (2, 3, 128, 200)]
-)
+@pytest.mark.parametrize("shape", [(128, 200), (3, 128, 200), (2, 3, 128, 200)])
 def test__translate_probs_across_borders__forces_chunking(
     monkeypatch: pytest.MonkeyPatch, shape: tuple[int, ...]
 ) -> None:
-    """Force the chunked path via a tiny budget and verify it actually runs
-    across arbitrary batch shapes, matching the unchunked reference exactly."""
+    """Force the chunked path and verify it runs across arbitrary batch shapes.
+
+    Monkey-patches the chunk budget down to a single row so every batch row
+    goes through the chunked dispatch, and spies on the unchunked helper to
+    confirm it is invoked once per chunk.
+    """
     torch.manual_seed(1)
     num_buckets = shape[-1]
     logits = torch.randn(*shape)
@@ -247,7 +249,7 @@ def test__translate_probs_across_borders__forces_chunking(
     call_counter = {"n": 0}
     orig = _translate_probs_across_borders_unchunked
 
-    def counting_unchunked(*args, **kwargs):
+    def counting_unchunked(*args, **kwargs) -> torch.Tensor:
         call_counter["n"] += 1
         return orig(*args, **kwargs)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -222,6 +222,46 @@ def test__translate_probs_across_borders__matches_unchunked(batch: int) -> None:
     out_public = translate_probs_across_borders(logits, frm=frm, to=to)
 
     assert out_public.shape == out_unchunked.shape
-    # Chunking over the leading dim is per-row independent, so results should
-    # be numerically identical up to kernel-dispatch jitter.
-    assert torch.allclose(out_public, out_unchunked, atol=0.0, rtol=0.0)
+    # Each row is processed independently, so chunking must be bit-exact.
+    assert torch.equal(out_public, out_unchunked)
+
+
+@pytest.mark.parametrize(
+    "shape", [(128, 200), (3, 128, 200), (2, 3, 128, 200)]
+)
+def test__translate_probs_across_borders__forces_chunking(
+    monkeypatch: pytest.MonkeyPatch, shape: tuple[int, ...]
+) -> None:
+    """Force the chunked path via a tiny budget and verify it actually runs
+    across arbitrary batch shapes, matching the unchunked reference exactly."""
+    torch.manual_seed(1)
+    num_buckets = shape[-1]
+    logits = torch.randn(*shape)
+    frm = torch.linspace(-3.0, 3.0, num_buckets + 1)
+    to = torch.linspace(-3.0, 3.0, num_buckets + 1)
+
+    out_unchunked = _translate_probs_across_borders_unchunked(logits, frm=frm, to=to)
+
+    # Force many tiny chunks: budget per chunk becomes 1 row worth of elements.
+    monkeypatch.setattr("tabpfn.utils._TRANSLATE_CHUNK_BUDGET_ELEMENTS", num_buckets)
+    call_counter = {"n": 0}
+    orig = _translate_probs_across_borders_unchunked
+
+    def counting_unchunked(*args, **kwargs):
+        call_counter["n"] += 1
+        return orig(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "tabpfn.utils._translate_probs_across_borders_unchunked",
+        counting_unchunked,
+    )
+    out_chunked = translate_probs_across_borders(logits, frm=frm, to=to)
+
+    total_rows = 1
+    for d in shape[:-1]:
+        total_rows *= d
+    # Expect one unchunked call per chunk: more than one proves we chunked.
+    assert call_counter["n"] > 1
+    assert call_counter["n"] == total_rows  # chunk_size == 1 row here
+    assert out_chunked.shape == out_unchunked.shape
+    assert torch.equal(out_chunked, out_unchunked)


### PR DESCRIPTION
## Summary

- `_cdf` inside `translate_probs_across_borders` allocates several `(n_test, num_buckets)` fp32 intermediates. At large `n_test` this dominates peak memory in `TabPFNRegressor.predict`, far beyond the size of the returned array.
- The transform is row-independent, so we chunk the leading dimension when the flattened batch would produce intermediates larger than a fixed element budget. Output is numerically identical to the unchunked path; small batches keep the original fast path.
- PR #745 handled the `n_estimators` axis (on-the-fly accumulation); this handles the `n_test` axis. Complementary fixes.

Measured on CUDA (H100, `n_train=10k`, `features=50`, `fit_mode=fit_preprocessors`, `n_estimators=1`):

| n_test   | orig peak | patched peak |
|---------:|----------:|-------------:|
| 32_000   |   7.46 GB |      4.55 GB |
| 100_000  |  23.09 GB |     11.47 GB |
| 250_000  |  57.61 GB |     22.80 GB |

Predict wall time changes by <1% across 5 trials at each size, and is slightly faster at the largest sizes (reduced allocator pressure).

## Test plan

- [x] New parametrized test in `tests/test_utils.py` asserting the chunked path matches the unchunked reference bit-for-bit (`atol=0, rtol=0`) for batch sizes in {1, 32, 4097}.
- [x] `pytest tests/test_utils.py` — 13 passed.
- [x] Smoke predict with `n_estimators=2` returns expected shape/values.

## Note to reviewer

Rename `changelog/PR.fixed.md` → `changelog/<this-PR-number>.fixed.md` once the PR number is assigned.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core tensor math used during prediction and introduces a chunking loop that could affect performance or shape handling on edge cases, though tests assert bit-identical outputs.
> 
> **Overview**
> Reduces `TabPFNRegressor.predict` peak GPU memory for very large test sets by chunking `translate_probs_across_borders` over flattened batch rows, keeping `_cdf` intermediates bounded and avoiding `torch.cat` transients via preallocated output.
> 
> Adds `_translate_probs_across_borders_unchunked` as a reference/fast path and new tests asserting bit-exact equality with the unchunked implementation and verifying the chunked dispatch across arbitrary batch shapes; includes a changelog entry documenting the memory reduction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c939459f9ebe2854f602da2fe39c70a9d00f318d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->