### PR TITLE
docs: update TELEMETRY.md to reflect current event set

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,10 +1,10 @@
-# 📊 Telemetry
+# Telemetry
 
 This project includes lightweight, anonymous telemetry to help us improve TabPFN. If you'd rather not send telemetry, you can always opt out (see **Opting out**).
 
 ---
 
-## 🔍 What we collect
+## What we collect
 
 We only gather **very high-level usage signals** — enough to guide development, never enough to identify you or your data.
 
@@ -40,7 +40,7 @@ Here's the full list:
 
 ---
 
-## 🛡️ How we protect your privacy
+## How we protect your privacy
 
 - **No inputs, no outputs, no code** ever leave your machine.
 - **No personal data** is collected.
@@ -51,7 +51,7 @@ This approach lets us understand dataset *patterns* (e.g. "most users run with ~
 
 ---
 
-## 🤔 Why collect telemetry?
+## Why collect telemetry?
 
 Open-source projects don't get much feedback unless people file issues. Telemetry helps us:
 - See which parts of TabPFN are most used (fit vs predict, classification vs regression)
@@ -62,7 +62,7 @@ This information goes directly into **making TabPFN better** for the community.
 
 ---
 
-## 🚫 Opting out
+## Opting out
 
 Don't want to send telemetry? No problem — just set the environment variable:
 

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -6,53 +6,59 @@ This project includes lightweight, anonymous telemetry to help us improve TabPFN
 
 ## 🔍 What we collect
 
-We only gather **very high-level usage signals** — enough to guide development, never enough to identify you or your data.  
+We only gather **very high-level usage signals** — enough to guide development, never enough to identify you or your data.
 
 Here's the full list:
 
 ### Events
-- `ping` – sent when models initialize, used to check liveness  
-- `fit_called` – sent when you call `fit`  
+- `ping` – periodic liveness heartbeat (daily / weekly / monthly cadence)
+- `session` – sent when you initialize a TabPFN estimator (`TabPFNClassifier`, `TabPFNRegressor`)
+- `model_load` – sent when TabPFN attempts to load model weights (reports `success` / `failed`)
+- `dataset` – sent when a dataset is passed to `fit` or `predict` (no dataset content; shape only)
+- `fit_called` – sent when you call `fit`
 - `predict_called` – sent when you call `predict`
-- `session` - sent whenever a user initializes a TabPFN estimator.
+- `extension_entry` – sent when a TabPFN extension entry point (e.g. from `tabpfn-extensions`, `tabpfn-time-series`) is invoked
 
 ### Metadata (all events)
-- `python_version` – version of Python you're running
+- `python_version` – Python version you're running
 - `tabpfn_version` – TabPFN package version
+- `numpy_version` – local NumPy version
+- `pandas_version` – local pandas version
+- `gpu_type` – type of GPU TabPFN is running on
+- `platform_os` – operating system
+- `runtime_kernel` – runtime kernel (e.g. CPython)
+- `runtime_environment` – runtime environment (e.g. notebook / script / CI)
 - `timestamp` – time of the event
-- `numpy_vesion` - local Numpy version
-- `pandas_version` - local Pandas version
-- `gpu_type` - type of GPU TabPFN is running on.
-- `install_date` - `year-month-day` when TabPFN was used for the first time
-- `install_id` - unique, random and anonymous installation ID.
+- `install_date` – `year-month-day` when TabPFN was used for the first time
+- `install_id` – unique, random and anonymous installation ID
 
-### Extra metadata (`fit` / `predict` only)
-- `task` – whether the call was for **classification** or **regression**  
-- `num_rows` – *rounded* number of rows in your dataset  
-- `num_columns` – *rounded* number of columns in your dataset  
-- `duration_ms` – time it took to complete the call  
+### Extra metadata (per-event)
+- `fit_called` / `predict_called`: `task` (classification or regression), `num_rows` (*rounded*), `num_columns` (*rounded*), `duration_ms`
+- `model_load`: `model_name` (HuggingFace repo id), `status`
+- `dataset`: `task`, `role` (train / test), `num_rows` (*rounded*), `num_columns` (*rounded*)
+- `extension_entry`: `extension_name`
 
 ---
 
 ## 🛡️ How we protect your privacy
 
-- **No inputs, no outputs, no code** ever leave your machine.  
-- **No personal data** is collected.  
-- Dataset shapes are **rounded into ranges** (e.g. `(953, 17)` → `(1000, 20)`) so exact dimensionalities can't be linked back to you.  
-- The data is strictly anonymous — it cannot be tied to individuals, projects, or datasets.  
+- **No inputs, no outputs, no code** ever leave your machine.
+- **No personal data** is collected.
+- Dataset shapes are **rounded into ranges** (e.g. `(953, 17)` → `(1000, 20)`) so exact dimensionalities can't be linked back to you.
+- The data is strictly anonymous — it cannot be tied to individuals, projects, or datasets.
 
-This approach lets us understand dataset *patterns* (e.g. "most users run with ~1k features") while ensuring no one's data is exposed.  
+This approach lets us understand dataset *patterns* (e.g. "most users run with ~1k features") while ensuring no one's data is exposed.
 
 ---
 
 ## 🤔 Why collect telemetry?
 
-Open-source projects don't get much feedback unless people file issues. Telemetry helps us:  
-- See which parts of TabPFN are most used (fit vs predict, classification vs regression)  
-- Detect performance bottlenecks and stability issues  
-- Prioritize improvements that benefit the most users  
+Open-source projects don't get much feedback unless people file issues. Telemetry helps us:
+- See which parts of TabPFN are most used (fit vs predict, classification vs regression)
+- Detect performance bottlenecks and stability issues
+- Prioritize improvements that benefit the most users
 
-This information goes directly into **making TabPFN better** for the community.  
+This information goes directly into **making TabPFN better** for the community.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds three events that the telemetry layer emits today but were missing from the document: `model_load`, `dataset`, and `extension_entry`.
- Adds the per-event metadata fields that weren't listed: `runtime_kernel`, `runtime_environment`, `platform_os`.
- Fixes the `numpy_vesion` → `numpy_version` typo.
- Breaks out an "Extra metadata (per-event)" section so readers can see exactly which fields are attached to each event type.

Brings `TELEMETRY.md` into line with the events declared in `tabpfn_common_utils.telemetry.core.events`.

## Test plan

- [ ] Render on GitHub and eyeball the formatting
- [ ] Confirm event names match `tabpfn_common_utils/src/tabpfn_common_utils/telemetry/core/events.py`