### PR TITLE
KV cache: skip re-transforming train rows at predict

### DIFF
--- a/src/tabpfn/architectures/tabpfn_v3.py
+++ b/src/tabpfn/architectures/tabpfn_v3.py
@@ -1676,6 +1676,7 @@ class TabPFNV3(Architecture):
         task_type: str | None = None,
         kv_cache: TabPFNV3Cache | None = None,
         return_kv_cache: bool = False,
+        x_is_test_only: bool = False,
         # TODO: test_targets_MB needed because model_loading has a condition
         # on its presence. Clean this up.
         test_targets_MB: torch.Tensor | None = None,
@@ -1686,8 +1687,12 @@ class TabPFNV3(Architecture):
     ):
         """Main forward pass for TabPFN v3.
 
-        This function always assumes the full dataset to be passed, even
-        in the case of a KV cache.
+        When a KV cache is provided, ``x_is_test_only=True`` lets the
+        caller pass only the test rows (shape ``(num_test, 1, D)``) instead
+        of padding with train-row placeholders. ``y`` still carries the
+        train labels — the decoder reads ``y[:num_train]`` for the
+        many-class head. Outside the cache path, ``x`` is always the full
+        dataset and this flag is ignored.
         """
         # Suppress RMSNorm dtype mismatch warning when running in mixed
         # precision (fp16 input, fp32 weights). Harmless until we move
@@ -1719,10 +1724,16 @@ class TabPFNV3(Architecture):
                 kv_cache=kv_cache,
                 only_return_standard_out=only_return_standard_out,
                 save_peak_memory_factor=performance_options.save_peak_memory_factor,
+                x_is_test_only=x_is_test_only,
             )
             if return_kv_cache:
                 return output, kv_cache
             return output
+        if x_is_test_only:
+            raise ValueError(
+                "x_is_test_only=True requires kv_cache to be provided; "
+                "the non-cache forward needs the full train+test tensor."
+            )
 
         if performance_options.use_chunkwise_inference:
             output, cache = _forward_memory_efficient_chunkwise_inference(
@@ -1888,17 +1899,21 @@ class TabPFNV3(Architecture):
         kv_cache: TabPFNV3Cache,
         only_return_standard_out: bool = True,
         save_peak_memory_factor: int | None = None,
+        x_is_test_only: bool = False,
     ) -> torch.Tensor | dict[str, torch.Tensor]:
         """Fast inference path using a pre-built KV cache.
 
         Only test rows are processed through stages 0-2 (using cached scaler
         stats and inducing hidden states) and through the ICL transformer
-        (using cached K/V). Even though train rows are not touched at all,
-        this function still assumes the full dataset to be passed.
+        (using cached K/V). When ``x_is_test_only`` is True, ``x`` already
+        contains just the test rows and no slicing is needed; otherwise
+        ``x`` is the full train+test tensor and we slice off the train
+        half (which is never read). ``y`` remains full-length either way
+        because the many-class decoder reads ``y[:num_train]``.
         """
         x_RiBC = x
         num_train = y.shape[0]
-        x_test_RBC = x_RiBC[num_train:]
+        x_test_RBC = x_RiBC if x_is_test_only else x_RiBC[num_train:]
 
         # ---- Stages 0-2 on test rows only ----
         x_test_BRiCE = self._embed_feature_groups(

--- a/src/tabpfn/inference.py
+++ b/src/tabpfn/inference.py
@@ -1005,6 +1005,10 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
 
     When ``keep_cache_on_device=True``, each per-estimator cache is kept
     on the GPU for subsequent prediction calls, avoiding CPU↔GPU transfers.
+
+    At predict, only test rows are preprocessed (CPU and GPU) and
+    uploaded. The model is called with ``x_is_test_only=True``. ``y``
+    still carries the full train labels for the many-class decoder.
     """
 
     def __init__(
@@ -1059,11 +1063,6 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
         # Place model copies on all devices before building caches
         self.to(devices, self.force_inference_dtype, self.dtype_byte_size)
 
-        # Cast model weights to force_inference_dtype once per device
-        if self.force_inference_dtype is not None:
-            for model_cache in self.model_caches:
-                model_cache.set_dtype(self.force_inference_dtype)
-
         # Preprocess ensemble members (CPU work)
         fit_preprocess_start = time.perf_counter()
         self.ensemble_members: list[TabPFNEnsembleMember] = (
@@ -1112,6 +1111,11 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
         in parallel threads.
         """
         model = self.model_caches[model_index].get(device)
+
+        # Cast model weights to match force_inference_dtype (else linear
+        # layers throw a Half/Float mismatch — matches CacheKV).
+        if self.force_inference_dtype is not None:
+            model.type(self.force_inference_dtype)
 
         tensor_dtype = self.force_inference_dtype or torch.float32
         if not isinstance(X_train, torch.Tensor):
@@ -1190,7 +1194,6 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
             partial(
                 self._call_model,
                 cache_index=i,
-                X_train=ensemble_member.X_train,
                 X_test=ensemble_member.transform_X_test(X),
                 y_train=ensemble_member.y_train,
                 feature_schema=ensemble_member.feature_schema,
@@ -1219,7 +1222,6 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
         *,
         device: torch.device,
         cache_index: int,
-        X_train: torch.Tensor | np.ndarray,
         X_test: torch.Tensor | np.ndarray,
         y_train: torch.Tensor | np.ndarray,
         feature_schema: FeatureSchema,
@@ -1236,13 +1238,33 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
         ``self.caches[cache_index]``.  When ``keep_cache_on_device`` is True,
         the cache is moved to ``device`` on the first call and kept there.
 
+        Only X_test is uploaded and preprocessed — the v3 model's cache
+        fast path never reads train rows when ``x_is_test_only=True``.
+
         May be executed in parallel across threads, one per device.
         """
         model = self.model_caches[model_index].get(device)
 
-        X_full, y_train = _prepare_model_inputs(
-            device, self.force_inference_dtype, X_train, X_test, y_train
+        dtype = self.force_inference_dtype or torch.float32
+        X_test_tensor = torch.as_tensor(X_test, dtype=dtype, device=device).unsqueeze(1)
+        y_train = torch.as_tensor(y_train, dtype=dtype, device=device)
+
+        X_test_tensor, feature_schema = _maybe_run_gpu_preprocessing(
+            X_test_tensor,
+            gpu_preprocessor=gpu_preprocessor,
+            num_train_rows=0,
+            use_fitted_cache=True,
+            feature_schema=feature_schema,
         )
+
+        # Cast post-preproc tensors back to force_inference_dtype if set —
+        # GPU preprocessing may emit fp32 internally (SVD/quantile for
+        # numerical stability) even under a fp16 run. Matches CacheKV.
+        if self.force_inference_dtype is not None:
+            X_test_tensor = X_test_tensor.type(self.force_inference_dtype)
+            y_train = y_train.type(self.force_inference_dtype)
+
+        batched_cat_ix = [feature_schema.indices_for(FeatureModality.CATEGORICAL)]
 
         performance_options = model.get_default_performance_options()
         performance_options = dataclasses.replace(
@@ -1251,16 +1273,6 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
             if save_peak_mem
             else None,
         )
-
-        # Reuse fitted gpu preprocessor state from _build_cache
-        X_full, feature_schema = _maybe_run_gpu_preprocessing(
-            X_full,
-            gpu_preprocessor=gpu_preprocessor,
-            num_train_rows=X_train.shape[0],
-            use_fitted_cache=True,
-            feature_schema=feature_schema,
-        )
-        batched_cat_ix = [feature_schema.indices_for(FeatureModality.CATEGORICAL)]
 
         kwargs = {}
         if _model_expectes_task_type_arg(model):
@@ -1278,12 +1290,13 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
             torch.inference_mode(),
         ):
             return model(
-                X_full,
+                X_test_tensor,
                 y_train,
                 only_return_standard_out=only_return_standard_out,
                 categorical_inds=batched_cat_ix,
                 performance_options=performance_options,
                 kv_cache=cache_on_device,
+                x_is_test_only=True,
                 **kwargs,
             )
 


### PR DESCRIPTION
outdated