### PR TITLE
Restore ENABLE_GPU_PREPROCESSING default to True on ben/updates

### DIFF
--- a/src/tabpfn/inference_config.py
+++ b/src/tabpfn/inference_config.py
@@ -128,11 +128,11 @@ class InferenceConfig:
             indices are repeated for the remaining estimators.
     """
 
-    ENABLE_GPU_PREPROCESSING: bool = False
+    ENABLE_GPU_PREPROCESSING: bool = True
     """Move quantile transform, SVD feature generation, and feature shuffling to
-    GPU / torch.  When ``True``, these operations run on the same device as
-    the model, which can be significantly faster for large datasets (>10 k rows).
-    When ``False`` (default), all preprocessing runs on CPU / sklearn as before.
+    GPU / torch.  When ``True`` (default), these operations run on the same device
+    as the model, which can be significantly faster for large datasets (>10 k rows).
+    When ``False``, all preprocessing runs on CPU / sklearn as before.
 
     Only ``quantile_uni*`` transforms are accelerated (the torch quantile
     transformer only supports uniform output).  Other transforms stay on CPU


### PR DESCRIPTION
## Summary

Follow-up to #895 (Merge main into ben/updates). The PR description for #895 stated the resolution for \`inference_config.py\` was to preserve \`ben/updates\`' value (\`ENABLE_GPU_PREPROCESSING: bool = True\`, the preview default-on), but the merge ended up with \`main\`'s \`False\` value. This PR restores the intended \`True\` default and updates the adjacent docstring accordingly.

Confirmed on \`a031a47\` (ben/updates pre-merge) the default was \`True\`; on \`24c9233\` (post-merge HEAD) it is now \`False\`.

## Root cause

During the merge I ran \`git checkout --ours src/tabpfn/inference_config.py\`, then a subsequent catch-all loop \`for f in $(git diff --name-only --diff-filter=U); do git checkout --theirs \"\$f\"; done\` silently overwrote it — because \`git checkout --ours/--theirs\` only updates the working tree; the file stays marked conflicted until \`git add\`, so it was still picked up by the loop and flipped to \`--theirs\`.

## Diff

```diff
-    ENABLE_GPU_PREPROCESSING: bool = False
+    ENABLE_GPU_PREPROCESSING: bool = True
     \"\"\"Move quantile transform, SVD feature generation, and feature shuffling to
-    GPU / torch.  When \`\`True\`\`, these operations run on the same device as
-    the model, which can be significantly faster for large datasets (>10 k rows).
-    When \`\`False\`\` (default), all preprocessing runs on CPU / sklearn as before.
+    GPU / torch.  When \`\`True\`\` (default), these operations run on the same device
+    as the model, which can be significantly faster for large datasets (>10 k rows).
+    When \`\`False\`\`, all preprocessing runs on CPU / sklearn as before.
```

## Test plan

- [x] Python default check: \`InferenceConfig().ENABLE_GPU_PREPROCESSING == True\`
- [x] \`ruff check\`, \`ruff format --check\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default inference behavior to run parts of preprocessing on GPU, which may affect runtime characteristics and expose device-specific issues for users who relied on CPU preprocessing by default.
> 
> **Overview**
> Restores `InferenceConfig.ENABLE_GPU_PREPROCESSING` default to `True`, re-enabling GPU/torch-based quantile transform, SVD feature generation, and feature shuffling by default.
> 
> Updates the adjacent docstring to reflect that GPU preprocessing is now the default and CPU/sklearn preprocessing requires explicitly setting the flag to `False`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a96eb6e5b55dfc7831b92ff6e35707979382410f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->