### PR TITLE
Fix stale keep_cache_on_device docstring on ben/updates

### DIFF
--- a/src/tabpfn/inference.py
+++ b/src/tabpfn/inference.py
@@ -1040,10 +1040,10 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
             force_inference_dtype: The dtype to force inference to.
             save_peak_mem: Whether to save peak memory usage.
             autocast: Whether to use torch.autocast during cache build.
-            keep_cache_on_device: If True, keep each per-estimator KV cache
-                on the device where it was built.  Uses more device memory
-                but avoids CPU↔GPU transfers, giving lower latency.  When
-                False (default), caches are moved to CPU after building and
+            keep_cache_on_device: If True (default), keep each per-estimator
+                KV cache on the device where it was built.  Uses more device
+                memory but avoids CPU↔GPU transfers, giving lower latency.
+                When False, caches are moved to CPU after building and
                 transferred to the target device on every predict call.
         """
         super().__init__(


### PR DESCRIPTION
Follow-up to #895. The \`keep_cache_on_device\` docstring in \`InferenceEngineExplicitKVCache.__init__\` still read \"When False (default), caches are moved to CPU...\" from before #895 set the default to \`True\` on \`ben/updates\`. Update the text to match the actual default.

```diff
-            keep_cache_on_device: If True, keep each per-estimator KV cache
-                on the device where it was built.  Uses more device memory
-                but avoids CPU↔GPU transfers, giving lower latency.  When
-                False (default), caches are moved to CPU after building and
-                transferred to the target device on every predict call.
+            keep_cache_on_device: If True (default), keep each per-estimator
+                KV cache on the device where it was built.  Uses more device
+                memory but avoids CPU↔GPU transfers, giving lower latency.
+                When False, caches are moved to CPU after building and
+                transferred to the target device on every predict call.
```

Docs-only, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change correcting the stated default for `keep_cache_on_device`; no runtime behavior is modified.
> 
> **Overview**
> Updates the `InferenceEngineExplicitKVCache.__init__` docstring to state that `keep_cache_on_device` defaults to `True`, aligning documentation with the current parameter default and cache behavior description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 758efd9461b4d926e70364a08b4f43ab2884ab7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->