### PR TITLE
[PRI-280] Nightly notebook install check

### DIFF
--- a/.github/workflows/nightly-notebook-check.yml
+++ b/.github/workflows/nightly-notebook-check.yml
@@ -11,7 +11,7 @@ name: Nightly notebook install check
 
 on:
   schedule:
-    - cron: "17 7 * * *"   # 07:17 UTC daily; off-peak for PyPI
+    - cron: 17 7 * * *   # 07:17 UTC daily; off-peak for PyPI
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/nightly-notebook-check.yml
+++ b/.github/workflows/nightly-notebook-check.yml
@@ -78,7 +78,10 @@ jobs:
               if (lines.length > 0) failedLines = lines.join("\n");
             } catch (e) { /* output file missing — fall through to default */ }
 
-            const title = "Nightly: notebook install check failed";
+            // Per-version title so each Python version owns its own
+            // tracking issue and can be closed independently when fixed.
+            const title =
+              `Nightly: notebook install check failed (Python ${process.env.PYTHON_VERSION})`;
             const { data: issues } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/nightly-notebook-check.yml
+++ b/.github/workflows/nightly-notebook-check.yml
@@ -1,7 +1,8 @@
 name: Nightly notebook install check
 
 # Reproduces each example notebook's pip-install sequence in a fresh venv
-# and asserts `tabpfn` resolves to PyPI's latest.
+# across the Python versions we expect users to install on, and asserts
+# `tabpfn` resolves to PyPI's latest.
 #
 # Runs daily on a cron and on manual dispatch. Failures open or comment
 # on a tracking issue rather than emailing — scheduled-run failures
@@ -18,9 +19,13 @@ permissions:
 
 jobs:
   check:
-    name: Verify notebooks resolve latest tabpfn
+    name: Verify notebooks resolve latest tabpfn (Py ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v4.3.1
@@ -28,7 +33,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
@@ -50,8 +55,14 @@ jobs:
       - name: Open or update tracking issue on failure
         if: failure()
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
         with:
           script: |
+            // Multiple matrix cells may file/comment concurrently. The
+            // worst case is a couple of duplicate issues filed on the
+            // same nightly when both happen to win the race against an
+            // empty issue list — acceptable, the maintainer closes one.
             const title = "Nightly: notebook install check failed";
             const { data: issues } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
@@ -63,7 +74,9 @@ jobs:
               `${context.serverUrl}/${context.repo.owner}/` +
               `${context.repo.repo}/actions/runs/${context.runId}`;
             const body =
-              `Run: ${runUrl}\n\nSee logs for the failing notebook and details.`;
+              `Run: ${runUrl}\n` +
+              `Python: ${process.env.PYTHON_VERSION}\n\n` +
+              `See logs for the failing notebook and details.`;
             const existing = issues.find(i => i.title === title);
             if (existing) {
               await github.rest.issues.createComment({

--- a/.github/workflows/nightly-notebook-check.yml
+++ b/.github/workflows/nightly-notebook-check.yml
@@ -12,14 +12,6 @@ on:
   schedule:
     - cron: 17 7 * * *   # 07:17 UTC daily; off-peak for PyPI
   workflow_dispatch:
-  # TEMPORARY: remove before merging. Lets the PR validate the workflow
-  # end-to-end on a GH-hosted runner. `paths:` keeps it from firing on
-  # unrelated PRs after merge if forgotten.
-  pull_request:
-    paths:
-      - .github/workflows/nightly-notebook-check.yml
-      - tests/test_notebook_installs.py
-      - examples/notebooks/**
 
 permissions:
   contents: read

--- a/.github/workflows/nightly-notebook-check.yml
+++ b/.github/workflows/nightly-notebook-check.yml
@@ -1,0 +1,93 @@
+name: Nightly notebook install check
+
+# Reproduces each example notebook's pip-install sequence in a fresh venv
+# and asserts `tabpfn` resolves to PyPI's latest. Catches transitive caps
+# (e.g. a stale `tabpfn-extensions[all]` pinning tabpfn below the latest
+# release) before they reach Colab users.
+#
+# Runs daily on a cron and on manual dispatch. Failures open or comment
+# on a tracking issue rather than emailing — scheduled-run failures
+# don't notify by default.
+
+on:
+  schedule:
+    - cron: "17 7 * * *"   # 07:17 UTC daily; off-peak for PyPI
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    name: Verify notebooks resolve latest tabpfn
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v4.3.1
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: examples/notebooks/*.ipynb
+
+      - name: Install pytest
+        run: uv pip install --system pytest
+
+      - name: Run notebook install check
+        env:
+          RUN_NOTEBOOK_INSTALL_CHECK: "1"
+        # `--noconftest` skips loading tests/conftest.py, which imports
+        # numpy/torch — we don't install them here because the test creates
+        # its own per-notebook venvs and doesn't need them on the runner.
+        run: pytest --noconftest tests/test_notebook_installs.py -v
+
+      - name: Open or update tracking issue on failure
+        if: failure()
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const title = "Nightly: notebook install check failed";
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              labels: ["nightly-failure"],
+            });
+            const runUrl =
+              `${context.serverUrl}/${context.repo.owner}/` +
+              `${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              `Run: ${runUrl}`,
+              ``,
+              `Most likely cause: a transitive dependency in one of the example`,
+              `notebooks is capping \`tabpfn\` below the latest PyPI release.`,
+              `Common offender: \`tabpfn-extensions[all]\` shipping with a`,
+              `\`tabpfn<N\` pin that's now stale.`,
+              ``,
+              `Run logs show which notebook failed and the resolved version.`,
+            ].join("\n");
+            const existing = issues.find(i => i.title === title);
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ["nightly-failure"],
+              });
+            }

--- a/.github/workflows/nightly-notebook-check.yml
+++ b/.github/workflows/nightly-notebook-check.yml
@@ -12,6 +12,14 @@ on:
   schedule:
     - cron: 17 7 * * *   # 07:17 UTC daily; off-peak for PyPI
   workflow_dispatch:
+  # TEMPORARY: remove before merging. Lets the PR validate the workflow
+  # end-to-end on a GH-hosted runner. `paths:` keeps it from firing on
+  # unrelated PRs after merge if forgotten.
+  pull_request:
+    paths:
+      - .github/workflows/nightly-notebook-check.yml
+      - tests/test_notebook_installs.py
+      - examples/notebooks/**
 
 permissions:
   contents: read

--- a/.github/workflows/nightly-notebook-check.yml
+++ b/.github/workflows/nightly-notebook-check.yml
@@ -1,9 +1,7 @@
 name: Nightly notebook install check
 
 # Reproduces each example notebook's pip-install sequence in a fresh venv
-# and asserts `tabpfn` resolves to PyPI's latest. Catches transitive caps
-# (e.g. a stale `tabpfn-extensions[all]` pinning tabpfn below the latest
-# release) before they reach Colab users.
+# and asserts `tabpfn` resolves to PyPI's latest.
 #
 # Runs daily on a cron and on manual dispatch. Failures open or comment
 # on a tracking issue rather than emailing — scheduled-run failures
@@ -64,16 +62,8 @@ jobs:
             const runUrl =
               `${context.serverUrl}/${context.repo.owner}/` +
               `${context.repo.repo}/actions/runs/${context.runId}`;
-            const body = [
-              `Run: ${runUrl}`,
-              ``,
-              `Most likely cause: a transitive dependency in one of the example`,
-              `notebooks is capping \`tabpfn\` below the latest PyPI release.`,
-              `Common offender: \`tabpfn-extensions[all]\` shipping with a`,
-              `\`tabpfn<N\` pin that's now stale.`,
-              ``,
-              `Run logs show which notebook failed and the resolved version.`,
-            ].join("\n");
+            const body =
+              `Run: ${runUrl}\n\nSee logs for the failing notebook and details.`;
             const existing = issues.find(i => i.title === title);
             if (existing) {
               await github.rest.issues.createComment({

--- a/.github/workflows/nightly-notebook-check.yml
+++ b/.github/workflows/nightly-notebook-check.yml
@@ -45,12 +45,19 @@ jobs:
         run: uv pip install --system pytest
 
       - name: Run notebook install check
+        shell: bash
         env:
           RUN_NOTEBOOK_INSTALL_CHECK: "1"
         # `--noconftest` skips loading tests/conftest.py, which imports
         # numpy/torch — we don't install them here because the test creates
         # its own per-notebook venvs and doesn't need them on the runner.
-        run: pytest --noconftest tests/test_notebook_installs.py -v
+        # `tee` captures output to a file for the failure-issue body while
+        # still streaming live to the GH Actions log; pipefail preserves
+        # pytest's exit code through the pipe.
+        run: |
+          set -o pipefail
+          pytest --noconftest tests/test_notebook_installs.py -v 2>&1 \
+            | tee pytest_output.txt
 
       - name: Open or update tracking issue on failure
         if: failure()
@@ -63,6 +70,14 @@ jobs:
             // worst case is a couple of duplicate issues filed on the
             // same nightly when both happen to win the race against an
             // empty issue list — acceptable, the maintainer closes one.
+            const fs = require("fs");
+            let failedLines = "(no FAILED lines parsed; see logs)";
+            try {
+              const text = fs.readFileSync("pytest_output.txt", "utf-8");
+              const lines = text.split("\n").filter(l => l.startsWith("FAILED "));
+              if (lines.length > 0) failedLines = lines.join("\n");
+            } catch (e) { /* output file missing — fall through to default */ }
+
             const title = "Nightly: notebook install check failed";
             const { data: issues } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
@@ -76,7 +91,8 @@ jobs:
             const body =
               `Run: ${runUrl}\n` +
               `Python: ${process.env.PYTHON_VERSION}\n\n` +
-              `See logs for the failing notebook and details.`;
+              `\`\`\`\n${failedLines}\n\`\`\`\n\n` +
+              `See logs for full output.`;
             const existing = issues.find(i => i.title === title);
             if (existing) {
               await github.rest.issues.createComment({

--- a/changelog/901.added.md
+++ b/changelog/901.added.md
@@ -1,0 +1,1 @@
+Add a nightly workflow that reproduces every example notebook's pip-install sequence in a fresh venv and asserts `tabpfn` resolves to the latest PyPI release.

--- a/tests/test_notebook_installs.py
+++ b/tests/test_notebook_installs.py
@@ -19,8 +19,6 @@ import re
 import shlex
 import shutil
 import subprocess
-import time
-import urllib.error
 from pathlib import Path
 from typing import cast
 from urllib.request import Request, urlopen
@@ -36,15 +34,6 @@ if not os.environ.get("RUN_NOTEBOOK_INSTALL_CHECK"):
 NOTEBOOK_DIR = Path(__file__).parents[1] / "examples" / "notebooks"
 NOTEBOOKS = sorted(NOTEBOOK_DIR.glob("*.ipynb"))
 PIP_RE = re.compile(r"^\s*[!%](?:uv\s+)?pip\s+install\s+(.+?)\s*$")
-NETWORKY = (
-    "connection",
-    "timeout",
-    "503",
-    "504",
-    "failed to fetch",
-    "network",
-    "temporary failure",
-)
 
 
 def _extract_install_lines(notebook_path: Path) -> list[str]:
@@ -63,25 +52,19 @@ def _extract_install_lines(notebook_path: Path) -> list[str]:
 
 
 @functools.lru_cache(maxsize=1)
-def _latest_tabpfn_version(retries: int = 3, backoff: float = 5.0) -> str:
-    """Fetch latest tabpfn version from PyPI, retrying on transient failures.
+def _latest_tabpfn_version() -> str:
+    """Fetch latest tabpfn version from PyPI.
 
-    Cached: latest version is constant within a test session, so we hit PyPI
-    once regardless of how many notebooks we check.
+    Cached so we only hit PyPI once per session regardless of notebook count.
+    Network failures crash the test loudly — the workflow surfaces them as
+    nightly-failure issues for the maintainer to investigate or rerun.
     """
-    for attempt in range(retries):
-        try:
-            req = Request(
-                "https://pypi.org/pypi/tabpfn/json",
-                headers={"User-Agent": "tabpfn-notebook-check/1.0"},
-            )
-            with urlopen(req, timeout=15) as r:  # noqa: S310
-                return cast("str", json.load(r)["info"]["version"])
-        except (urllib.error.URLError, TimeoutError) as e:
-            if attempt == retries - 1:
-                pytest.skip(f"PyPI metadata fetch failed (network): {e}")
-            time.sleep(backoff)
-    raise RuntimeError("unreachable")
+    req = Request(
+        "https://pypi.org/pypi/tabpfn/json",
+        headers={"User-Agent": "tabpfn-notebook-check/1.0"},
+    )
+    with urlopen(req, timeout=15) as r:  # noqa: S310
+        return cast("str", json.load(r)["info"]["version"])
 
 
 @pytest.mark.parametrize("notebook", NOTEBOOKS, ids=lambda p: p.name)
@@ -103,7 +86,6 @@ def test_notebook_resolves_latest_tabpfn(notebook: Path, tmp_path: Path) -> None
     subprocess.run(  # noqa: S603
         ["uv", "venv", "--python", "3.12", str(venv)],  # noqa: S607
         check=True,
-        capture_output=True,
         env=base_env,
     )
     bin_dir = "Scripts" if os.name == "nt" else "bin"
@@ -116,20 +98,12 @@ def test_notebook_resolves_latest_tabpfn(notebook: Path, tmp_path: Path) -> None
     }
 
     for line in install_lines:
-        result = subprocess.run(  # noqa: S603
+        subprocess.run(  # noqa: S603
             ["uv", "pip", "install", *shlex.split(line)],  # noqa: S607
             env=env,
-            capture_output=True,
-            text=True,
+            check=True,
             timeout=600,
-            check=False,
         )
-        if result.returncode != 0:
-            stderr = result.stderr.lower()
-            tail = result.stderr.strip()[-500:]
-            if any(s in stderr for s in NETWORKY):
-                pytest.skip(f"network error during '{line}': {tail[-200:]}")
-            pytest.fail(f"install failed: {line}\n--- stderr ---\n{tail}")
 
     show = subprocess.run(
         ["uv", "pip", "show", "tabpfn"],  # noqa: S607

--- a/tests/test_notebook_installs.py
+++ b/tests/test_notebook_installs.py
@@ -72,8 +72,6 @@ def test_notebook_resolves_latest_tabpfn(notebook: Path, tmp_path: Path) -> None
         pytest.skip("uv not on PATH")
 
     install_lines = _extract_install_lines(notebook)
-    if not any("tabpfn" in line for line in install_lines):
-        pytest.skip(f"{notebook.name} does not install tabpfn")
 
     # Don't inherit [tool.uv] settings from any pyproject.toml above us
     # (e.g. TabPFN's `exclude-newer`). We're simulating a fresh Colab user
@@ -83,7 +81,7 @@ def test_notebook_resolves_latest_tabpfn(notebook: Path, tmp_path: Path) -> None
 
     venv = tmp_path / "venv"
     subprocess.run(  # noqa: S603
-        ["uv", "venv", "--python", "3.12", str(venv)],  # noqa: S607
+        ["uv", "venv", str(venv)],  # noqa: S607
         check=True,
         env=base_env,
     )

--- a/tests/test_notebook_installs.py
+++ b/tests/test_notebook_installs.py
@@ -9,6 +9,7 @@ Skipped by default. Set `RUN_NOTEBOOK_INSTALL_CHECK=1` to enable.
 Intended to run from `.github/workflows/nightly-notebook-check.yml`, not
 from the regular PR test matrix.
 """
+
 from __future__ import annotations
 
 import json
@@ -20,6 +21,7 @@ import subprocess
 import time
 import urllib.error
 from pathlib import Path
+from typing import cast
 from urllib.request import Request, urlopen
 
 import pytest
@@ -67,8 +69,8 @@ def _latest_tabpfn_version(retries: int = 3, backoff: float = 5.0) -> str:
                 "https://pypi.org/pypi/tabpfn/json",
                 headers={"User-Agent": "tabpfn-notebook-check/1.0"},
             )
-            with urlopen(req, timeout=15) as r:
-                return json.load(r)["info"]["version"]
+            with urlopen(req, timeout=15) as r:  # noqa: S310
+                return cast("str", json.load(r)["info"]["version"])
         except (urllib.error.URLError, TimeoutError) as e:
             if attempt == retries - 1:
                 pytest.skip(f"PyPI metadata fetch failed (network): {e}")
@@ -92,8 +94,8 @@ def test_notebook_resolves_latest_tabpfn(notebook: Path, tmp_path: Path) -> None
     base_env = {**os.environ, "UV_NO_CONFIG": "1"}
 
     venv = tmp_path / "venv"
-    subprocess.run(
-        ["uv", "venv", "--python", "3.12", str(venv)],
+    subprocess.run(  # noqa: S603
+        ["uv", "venv", "--python", "3.12", str(venv)],  # noqa: S607
         check=True,
         capture_output=True,
         env=base_env,
@@ -105,25 +107,23 @@ def test_notebook_resolves_latest_tabpfn(notebook: Path, tmp_path: Path) -> None
     }
 
     for line in install_lines:
-        result = subprocess.run(
-            ["uv", "pip", "install", *shlex.split(line)],
+        result = subprocess.run(  # noqa: S603
+            ["uv", "pip", "install", *shlex.split(line)],  # noqa: S607
             env=env,
             capture_output=True,
             text=True,
             timeout=600,
+            check=False,
         )
         if result.returncode != 0:
             stderr = result.stderr.lower()
+            tail = result.stderr.strip()[-500:]
             if any(s in stderr for s in NETWORKY):
-                pytest.skip(
-                    f"network error during '{line}': {result.stderr.strip()[-200:]}"
-                )
-            pytest.fail(
-                f"install failed: {line}\n--- stderr ---\n{result.stderr.strip()[-500:]}"
-            )
+                pytest.skip(f"network error during '{line}': {tail[-200:]}")
+            pytest.fail(f"install failed: {line}\n--- stderr ---\n{tail}")
 
     show = subprocess.run(
-        ["uv", "pip", "show", "tabpfn"],
+        ["uv", "pip", "show", "tabpfn"],  # noqa: S607
         env=env,
         capture_output=True,
         text=True,

--- a/tests/test_notebook_installs.py
+++ b/tests/test_notebook_installs.py
@@ -12,6 +12,7 @@ from the regular PR test matrix.
 
 from __future__ import annotations
 
+import functools
 import json
 import os
 import re
@@ -61,8 +62,13 @@ def _extract_install_lines(notebook_path: Path) -> list[str]:
     return lines
 
 
+@functools.lru_cache(maxsize=1)
 def _latest_tabpfn_version(retries: int = 3, backoff: float = 5.0) -> str:
-    """Fetch latest tabpfn version from PyPI, retrying on transient failures."""
+    """Fetch latest tabpfn version from PyPI, retrying on transient failures.
+
+    Cached: latest version is constant within a test session, so we hit PyPI
+    once regardless of how many notebooks we check.
+    """
     for attempt in range(retries):
         try:
             req = Request(
@@ -100,10 +106,13 @@ def test_notebook_resolves_latest_tabpfn(notebook: Path, tmp_path: Path) -> None
         capture_output=True,
         env=base_env,
     )
+    bin_dir = "Scripts" if os.name == "nt" else "bin"
     env = {
         **base_env,
         "VIRTUAL_ENV": str(venv),
-        "PATH": f"{venv}/bin:{os.environ.get('PATH', '')}",
+        "PATH": os.pathsep.join(
+            filter(None, [str(venv / bin_dir), os.environ.get("PATH")]),
+        ),
     }
 
     for line in install_lines:

--- a/tests/test_notebook_installs.py
+++ b/tests/test_notebook_installs.py
@@ -2,8 +2,7 @@
 
 Reproduces the install sequence from each `examples/notebooks/*.ipynb` in a
 fresh venv and asserts that `tabpfn` resolves to the version currently
-published as latest on PyPI. Catches transitive caps (e.g. a stale
-`tabpfn-extensions[all]` pinning `tabpfn<7`) before users hit them.
+published as latest on PyPI.
 
 Skipped by default. Set `RUN_NOTEBOOK_INSTALL_CHECK=1` to enable.
 Intended to run from `.github/workflows/nightly-notebook-check.yml`, not
@@ -120,7 +119,5 @@ def test_notebook_resolves_latest_tabpfn(notebook: Path, tmp_path: Path) -> None
 
     latest = _latest_tabpfn_version()
     assert installed == latest, (
-        f"{notebook.name}: sequential install resolves tabpfn=={installed}, "
-        f"but PyPI latest is {latest}. Likely cause: a transitive cap (e.g. "
-        f"tabpfn-extensions or another notebook dep) is holding tabpfn back."
+        f"{notebook.name}: installed tabpfn=={installed}, PyPI latest is {latest}."
     )

--- a/tests/test_notebook_installs.py
+++ b/tests/test_notebook_installs.py
@@ -1,0 +1,143 @@
+"""Verify each example notebook resolves `tabpfn` to the latest PyPI release.
+
+Reproduces the install sequence from each `examples/notebooks/*.ipynb` in a
+fresh venv and asserts that `tabpfn` resolves to the version currently
+published as latest on PyPI. Catches transitive caps (e.g. a stale
+`tabpfn-extensions[all]` pinning `tabpfn<7`) before users hit them.
+
+Skipped by default. Set `RUN_NOTEBOOK_INSTALL_CHECK=1` to enable.
+Intended to run from `.github/workflows/nightly-notebook-check.yml`, not
+from the regular PR test matrix.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import time
+import urllib.error
+from pathlib import Path
+from urllib.request import Request, urlopen
+
+import pytest
+
+if not os.environ.get("RUN_NOTEBOOK_INSTALL_CHECK"):
+    pytest.skip(
+        "set RUN_NOTEBOOK_INSTALL_CHECK=1 to enable (intended for nightly CI)",
+        allow_module_level=True,
+    )
+
+NOTEBOOK_DIR = Path(__file__).parents[1] / "examples" / "notebooks"
+NOTEBOOKS = sorted(NOTEBOOK_DIR.glob("*.ipynb"))
+PIP_RE = re.compile(r"^\s*[!%](?:uv\s+)?pip\s+install\s+(.+?)\s*$")
+NETWORKY = (
+    "connection",
+    "timeout",
+    "503",
+    "504",
+    "failed to fetch",
+    "network",
+    "temporary failure",
+)
+
+
+def _extract_install_lines(notebook_path: Path) -> list[str]:
+    """Return pip-install argument strings from a notebook's code cells."""
+    data = json.loads(notebook_path.read_text(encoding="utf-8"))
+    lines = []
+    for cell in data.get("cells", []):
+        if cell.get("cell_type") != "code":
+            continue
+        source = "".join(cell.get("source", []))
+        for line in source.splitlines():
+            m = PIP_RE.match(line)
+            if m:
+                lines.append(m.group(1))
+    return lines
+
+
+def _latest_tabpfn_version(retries: int = 3, backoff: float = 5.0) -> str:
+    """Fetch latest tabpfn version from PyPI, retrying on transient failures."""
+    for attempt in range(retries):
+        try:
+            req = Request(
+                "https://pypi.org/pypi/tabpfn/json",
+                headers={"User-Agent": "tabpfn-notebook-check/1.0"},
+            )
+            with urlopen(req, timeout=15) as r:
+                return json.load(r)["info"]["version"]
+        except (urllib.error.URLError, TimeoutError) as e:
+            if attempt == retries - 1:
+                pytest.skip(f"PyPI metadata fetch failed (network): {e}")
+            time.sleep(backoff)
+    raise RuntimeError("unreachable")
+
+
+@pytest.mark.parametrize("notebook", NOTEBOOKS, ids=lambda p: p.name)
+def test_notebook_resolves_latest_tabpfn(notebook: Path, tmp_path: Path) -> None:
+    if shutil.which("uv") is None:
+        pytest.skip("uv not on PATH")
+
+    install_lines = _extract_install_lines(notebook)
+    if not any("tabpfn" in line for line in install_lines):
+        pytest.skip(f"{notebook.name} does not install tabpfn")
+
+    # Don't inherit [tool.uv] settings from any pyproject.toml above us
+    # (e.g. TabPFN's `exclude-newer`). We're simulating a fresh Colab user
+    # with no project context, so any repo-local resolver constraints would
+    # produce false negatives.
+    base_env = {**os.environ, "UV_NO_CONFIG": "1"}
+
+    venv = tmp_path / "venv"
+    subprocess.run(
+        ["uv", "venv", "--python", "3.12", str(venv)],
+        check=True,
+        capture_output=True,
+        env=base_env,
+    )
+    env = {
+        **base_env,
+        "VIRTUAL_ENV": str(venv),
+        "PATH": f"{venv}/bin:{os.environ.get('PATH', '')}",
+    }
+
+    for line in install_lines:
+        result = subprocess.run(
+            ["uv", "pip", "install", *shlex.split(line)],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=600,
+        )
+        if result.returncode != 0:
+            stderr = result.stderr.lower()
+            if any(s in stderr for s in NETWORKY):
+                pytest.skip(
+                    f"network error during '{line}': {result.stderr.strip()[-200:]}"
+                )
+            pytest.fail(
+                f"install failed: {line}\n--- stderr ---\n{result.stderr.strip()[-500:]}"
+            )
+
+    show = subprocess.run(
+        ["uv", "pip", "show", "tabpfn"],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    installed = next(
+        line.split(":", 1)[1].strip()
+        for line in show.stdout.splitlines()
+        if line.startswith("Version:")
+    )
+
+    latest = _latest_tabpfn_version()
+    assert installed == latest, (
+        f"{notebook.name}: sequential install resolves tabpfn=={installed}, "
+        f"but PyPI latest is {latest}. Likely cause: a transitive cap (e.g. "
+        f"tabpfn-extensions or another notebook dep) is holding tabpfn back."
+    )


### PR DESCRIPTION
## Summary

Adds a nightly workflow that reproduces every `examples/notebooks/*.ipynb` install sequence in a fresh venv across Python 3.11 / 3.12 / 3.13, and asserts `tabpfn` resolves to PyPI's latest. Failures open or comment on a tracking issue (no email by default for scheduled runs).

Catches the regression class behind PRI-280 — a transitive dep capping `tabpfn` below the latest release.

## Files

- `tests/test_notebook_installs.py` — pytest test, gated by `RUN_NOTEBOOK_INSTALL_CHECK=1`. Parameterized across notebooks.
- `.github/workflows/nightly-notebook-check.yml` — daily cron + `workflow_dispatch`, matrix over Python 3.11/3.12/3.13.
- `changelog/901.added.md` — towncrier fragment.

## Verified end-to-end

Sample run on this PR: <https://github.com/PriorLabs/TabPFN/actions/runs/25063167744/job/73422829076?pr=901>