### PR TITLE
docs: drop install_id and install_date from TELEMETRY.md

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -29,8 +29,6 @@ Here's the full list:
 - `runtime_kernel` – runtime kernel (e.g. CPython)
 - `runtime_environment` – runtime environment (e.g. notebook / script / CI)
 - `timestamp` – time of the event
-- `install_date` – `year-month-day` when TabPFN was used for the first time
-- `install_id` – unique, random and anonymous installation ID
 
 ### Extra metadata (per-event)
 - `fit_called` / `predict_called`: `task` (classification or regression), `num_rows` (*rounded*), `num_columns` (*rounded*), `duration_ms`


### PR DESCRIPTION
## Summary

- Drops `install_id` and `install_date` from the per-event metadata list. These fields are no longer attached to telemetry events.

Brings `TELEMETRY.md` into line with the metadata fields declared in `tabpfn_common_utils.telemetry.core.events`.

## Test plan

- [ ] Render on GitHub and eyeball the formatting
- [ ] Confirm metadata fields match `tabpfn_common_utils/src/tabpfn_common_utils/telemetry/core/events.py`