### PR TITLE
Update copyright year to 2026 and consolidate authors

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,4 +515,4 @@ export TABPFN_DISABLE_TELEMETRY=1
 ```
 ---
 
-Built with ❤️ by [Prior Labs](https://priorlabs.ai) - Copyright (c) 2025 Prior Labs GmbH
+Built with ❤️ by [Prior Labs](https://priorlabs.ai) - Copyright (c) 2026 Prior Labs GmbH

--- a/changelog/916.changed.md
+++ b/changelog/916.changed.md
@@ -1,0 +1,1 @@
+Updated copyright year to 2026 and consolidated the `authors` field in `pyproject.toml` to a single Prior Labs entry.

--- a/examples/kv_cache_fast_prediction.py
+++ b/examples/kv_cache_fast_prediction.py
@@ -1,4 +1,4 @@
-#  Copyright (c) Prior Labs GmbH 2025.
+#  Copyright (c) Prior Labs GmbH 2026.
 """TabPFN with KV cache vs. without on binary classification (synthetic).
 
 `fit_mode="fit_with_cache"` builds a key-value (KV) cache *during* `fit`.

--- a/examples/save_and_load_model.py
+++ b/examples/save_and_load_model.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-# Copyright (c) Prior Labs GmbH 2025.
+# Copyright (c) Prior Labs GmbH 2026.
 from pathlib import Path
 
 from sklearn.datasets import load_diabetes

--- a/examples/tabpfn_for_binary_classification.py
+++ b/examples/tabpfn_for_binary_classification.py
@@ -1,4 +1,4 @@
-#  Copyright (c) Prior Labs GmbH 2025.
+#  Copyright (c) Prior Labs GmbH 2026.
 """Example of using TabPFN for binary classification.
 
 This example demonstrates how to use TabPFNClassifier on a binary classification task

--- a/examples/tabpfn_for_multiclass_classification.py
+++ b/examples/tabpfn_for_multiclass_classification.py
@@ -1,4 +1,4 @@
-#  Copyright (c) Prior Labs GmbH 2025.
+#  Copyright (c) Prior Labs GmbH 2026.
 """Example of using TabPFN for multiclass classification.
 
 This example demonstrates how to use TabPFNClassifier on a multiclass classification task

--- a/examples/tabpfn_for_regression.py
+++ b/examples/tabpfn_for_regression.py
@@ -1,4 +1,4 @@
-#  Copyright (c) Prior Labs GmbH 2025.
+#  Copyright (c) Prior Labs GmbH 2026.
 """Example of using TabPFN for regression.
 
 This example demonstrates how to use TabPFNRegressor on a regression task

--- a/examples/tabpfn_with_tuning.py
+++ b/examples/tabpfn_with_tuning.py
@@ -1,4 +1,4 @@
-#  Copyright (c) Prior Labs GmbH 2025.
+#  Copyright (c) Prior Labs GmbH 2026.
 """Example of using TabPFN for binary classification with an eval_metric and tuning.
 
 This example demonstrates how to calibrate and tune the predictions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,29 +26,7 @@ dependencies = [
   "lightgbm>=3.0",
 ]
 requires-python = ">=3.9"
-authors = [
-  { name = "Noah Hollmann" },
-  { name = "Samuel Müller" },
-  { name = "Lennart Purucker" },
-  { name = "Arjun Krishnakumar" },
-  { name = "Max Körfer" },
-  { name = "Shi Bin Hoo" },
-  { name = "Robin Tibor Schirrmeister" },
-  { name = "Frank Hutter" },
-  # Huge thanks to code refactoring contributor Eddie
-  { name = "Eddie Bergman" },
-  # Prior Labs Contributors
-  { name = "Leo Grinsztajn" },
-  { name = "Felix Jabloski" },
-  { name = "Klemens Flöge" },
-  { name = "Oscar Key" },
-  { name = "Felix Birkel" },
-  { name = "Philipp Jund" },
-  { name = "Brendan Roof" },
-  { name = "Dominik Safaric" },
-  { name = "Benjamin Jaeger" },
-  { name = "Alan Arazi" }
-]
+authors = [{ name = "Prior Labs", email = "opensource@priorlabs.ai" }]
 
 readme = "README.md"
 description = "TabPFN: Foundation model for tabular data"

--- a/src/tabpfn/architectures/base/attention/full_attention.py
+++ b/src/tabpfn/architectures/base/attention/full_attention.py
@@ -1,4 +1,4 @@
-#  Copyright (c) Prior Labs GmbH 2025.
+#  Copyright (c) Prior Labs GmbH 2026.
 """Implements standard quadratic attention."""
 
 from __future__ import annotations

--- a/src/tabpfn/architectures/base/bar_distribution.py
+++ b/src/tabpfn/architectures/base/bar_distribution.py
@@ -1,4 +1,4 @@
-#  Copyright (c) Prior Labs GmbH 2025.
+#  Copyright (c) Prior Labs GmbH 2026.
 
 # TODO: This module needs some tidying
 from __future__ import annotations

--- a/src/tabpfn/architectures/base/config.py
+++ b/src/tabpfn/architectures/base/config.py
@@ -1,4 +1,4 @@
-#  Copyright (c) Prior Labs GmbH 2025.
+#  Copyright (c) Prior Labs GmbH 2026.
 
 from __future__ import annotations
 

--- a/src/tabpfn/architectures/base/layer.py
+++ b/src/tabpfn/architectures/base/layer.py
@@ -1,4 +1,4 @@
-#  Copyright (c) Prior Labs GmbH 2025.
+#  Copyright (c) Prior Labs GmbH 2026.
 
 # TODO: Seems like there's a lot in this file that is over-parametrized for regular
 # usage. Could likely just remove it.

--- a/src/tabpfn/architectures/base/memory.py
+++ b/src/tabpfn/architectures/base/memory.py
@@ -1,4 +1,4 @@
-#  Copyright (c) Prior Labs GmbH 2025.
+#  Copyright (c) Prior Labs GmbH 2026.
 
 from __future__ import annotations
 

--- a/src/tabpfn/architectures/base/mlp.py
+++ b/src/tabpfn/architectures/base/mlp.py
@@ -1,4 +1,4 @@
-#  Copyright (c) Prior Labs GmbH 2025.
+#  Copyright (c) Prior Labs GmbH 2026.
 
 from __future__ import annotations
 

--- a/src/tabpfn/architectures/base/thinking_tokens.py
+++ b/src/tabpfn/architectures/base/thinking_tokens.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 from __future__ import annotations
 
 from typing_extensions import override

--- a/src/tabpfn/architectures/base/transformer.py
+++ b/src/tabpfn/architectures/base/transformer.py
@@ -1,4 +1,4 @@
-#  Copyright (c) Prior Labs GmbH 2025.
+#  Copyright (c) Prior Labs GmbH 2026.
 
 from __future__ import annotations
 

--- a/src/tabpfn/architectures/encoders/pipeline_interfaces.py
+++ b/src/tabpfn/architectures/encoders/pipeline_interfaces.py
@@ -1,4 +1,4 @@
-#  Copyright (c) Prior Labs GmbH 2025.
+#  Copyright (c) Prior Labs GmbH 2026.
 
 """Interfaces for encoders."""
 

--- a/src/tabpfn/architectures/encoders/steps/remove_empty_features_encoder_step.py
+++ b/src/tabpfn/architectures/encoders/steps/remove_empty_features_encoder_step.py
@@ -1,6 +1,6 @@
 """Encoder step to remove empty (constant) features."""
 
-#  Copyright (c) Prior Labs GmbH 2025.
+#  Copyright (c) Prior Labs GmbH 2026.
 
 from __future__ import annotations
 

--- a/src/tabpfn/architectures/tabpfn_v2_5.py
+++ b/src/tabpfn/architectures/tabpfn_v2_5.py
@@ -5,7 +5,7 @@ the MLP hidden layer size.
 
 Note that this version does not support a KV cache.
 
-Copyright (c) Prior Labs GmbH 2025.
+Copyright (c) Prior Labs GmbH 2026.
 """
 
 from __future__ import annotations

--- a/src/tabpfn/architectures/tabpfn_v2_6.py
+++ b/src/tabpfn/architectures/tabpfn_v2_6.py
@@ -2,7 +2,7 @@
 
 Compared to v2.5, this uses RMSNorm instead of LayerNorm.
 
-Copyright (c) Prior Labs GmbH 2025.
+Copyright (c) Prior Labs GmbH 2026.
 """
 
 from __future__ import annotations

--- a/src/tabpfn/base.py
+++ b/src/tabpfn/base.py
@@ -1,6 +1,6 @@
 """Common logic for TabPFN models."""
 
-#  Copyright (c) Prior Labs GmbH 2025.
+#  Copyright (c) Prior Labs GmbH 2026.
 
 from __future__ import annotations
 

--- a/src/tabpfn/classifier.py
+++ b/src/tabpfn/classifier.py
@@ -14,7 +14,7 @@
     ```
 """
 
-#  Copyright (c) Prior Labs GmbH 2025.
+#  Copyright (c) Prior Labs GmbH 2026.
 
 from __future__ import annotations
 

--- a/src/tabpfn/constants.py
+++ b/src/tabpfn/constants.py
@@ -1,6 +1,6 @@
 """Various constants used throughout the library."""
 
-#  Copyright (c) Prior Labs GmbH 2025.
+#  Copyright (c) Prior Labs GmbH 2026.
 
 # TODO(eddiebergman): Should probably put these where they belong but
 # for the time being, this just helps with typing and not the possible

--- a/src/tabpfn/errors.py
+++ b/src/tabpfn/errors.py
@@ -1,6 +1,6 @@
 """Custom exception classes for TabPFN."""
 
-#  Copyright (c) Prior Labs GmbH 2025.
+#  Copyright (c) Prior Labs GmbH 2026.
 
 from __future__ import annotations
 

--- a/src/tabpfn/inference.py
+++ b/src/tabpfn/inference.py
@@ -1,6 +1,6 @@
 """Module that defines different ways to run inference with TabPFN."""
 
-#  Copyright (c) Prior Labs GmbH 2025.
+#  Copyright (c) Prior Labs GmbH 2026.
 
 from __future__ import annotations
 

--- a/src/tabpfn/inference_config.py
+++ b/src/tabpfn/inference_config.py
@@ -1,6 +1,6 @@
 """Additional configuration options for inference."""
 
-#  Copyright (c) Prior Labs GmbH 2025.
+#  Copyright (c) Prior Labs GmbH 2026.
 
 from __future__ import annotations
 

--- a/src/tabpfn/model_loading.py
+++ b/src/tabpfn/model_loading.py
@@ -1,6 +1,6 @@
 """Functions for downloading and loading model checkpoints."""
 
-#  Copyright (c) Prior Labs GmbH 2025.
+#  Copyright (c) Prior Labs GmbH 2026.
 
 from __future__ import annotations
 

--- a/src/tabpfn/preprocessing/torch/__init__.py
+++ b/src/tabpfn/preprocessing/torch/__init__.py
@@ -1,4 +1,4 @@
-#  Copyright (c) Prior Labs GmbH 2025.
+#  Copyright (c) Prior Labs GmbH 2026.
 
 """Torch-based preprocessing utilities."""
 

--- a/src/tabpfn/preprocessing/torch/factory.py
+++ b/src/tabpfn/preprocessing/torch/factory.py
@@ -1,4 +1,4 @@
-#  Copyright (c) Prior Labs GmbH 2025.
+#  Copyright (c) Prior Labs GmbH 2026.
 
 """Factory for creating torch preprocessing pipelines."""
 

--- a/src/tabpfn/preprocessing/torch/gpu_preprocessing_metadata.py
+++ b/src/tabpfn/preprocessing/torch/gpu_preprocessing_metadata.py
@@ -1,4 +1,4 @@
-#  Copyright (c) Prior Labs GmbH 2025.
+#  Copyright (c) Prior Labs GmbH 2026.
 
 """Utilities for GPU preprocessing pipeline construction."""
 

--- a/src/tabpfn/preprocessing/torch/pipeline_interface.py
+++ b/src/tabpfn/preprocessing/torch/pipeline_interface.py
@@ -1,4 +1,4 @@
-#  Copyright (c) Prior Labs GmbH 2025.
+#  Copyright (c) Prior Labs GmbH 2026.
 
 """Interfaces for torch preprocessing pipeline."""
 

--- a/src/tabpfn/preprocessing/torch/steps.py
+++ b/src/tabpfn/preprocessing/torch/steps.py
@@ -1,4 +1,4 @@
-#  Copyright (c) Prior Labs GmbH 2025.
+#  Copyright (c) Prior Labs GmbH 2026.
 
 """Pipeline step wrappers for torch preprocessing operations."""
 

--- a/src/tabpfn/regressor.py
+++ b/src/tabpfn/regressor.py
@@ -13,7 +13,7 @@
     ```
 """
 
-#  Copyright (c) Prior Labs GmbH 2025.
+#  Copyright (c) Prior Labs GmbH 2026.
 
 from __future__ import annotations
 

--- a/src/tabpfn/utils.py
+++ b/src/tabpfn/utils.py
@@ -1,6 +1,6 @@
 """A collection of random utilities for the TabPFN models."""
 
-#  Copyright (c) Prior Labs GmbH 2025.
+#  Copyright (c) Prior Labs GmbH 2026.
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Issue
N/A

## Motivation and Context

This PR updates the copyright year from 2025 to 2026 across the codebase and consolidates the authors list in `pyproject.toml` to a single organizational entry for Prior Labs with a contact email.

### Changes Made:
1. **pyproject.toml**: Replaced the detailed list of individual contributors with a single organizational author entry: `[{ name = "Prior Labs", email = "opensource@priorlabs.ai" }]`
2. **Copyright headers**: Updated all copyright year references from 2025 to 2026 in:
   - README.md
   - All example files
   - All source files in `src/tabpfn/`

---

## Public API Changes

- [x] No Public API changes

---

## How Has This Been Tested?

No testing needed. These are metadata and documentation updates with no functional code changes.

---

## Checklist

- [x] The changes have been tested locally.
- [x] Documentation has been updated (copyright year in README).
- [x] A changelog entry has been added (no changelog needed - administrative update)
- [x] The code follows the project's style guidelines.
- [x] I have considered the impact of these changes on the public API (none).
