### PR TITLE
Introduce embedding_dim API and rename ninp to emsize

### DIFF
--- a/changelog/924.added.md
+++ b/changelog/924.added.md
@@ -1,0 +1,1 @@
+Add `embedding_dim` abstract property to the `Architecture` interface, exposing the output embedding dimension for all architecture implementations.

--- a/src/tabpfn/architectures/base/config.py
+++ b/src/tabpfn/architectures/base/config.py
@@ -53,7 +53,7 @@ class ModelConfig(ArchitectureConfig):
     nan_handling_enabled: Literal[True] = True
     nan_handling_y_encoder: Literal[True] = True
     nhid_factor: int = 4
-    """Hidden dimension in the MLP layers is ninp * nhid_factor."""
+    """Hidden dimension in the MLP layers is emsize * nhid_factor."""
     nlayers: int = 12
     """Number of layers in the encoder, each consisting of
     a multi-head attention and an MLP layer."""

--- a/src/tabpfn/architectures/base/transformer.py
+++ b/src/tabpfn/architectures/base/transformer.py
@@ -121,10 +121,10 @@ class PerFeatureTransformer(Architecture):
         Args:
             encoder:
                 Pass a nn.Module that takes in a batch of sequences of inputs and
-                returns something of the shape (seq_len, batch_size, ninp)
+                returns something of the shape (seq_len, batch_size, emsize)
             y_encoder:
                 A nn.Module that takes in a batch of sequences of outputs and
-                returns something of the shape (seq_len, batch_size, ninp)
+                returns something of the shape (seq_len, batch_size, emsize)
             activation: An activation function, "gelu" or "relu"
             min_num_layers_layer_dropout:
                 If this is set, it enables to drop the last
@@ -185,9 +185,9 @@ class PerFeatureTransformer(Architecture):
 
         self.encoder = encoder
         self.y_encoder = y_encoder
-        self.ninp = config.emsize
+        self.emsize = config.emsize
         self.nhid_factor = config.nhid_factor
-        nhid = self.ninp * self.nhid_factor
+        nhid = self.emsize * self.nhid_factor
         self.features_per_group = config.features_per_group
         self.cache_trainset_representation = cache_trainset_representation
         self.cached_embeddings: torch.Tensor | None = None
@@ -238,7 +238,7 @@ class PerFeatureTransformer(Architecture):
 
             self.global_att_embeddings_for_compression = nn.Embedding(
                 num_global_att_tokens_for_compression,
-                self.ninp,
+                self.emsize,
             )
 
             self.encoder_compression_layer = LayerStack.of_repeated_layer(
@@ -250,7 +250,7 @@ class PerFeatureTransformer(Architecture):
         self.decoder_dict = nn.ModuleDict(
             {
                 "standard": nn.Sequential(
-                    nn.Linear(self.ninp, nhid),
+                    nn.Linear(self.emsize, nhid),
                     nn.GELU(),
                     nn.Linear(nhid, n_out),
                 )
@@ -260,11 +260,11 @@ class PerFeatureTransformer(Architecture):
         self.feature_positional_embedding = config.feature_positional_embedding
         if self.feature_positional_embedding == "learned":
             self.feature_positional_embedding_embeddings = nn.Embedding(
-                1_000, self.ninp
+                1_000, self.emsize
             )
         elif self.feature_positional_embedding == "subspace":
             self.feature_positional_embedding_embeddings = nn.Linear(
-                self.ninp // 4, self.ninp
+                self.emsize // 4, self.emsize
             )
 
         self.dag_pos_enc_dim = config.dag_pos_enc_dim

--- a/src/tabpfn/architectures/base/transformer.py
+++ b/src/tabpfn/architectures/base/transformer.py
@@ -277,6 +277,11 @@ class PerFeatureTransformer(Architecture):
         state.setdefault("feature_positional_embedding", None)
         super().__setstate__(state)
 
+    @property
+    @override
+    def embedding_dim(self) -> int:
+        return self.emsize
+
     @overload
     def forward(
         self,

--- a/src/tabpfn/architectures/interface.py
+++ b/src/tabpfn/architectures/interface.py
@@ -249,9 +249,9 @@ class Architecture(nn.Module, ABC):
         )
 
     @property
+    @abstractmethod
     def embedding_dim(self) -> int:
         """Returns the dimension of the embeddings.
 
         This is the size of the embeddings that can be used for further processing.
         """
-        return self.emsize

--- a/src/tabpfn/architectures/interface.py
+++ b/src/tabpfn/architectures/interface.py
@@ -251,7 +251,9 @@ class Architecture(nn.Module, ABC):
     @property
     @abstractmethod
     def embedding_dim(self) -> int:
-        """Returns the dimension of the embeddings.
+        """The row-level embedding dimension produced by this architecture.
 
-        This is the size of the embeddings that can be used for further processing.
+        This is the size of each per-row latent representation, which can be
+        used for downstream tasks such as clustering, feature analysis, search,
+        or meta-learning.
         """

--- a/src/tabpfn/architectures/interface.py
+++ b/src/tabpfn/architectures/interface.py
@@ -247,3 +247,11 @@ class Architecture(nn.Module, ABC):
             force_recompute_layer=False,
             use_chunkwise_inference=False,
         )
+
+    @property
+    def embedding_dim(self) -> int:
+        """Returns the dimension of the embeddings.
+
+        This is the size of the embeddings that can be used for further processing.
+        """
+        return self.emsize

--- a/src/tabpfn/architectures/tabpfn_v2_5.py
+++ b/src/tabpfn/architectures/tabpfn_v2_5.py
@@ -570,7 +570,7 @@ class TabPFNV2p5(Architecture):
         self._do_encoder_nan_check = True
         # TODO(Phil): This is here to not fail the memory computation. We should make
         # this a proper API.
-        self.ninp = config.emsize
+        self.emsize = config.emsize
 
     def _get_feature_group_embedder(self, config: TabPFNV2p5Config) -> nn.Module:
         """Get the feature group embedder."""

--- a/src/tabpfn/architectures/tabpfn_v2_5.py
+++ b/src/tabpfn/architectures/tabpfn_v2_5.py
@@ -572,6 +572,11 @@ class TabPFNV2p5(Architecture):
         # this a proper API.
         self.emsize = config.emsize
 
+    @property
+    @override
+    def embedding_dim(self) -> int:
+        return self.emsize
+
     def _get_feature_group_embedder(self, config: TabPFNV2p5Config) -> nn.Module:
         """Get the feature group embedder."""
         encoding_size = config.features_per_group * ENCODING_SIZE_MULTIPLIER

--- a/src/tabpfn/architectures/tabpfn_v2_6.py
+++ b/src/tabpfn/architectures/tabpfn_v2_6.py
@@ -583,6 +583,11 @@ class TabPFNV2p6(Architecture):
         # this a proper API.
         self.emsize = config.emsize
 
+    @property
+    @override
+    def embedding_dim(self) -> int:
+        return self.emsize
+
     def _get_feature_group_embedder(self, config: TabPFNV2p6Config) -> nn.Module:
         """Get the feature group embedder."""
         encoding_size = config.features_per_group * ENCODING_SIZE_MULTIPLIER

--- a/src/tabpfn/architectures/tabpfn_v2_6.py
+++ b/src/tabpfn/architectures/tabpfn_v2_6.py
@@ -581,7 +581,7 @@ class TabPFNV2p6(Architecture):
         self._do_encoder_nan_check = True
         # TODO(Phil): This is here to not fail the memory computation. We should make
         # this a proper API.
-        self.ninp = config.emsize
+        self.emsize = config.emsize
 
     def _get_feature_group_embedder(self, config: TabPFNV2p6Config) -> nn.Module:
         """Get the feature group embedder."""

--- a/src/tabpfn/architectures/tabpfn_v3.py
+++ b/src/tabpfn/architectures/tabpfn_v3.py
@@ -1640,9 +1640,15 @@ class TabPFNV3(Architecture):
         )
         self.standard_scaler = TorchStandardScaler()
         self._nan_safe_output = True
-        self.ninp = config.embed_dim
+        self.emsize = config.embed_dim
+        self.num_cls_tokens = config.feat_agg_num_cls_tokens
         self.inference_row_chunk_size = config.inference_row_chunk_size
         self.inference_col_chunk_size = config.inference_col_chunk_size
+
+    @property
+    @override
+    def embedding_dim(self) -> int:
+        return self.icl_emsize
 
     @override
     def forward(

--- a/src/tabpfn/architectures/tabpfn_v3.py
+++ b/src/tabpfn/architectures/tabpfn_v3.py
@@ -1641,7 +1641,6 @@ class TabPFNV3(Architecture):
         self.standard_scaler = TorchStandardScaler()
         self._nan_safe_output = True
         self.emsize = config.embed_dim
-        self.num_cls_tokens = config.feat_agg_num_cls_tokens
         self.inference_row_chunk_size = config.inference_row_chunk_size
         self.inference_col_chunk_size = config.inference_col_chunk_size
 

--- a/tests/test_classifier_interface.py
+++ b/tests/test_classifier_interface.py
@@ -828,7 +828,7 @@ def test_get_embeddings(
     assert isinstance(embeddings, np.ndarray)
     assert embeddings.shape[0] == n_estimators
     assert embeddings.shape[1] == X.shape[0]
-    assert embeddings.shape[2] == model.models_[0].input_size
+    assert embeddings.shape[2] == model.models_[0].embedding_dim
 
 
 def test_pandas_output_config(X_y: tuple[np.ndarray, np.ndarray]):

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -74,7 +74,7 @@ class _TestModel(Architecture):
         return x.sum(-2, keepdim=True).sum(-1, keepdim=True).reshape(-1, test_rows)
 
     @property
-    def emsize(self) -> int:
+    def embedding_dim(self) -> int:
         return 2
 
     @property
@@ -116,7 +116,7 @@ class _TestModelLegacy(Architecture):
         return x.sum(-2, keepdim=True).sum(-1, keepdim=True).reshape(-1, test_rows)
 
     @property
-    def emsize(self) -> int:
+    def embedding_dim(self) -> int:
         return 2
 
     @property

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -74,7 +74,7 @@ class _TestModel(Architecture):
         return x.sum(-2, keepdim=True).sum(-1, keepdim=True).reshape(-1, test_rows)
 
     @property
-    def ninp(self) -> int:
+    def emsize(self) -> int:
         return 2
 
     @property
@@ -116,7 +116,7 @@ class _TestModelLegacy(Architecture):
         return x.sum(-2, keepdim=True).sum(-1, keepdim=True).reshape(-1, test_rows)
 
     @property
-    def ninp(self) -> int:
+    def emsize(self) -> int:
         return 2
 
     @property

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -113,6 +113,11 @@ class DummyArchitecture(Architecture):
     ) -> Tensor | dict[str, Tensor]:
         raise NotImplementedError()
 
+    @property
+    @override
+    def embedding_dim(self) -> int:
+        raise NotImplementedError()
+
 
 @patch.dict(ARCHITECTURES, fake_arch=FakeArchitectureModule())
 def test__load_model__architecture_name_in_checkpoint__loads_specified_architecture(

--- a/tests/test_regressor_interface.py
+++ b/tests/test_regressor_interface.py
@@ -584,7 +584,7 @@ def test_get_embeddings(
 
     # Need to access the model through the executor
     model_instance = next(iter(model.executor_.model_caches[0]._models.values()))
-    hidden_size = model_instance.ninp
+    hidden_size = model_instance.embedding_dim
 
     assert isinstance(embeddings, np.ndarray)
     assert embeddings.shape[0] == n_estimators


### PR DESCRIPTION
## Summary

- Renames `self.ninp` → `self.emsize` across all architecture classes (`PerFeatureTransformer`, `TabPFNV2p5`, `TabPFNV2p6`, `TabPFNV3`) for consistency with config field names
- Adds `embedding_dim` property to the `Architecture` base interface, backed by `self.emsize`
- `TabPFNV3` overrides `embedding_dim` to return `self.icl_emsize` (the ICL output embedding size, which is `embed_dim * feat_agg_num_cls_tokens`) since its output embedding dimension differs from the base `embed_dim`
- Updates tests and docstrings to use the new API

## Test plan

- [x] `tests/test_inference.py` — `_TestModel.emsize` and `_TestModelLegacy.emsize` renamed from `ninp`
- [x] `tests/test_regressor_interface.py` — `test_get_embeddings` uses `model_instance.embedding_dim`
- [x] `tests/test_classifier_interface.py` — `test_get_embeddings` uses `model.models_[0].embedding_dim`
- [x] All pre-commit hooks (mypy, ruff) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)