### PR TITLE
fix: add TABPFN_TOKEN to test_ubuntu_latest_314 job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,7 @@ jobs:
     env:
       TABPFN_MODEL_CACHE_DIR: ${{ github.workspace }}/model_cache
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      TABPFN_TOKEN: ${{ secrets.TABPFN_TOKEN }}
 
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v4.3.1


### PR DESCRIPTION
## Summary
- The `TABPFN_TOKEN` secret was added to other CI jobs in #912 but the `test_ubuntu_latest_314` job was missed.
- Without it, V2_5/V2_6 model downloads raise `TabPFNLicenseError`, leaving `model_cache/` in a state that breaks `hashFiles('model_cache/**')` in the save-cache step (manifesting as the cryptic `Fail to hash files under directory` template error).

## Test plan
- [ ] CI green on this PR (specifically the `Test Ubuntu-latest (Py 3.14)` job, which previously failed at the "Save model cache" step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that just exposes an existing secret to one job; the main impact is whether model downloads/caching now succeed in that workflow.
> 
> **Overview**
> Fixes CI for the `test_ubuntu_latest_314` gate by exporting `TABPFN_TOKEN` (from `secrets.TABPFN_TOKEN`) in that job’s environment.
> 
> This aligns the Py 3.14 Ubuntu job with other workflows so licensed model downloads can complete and the model cache save/hash step doesn’t fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98006efb58d8305d1c797e6b2637924a907d060b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->