### PR TITLE
Add tests that classifier/regressor pass an accuracy threshold.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,25 +31,11 @@ def set_global_seed() -> None:
     random.seed(seed)
 
 
-def _is_v3_classifier_in_cache() -> bool:
+def is_v3_classifier_in_cache() -> bool:
     cache_dir = get_cache_dir()
     return (cache_dir / ModelSource.get_classifier_v3().default_filename).exists()
 
 
-def _is_v3_regressor_in_cache() -> bool:
+def is_v3_regressor_in_cache() -> bool:
     cache_dir = get_cache_dir()
     return (cache_dir / ModelSource.get_regressor_v3().default_filename).exists()
-
-
-@pytest.fixture
-def skip_if_v3_classifier_unavailable() -> None:
-    """Skip the test when the V3 classifier model is not in the local cache."""
-    if not _is_v3_classifier_in_cache():
-        pytest.skip("V3 classifier model not in cache; skipping V3-specific test.")
-
-
-@pytest.fixture
-def skip_if_v3_regressor_unavailable() -> None:
-    """Skip the test when the V3 regressor model is not in the local cache."""
-    if not _is_v3_regressor_in_cache():
-        pytest.skip("V3 regressor model not in cache; skipping V3-specific test.")

--- a/tests/test_classifier_interface.py
+++ b/tests/test_classifier_interface.py
@@ -34,7 +34,7 @@ from tabpfn.model_loading import ModelSource, prepend_cache_path
 from tabpfn.preprocessing import PreprocessorConfig
 from tabpfn.utils import infer_devices
 
-from .conftest import _is_v3_classifier_in_cache
+from .conftest import is_v3_classifier_in_cache
 from .utils import (
     get_pytest_devices,
     is_cpu_float16_supported,
@@ -562,7 +562,7 @@ def test__fit_preprocessors_and_with_cache_produce_equal_results(
 def test__fit_preprocessors_and_low_memory_produce_equal_results(
     X_y: tuple[np.ndarray, np.ndarray], model_version: ModelVersion, device: str
 ) -> None:
-    if model_version == ModelVersion.V3 and not _is_v3_classifier_in_cache():
+    if model_version == ModelVersion.V3 and not is_v3_classifier_in_cache():
         pytest.skip("V3 classifier model not in cache; skipping V3-specific test.")
     kwargs = {
         "version": model_version,
@@ -588,6 +588,22 @@ def test__fit_preprocessors_and_low_memory_produce_equal_results(
     tabpfn.fit(X, y)
     np.testing.assert_array_almost_equal(probs, tabpfn.predict_proba(X))
     np.testing.assert_array_equal(preds, tabpfn.predict(X))
+
+
+@pytest.mark.parametrize("model_version", list(ModelVersion))
+def test__fit_and_predict__on_demo_dataset__accuracy_reasonable(
+    model_version: ModelVersion,
+) -> None:
+    if model_version == ModelVersion.V3 and not is_v3_classifier_in_cache():
+        pytest.skip("V3 classifier model not in cache.")
+
+    X, y = sklearn.datasets.load_iris(return_X_y=True)
+    model = TabPFNClassifier.create_default_for_version(
+        version=model_version, random_state=0
+    )
+    model.fit(X, y)
+    accuracy = accuracy_score(y, model.predict(X))
+    assert accuracy > 0.98
 
 
 # TODO(eddiebergman): Should probably run a larger suite with different configurations

--- a/tests/test_classifier_interface.py
+++ b/tests/test_classifier_interface.py
@@ -603,7 +603,7 @@ def test__fit_and_predict__on_demo_dataset__accuracy_reasonable(
     )
     model.fit(X, y)
     accuracy = accuracy_score(y, model.predict(X))
-    assert accuracy > 0.98
+    assert accuracy > 0.97
 
 
 # TODO(eddiebergman): Should probably run a larger suite with different configurations

--- a/tests/test_regressor_interface.py
+++ b/tests/test_regressor_interface.py
@@ -13,6 +13,7 @@ import sklearn.datasets
 import torch
 from sklearn import config_context
 from sklearn.base import check_is_fitted
+from sklearn.metrics import r2_score
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import StandardScaler
 from sklearn.utils.estimator_checks import parametrize_with_checks
@@ -27,7 +28,7 @@ from tabpfn.preprocessing import PreprocessorConfig
 from tabpfn.settings import settings
 from tabpfn.utils import infer_devices
 
-from .conftest import _is_v3_regressor_in_cache
+from .conftest import is_v3_regressor_in_cache
 from .utils import (
     get_pytest_devices,
     is_cpu_float16_supported,
@@ -314,7 +315,7 @@ def test__fit_preprocessors_and_with_cache_produce_equal_results(
 def test__fit_preprocessors_and_low_memory_produce_equal_results(
     X_y: tuple[np.ndarray, np.ndarray], model_version: ModelVersion, device: str
 ) -> None:
-    if model_version == ModelVersion.V3 and not _is_v3_regressor_in_cache():
+    if model_version == ModelVersion.V3 and not is_v3_regressor_in_cache():
         pytest.skip("V3 regressor model not in cache; skipping V3-specific test.")
     kwargs = {
         "version": model_version,
@@ -336,6 +337,22 @@ def test__fit_preprocessors_and_low_memory_produce_equal_results(
     tabpfn = TabPFNRegressor.create_default_for_version(fit_mode="low_memory", **kwargs)
     tabpfn.fit(X, y)
     np.testing.assert_array_almost_equal(preds, tabpfn.predict(X))
+
+
+@pytest.mark.parametrize("model_version", list(ModelVersion))
+def test__fit_and_predict__on_demo_dataset__r2_reasonable(
+    model_version: ModelVersion,
+) -> None:
+    if model_version == ModelVersion.V3 and not is_v3_regressor_in_cache():
+        pytest.skip("V3 regressor model not in cache.")
+
+    X, y = sklearn.datasets.make_friedman1(n_samples=200, noise=0.1, random_state=0)
+    model = TabPFNRegressor.create_default_for_version(
+        version=model_version, random_state=0
+    )
+    model.fit(X, y)
+    r2 = r2_score(y, model.predict(X))
+    assert r2 > 0.95
 
 
 def test_multiple_models_predict_different_results(


### PR DESCRIPTION
Just a quick smoke test to try and prevent regressions like https://linear.app/priorlabs/issue/PRI-277/v26-has-low-accuracy-on-mps

We'll need a different strategy to detect more subtle regressions (see https://linear.app/priorlabs/issue/RES-1530/tabpfn-continuous-benchmarking)

Fixes RES-1528