### PR TITLE
Enhance model saving functionality to include inference configuration…

### DIFF
--- a/changelog/930.fixed.md
+++ b/changelog/930.fixed.md
@@ -1,0 +1,1 @@
+Fix `save_tabpfn_model` not setting `architecture_name="tabpfn_v3"` for v3 configs and not persisting `inference_config_`, which broke resuming v3 finetuning from a saved checkpoint.

--- a/src/tabpfn/model_loading.py
+++ b/src/tabpfn/model_loading.py
@@ -1079,6 +1079,7 @@ def save_tabpfn_model(
         znorm_space_bardist = model.znorm_space_bardist_  # type: ignore
 
     configs = model.configs_
+    inference_config = getattr(model, "inference_config_", None)
     save_paths = save_path if isinstance(save_path, list) else [save_path]
 
     for ens_model, config, path in zip(
@@ -1102,6 +1103,8 @@ def save_tabpfn_model(
             "config": asdict(config),
             "architecture_name": architecture_name,
         }
+        if inference_config is not None:
+            checkpoint["inference_config"] = asdict(inference_config)
 
         if additional_fields is not None:
             checkpoint.update(additional_fields)
@@ -1225,6 +1228,8 @@ def load_fitted_tabpfn_model(
 def _resolve_architecture_name(config: ArchitectureConfig) -> str:
     """Resolve the architecture name from the config."""
     name = getattr(config, "name", "")
+    if "v3" in name:
+        return "tabpfn_v3"
     if "2.6" in name:
         return "tabpfn_v2_6"
     if "2.5" in name:

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -5,6 +5,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import asdict
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Literal, overload
 from typing_extensions import override
 from unittest.mock import patch
@@ -23,6 +24,8 @@ from tabpfn.architectures.interface import (
     ArchitectureConfig,
     ArchitectureModule,
 )
+from tabpfn.architectures.tabpfn_v3 import TabPFNV3Config
+from tabpfn.constants import ModelVersion
 from tabpfn.inference_config import InferenceConfig
 from tabpfn.preprocessing import PreprocessorConfig
 
@@ -138,6 +141,26 @@ def test__load_model__architecture_name_in_checkpoint__loads_specified_architect
     loaded_model, _, loaded_config, _ = model_loading.load_model(path=checkpoint_path)
     assert isinstance(loaded_model, DummyArchitecture)
     assert isinstance(loaded_config, FakeConfig)
+
+
+def test__save_tabpfn_model__stores_v3_architecture_and_inference_config(
+    tmp_path: Path,
+) -> None:
+    config = TabPFNV3Config(max_num_classes=10, num_buckets=100)
+    inference_config = InferenceConfig.get_default("multiclass", ModelVersion.V2_5)
+    estimator = SimpleNamespace(
+        models_=[torch.nn.Linear(1, 1)],
+        configs_=[config],
+        inference_config_=inference_config,
+    )
+    checkpoint_path = tmp_path / "checkpoint.ckpt"
+
+    model_loading.save_tabpfn_model(estimator, checkpoint_path)
+
+    checkpoint = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
+    assert checkpoint["architecture_name"] == "tabpfn_v3"
+    assert checkpoint["config"]["name"] == "TabPFN-v3"
+    assert checkpoint["inference_config"] == asdict(inference_config)
 
 
 def test__load_v2_checkpoint__returns_v2_preprocessings(


### PR DESCRIPTION

## Motivation and Context

When resuming fine-tuning with the v3 ckpts, training fails due to missing support for loading and saving the model. This PR fixes this issue. 
---

## Public API Changes

-   [ ] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?
Yes, this has been fully tested locally. 
---

## Checklist

-   [ ] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [ ] A changelog entry has been added (see `changelog/README.md`), or "no changelog needed" label requested.
-   [ ] The code follows the project's style guidelines.
-   [ ] I have considered the impact of these changes on the public API.

---
