### PR TITLE
Added Copyright Headers as a ruff rule

### DIFF
--- a/examples/finetune_classifier.py
+++ b/examples/finetune_classifier.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Example of fine-tuning a TabPFN classifier using the FinetunedTabPFNClassifier wrapper.
 
 Note: We recommend running the fine-tuning script on a CUDA-enabled GPU with 80 GB of VRAM.

--- a/examples/finetune_regressor.py
+++ b/examples/finetune_regressor.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Example of fine-tuning a TabPFN regressor using the FinetunedTabPFNRegressor wrapper.
 
 Note: We recommend running the fine-tuning script on a CUDA-enabled GPU with 80 GB of VRAM.

--- a/examples/sagemaker.py
+++ b/examples/sagemaker.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Invoke a TabPFN 2.5 model via a SageMaker Runtime endpoint.
 
 This module demonstrates how to:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,12 @@ extend-exclude = [
 # time on established project.
 extend-safe-fixes = ["ALL"]
 
+# Enable preview mode but only opt-in to preview rules we explicitly select
+# (currently: CPY001 from flake8-copyright). Without this, `CPY001` is silently
+# ignored by ruff.
+preview = true
+explicit-preview-rules = true
+
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
@@ -137,6 +143,7 @@ select = [
   "B",
   "BLE",
   "COM",
+  "CPY001", # flake8-copyright (preview rule; selected by exact code)
   "C4",
   "D",
   # "DTZ",  # One day I should know how to utilize timezones and dates...
@@ -229,10 +236,25 @@ exclude = [
   "**/*.ipynb",
 ]
 
+[tool.ruff.lint.flake8-copyright]
+# All files must carry a Prior Labs copyright header. Convention is:
+#   #  Copyright (c) Prior Labs GmbH <YEAR>.
+# The year is the year the file was first authored — it is not auto-rewritten
+#
+# Ruff's CPY001 works in two stages: `notice-rgx` matches a prefix, and `author`
+# must then immediately follow that match (after trimming whitespace). So the
+# regex anchors on `Copyright (c)` and the author config enforces that
+# "Prior Labs GmbH" comes next. The year then naturally follows.
+notice-rgx = '(?i)Copyright \(c\)'
+author = "Prior Labs GmbH"
+
 [tool.ruff.lint.per-file-ignores]
 # These files are copied without changes from extenal repositories, so ignore all rules.
 "src/tabpfn/misc/debug_versions.py" = ["ALL"]
 "src/tabpfn/misc/_sklearn_compat.py" = ["ALL"]
+
+# Open-source / externally-attributed code: do NOT add a Prior Labs copyright header.
+"src/tabpfn/preprocessing/steps/squashing_scaler_transformer.py" = ["CPY001"]
 
 "tests/*.py" = [
   "S101",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -240,11 +240,7 @@ exclude = [
 # All files must carry a Prior Labs copyright header. Convention is:
 #   #  Copyright (c) Prior Labs GmbH <YEAR>.
 # The year is the year the file was first authored — it is not auto-rewritten
-#
-# Ruff's CPY001 works in two stages: `notice-rgx` matches a prefix, and `author`
-# must then immediately follow that match (after trimming whitespace). So the
-# regex anchors on `Copyright (c)` and the author config enforces that
-# "Prior Labs GmbH" comes next. The year then naturally follows.
+
 notice-rgx = '(?i)Copyright \(c\)'
 author = "Prior Labs GmbH"
 

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Scripts package for TabPFN."""
 
 from __future__ import annotations

--- a/scripts/download_all_models.py
+++ b/scripts/download_all_models.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Download all TabPFN model files for offline use."""
 
 from __future__ import annotations

--- a/src/tabpfn/__init__.py
+++ b/src/tabpfn/__init__.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 from importlib.metadata import version
 
 from tabpfn.classifier import TabPFNClassifier

--- a/src/tabpfn/architectures/__init__.py
+++ b/src/tabpfn/architectures/__init__.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Contains a collection of different model architectures.
 
 "Architecture" refers to a PyTorch module, which is then wrapped by e.g.

--- a/src/tabpfn/architectures/base/__init__.py
+++ b/src/tabpfn/architectures/base/__init__.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """The base architecture.
 
 This is the original model before we switched to the multiple architecture arrangement.
@@ -215,7 +217,7 @@ def get_y_encoder(
 
     steps += [
         LinearInputEncoderStep(
-            num_features=sum([i["dim"] for i in inputs_to_merge]),  # type: ignore
+            num_features=sum(i["dim"] for i in inputs_to_merge),  # type: ignore
             emsize=embedding_size,
             in_keys=tuple(i["name"] for i in inputs_to_merge),  # type: ignore
             out_keys=("output",),

--- a/src/tabpfn/architectures/base/attention/__init__.py
+++ b/src/tabpfn/architectures/base/attention/__init__.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod

--- a/src/tabpfn/architectures/encoders/__init__.py
+++ b/src/tabpfn/architectures/encoders/__init__.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """DEPRECATION WARNING: Please note that this module will be deprecated in future
 versions of TabPFN in favor of a new torch-based preprocessing pipeline.
 """

--- a/src/tabpfn/architectures/encoders/steps/__init__.py
+++ b/src/tabpfn/architectures/encoders/steps/__init__.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 from .feature_group_projections_encoder_step import (
     LinearInputEncoderStep,
     MLPInputEncoderStep,

--- a/src/tabpfn/architectures/encoders/steps/_ops.py
+++ b/src/tabpfn/architectures/encoders/steps/_ops.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Custom implementations of PyTorch functions. Needed for ONNX export."""
 
 from __future__ import annotations

--- a/src/tabpfn/architectures/encoders/steps/feature_group_projections_encoder_step.py
+++ b/src/tabpfn/architectures/encoders/steps/feature_group_projections_encoder_step.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """DEPRECATED: Projections from cell-level tensors to embedding space.
 
 Please use the standalone modules like `nn.Linear` or an MLP module

--- a/src/tabpfn/architectures/encoders/steps/feature_transform_encoder_step.py
+++ b/src/tabpfn/architectures/encoders/steps/feature_transform_encoder_step.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Encoder step to normalize the input in different ways."""
 
 from __future__ import annotations

--- a/src/tabpfn/architectures/encoders/steps/frequency_feature_encoder_step.py
+++ b/src/tabpfn/architectures/encoders/steps/frequency_feature_encoder_step.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Encoder step to add frequency-based features to the input."""
 
 from __future__ import annotations

--- a/src/tabpfn/architectures/encoders/steps/multiclass_classification_target_encoder_step.py
+++ b/src/tabpfn/architectures/encoders/steps/multiclass_classification_target_encoder_step.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Encoder step to encode multiclass classification targets."""
 
 from __future__ import annotations

--- a/src/tabpfn/architectures/encoders/steps/nan_handling_encoder_step.py
+++ b/src/tabpfn/architectures/encoders/steps/nan_handling_encoder_step.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Encoder step to handle NaN and infinite values in the input."""
 
 from __future__ import annotations

--- a/src/tabpfn/architectures/encoders/steps/normalize_feature_groups_encoder_step.py
+++ b/src/tabpfn/architectures/encoders/steps/normalize_feature_groups_encoder_step.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Encoder step to handle variable number of features."""
 
 from __future__ import annotations

--- a/src/tabpfn/architectures/encoders/steps/remove_duplicate_features_encoder_step.py
+++ b/src/tabpfn/architectures/encoders/steps/remove_duplicate_features_encoder_step.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Encoder step to remove duplicate features. Note, this is a No-op currently."""
 
 from __future__ import annotations

--- a/src/tabpfn/architectures/interface.py
+++ b/src/tabpfn/architectures/interface.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Defines the interface for modules containing architectures."""
 
 from __future__ import annotations

--- a/src/tabpfn/architectures/kv_cache.py
+++ b/src/tabpfn/architectures/kv_cache.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """KV cache data structures for explicit cache passing through architectures.
 
 Provides cache containers for storing key-value projections from attention

--- a/src/tabpfn/architectures/shared/__init__.py
+++ b/src/tabpfn/architectures/shared/__init__.py
@@ -1,1 +1,3 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Shared code between the different architectures."""

--- a/src/tabpfn/architectures/shared/attention_gqa_check.py
+++ b/src/tabpfn/architectures/shared/attention_gqa_check.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Check for the enable_gqa parameter of PyTorch scaled_dot_product_attention."""
 
 from __future__ import annotations

--- a/src/tabpfn/architectures/shared/chunked_evaluate.py
+++ b/src/tabpfn/architectures/shared/chunked_evaluate.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Function for evaluating a function on a Tensor in chunks.
 
 This reduces the memory required for inference.

--- a/src/tabpfn/architectures/shared/column_embeddings.py
+++ b/src/tabpfn/architectures/shared/column_embeddings.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Function for loading the pre-generated column embeddings."""
 
 from __future__ import annotations

--- a/src/tabpfn/architectures/tabpfn_v3.py
+++ b/src/tabpfn/architectures/tabpfn_v3.py
@@ -1,4 +1,4 @@
-# ruff: noqa: PLR0912, C901
+# ruff: noqa: PLR0912, C901,
 """TabPFN v3 architecture.
 
 
@@ -19,6 +19,8 @@ Cl: number of CLS tokens
 D: head dimension
 H: num heads
 S: sequence length
+
+Copyright (c) Prior Labs GmbH 2026.
 """
 
 from __future__ import annotations

--- a/src/tabpfn/browser_auth.py
+++ b/src/tabpfn/browser_auth.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Browser-based license acceptance for TabPFN.
 
 Opens a browser to the PriorLabs login page so the user can accept the

--- a/src/tabpfn/finetuning/__init__.py
+++ b/src/tabpfn/finetuning/__init__.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Single-dataset fine-tuning wrappers for TabPFN models."""
 
 from tabpfn.finetuning.data_util import ClassifierBatch, RegressorBatch

--- a/src/tabpfn/finetuning/_torch_compat.py
+++ b/src/tabpfn/finetuning/_torch_compat.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """PyTorch compatibility helpers.
 
 This module contains small shims to keep TabPFN compatible across multiple

--- a/src/tabpfn/finetuning/data_util.py
+++ b/src/tabpfn/finetuning/data_util.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Utilities for data preparation used in fine-tuning wrappers."""
 
 from __future__ import annotations

--- a/src/tabpfn/finetuning/finetuned_base.py
+++ b/src/tabpfn/finetuning/finetuned_base.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Abstract base class for fine-tuning TabPFN models.
 
 This module provides the FinetunedTabPFNBase class, which contains shared

--- a/src/tabpfn/finetuning/finetuned_classifier.py
+++ b/src/tabpfn/finetuning/finetuned_classifier.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """A TabPFN classifier that finetunes the underlying model for a single task.
 
 This module provides the FinetunedTabPFNClassifier class, which wraps TabPFN

--- a/src/tabpfn/finetuning/finetuned_regressor.py
+++ b/src/tabpfn/finetuning/finetuned_regressor.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """A TabPFN regressor that finetunes the underlying model for a single task.
 
 This module provides the FinetunedTabPFNRegressor class, which wraps TabPFN

--- a/src/tabpfn/finetuning/logging.py
+++ b/src/tabpfn/finetuning/logging.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Protocol-based experiment logging for finetuning."""
 
 from __future__ import annotations

--- a/src/tabpfn/finetuning/train_util.py
+++ b/src/tabpfn/finetuning/train_util.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Some utility functions for training."""
 
 from __future__ import annotations

--- a/src/tabpfn/inference_tuning.py
+++ b/src/tabpfn/inference_tuning.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Inference tuning helpers for TabPFN fit/predict calls."""
 
 from __future__ import annotations

--- a/src/tabpfn/model/__init__.py
+++ b/src/tabpfn/model/__init__.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Contains references to the base architecture, for backwards compatability.
 
 DEPRECATED: import tabpfn.architectures.base instead

--- a/src/tabpfn/model/attention.py
+++ b/src/tabpfn/model/attention.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """DEPRECATED: Please import tabpfn.architectures.base.attention instead."""
 
 from __future__ import annotations

--- a/src/tabpfn/model/bar_distribution.py
+++ b/src/tabpfn/model/bar_distribution.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """DEPRECATED: Please import tabpfn.architectures.base.bar_distribution instead."""
 
 from __future__ import annotations

--- a/src/tabpfn/model/config.py
+++ b/src/tabpfn/model/config.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """DEPRECATED: Please import tabpfn.architectures.base.config instead."""
 
 from __future__ import annotations

--- a/src/tabpfn/model/encoders.py
+++ b/src/tabpfn/model/encoders.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """DEPRECATED: Please import tabpfn.architectures.encoders instead."""
 
 from __future__ import annotations

--- a/src/tabpfn/model/layer.py
+++ b/src/tabpfn/model/layer.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """DEPRECATED: Please import tabpfn.architectures.base.layer instead."""
 
 from __future__ import annotations

--- a/src/tabpfn/model/loading.py
+++ b/src/tabpfn/model/loading.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """DEPRECATED: Please import from `tabpfn.model_loading` instead."""
 
 from __future__ import annotations

--- a/src/tabpfn/model/memory.py
+++ b/src/tabpfn/model/memory.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """DEPRECATED: Please import tabpfn.architectures.base.memory instead."""
 
 from __future__ import annotations

--- a/src/tabpfn/model/mlp.py
+++ b/src/tabpfn/model/mlp.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """DEPRECATED: Please import tabpfn.architectures.base.mlp instead."""
 
 from __future__ import annotations

--- a/src/tabpfn/model/preprocessing.py
+++ b/src/tabpfn/model/preprocessing.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """DEPRECATED: Please import tabpfn.preprocessing instead."""
 
 from __future__ import annotations

--- a/src/tabpfn/model/transformer.py
+++ b/src/tabpfn/model/transformer.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """DEPRECATED: Please import tabpfn.architectures.base.transformer instead."""
 
 from __future__ import annotations

--- a/src/tabpfn/parallel_execute.py
+++ b/src/tabpfn/parallel_execute.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Parallel evaluation of a set of functions across multiple PyTorch devices."""
 
 from __future__ import annotations

--- a/src/tabpfn/preprocessing/__init__.py
+++ b/src/tabpfn/preprocessing/__init__.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 from __future__ import annotations
 
 from .clean import clean_data

--- a/src/tabpfn/preprocessing/clean.py
+++ b/src/tabpfn/preprocessing/clean.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Module for cleaning the data.
 
 These cleaning steps are performed before further preprocessing,

--- a/src/tabpfn/preprocessing/configs.py
+++ b/src/tabpfn/preprocessing/configs.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Preprocessor and ensemble config objects."""
 
 from __future__ import annotations

--- a/src/tabpfn/preprocessing/datamodel.py
+++ b/src/tabpfn/preprocessing/datamodel.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Data model for the preprocessing pipeline."""
 
 from __future__ import annotations

--- a/src/tabpfn/preprocessing/ensemble.py
+++ b/src/tabpfn/preprocessing/ensemble.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Module for generating ensemble configurations."""
 
 from __future__ import annotations

--- a/src/tabpfn/preprocessing/label_encoder.py
+++ b/src/tabpfn/preprocessing/label_encoder.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Label encoding utilities for TabPFN classifier."""
 
 from __future__ import annotations

--- a/src/tabpfn/preprocessing/modality_detection.py
+++ b/src/tabpfn/preprocessing/modality_detection.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Module to infer feature modalities: numerical, categorical, text, etc."""
 
 from __future__ import annotations

--- a/src/tabpfn/preprocessing/pipeline_factory.py
+++ b/src/tabpfn/preprocessing/pipeline_factory.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Methods to generate a preprocessing pipeline from ensemble configurations."""
 
 from __future__ import annotations

--- a/src/tabpfn/preprocessing/pipeline_interface.py
+++ b/src/tabpfn/preprocessing/pipeline_interface.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Interfaces for creating preprocessing pipelines."""
 
 from __future__ import annotations

--- a/src/tabpfn/preprocessing/presets.py
+++ b/src/tabpfn/preprocessing/presets.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Predefined preprocessor configurations for different model versions.
 
 This module provides factory functions that return preprocessor configurations

--- a/src/tabpfn/preprocessing/steps/__init__.py
+++ b/src/tabpfn/preprocessing/steps/__init__.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 from .adaptive_quantile_transformer import (
     AdaptiveQuantileTransformer,
 )

--- a/src/tabpfn/preprocessing/steps/adaptive_quantile_transformer.py
+++ b/src/tabpfn/preprocessing/steps/adaptive_quantile_transformer.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Adaptive Quantile Transformer."""
 
 from __future__ import annotations

--- a/src/tabpfn/preprocessing/steps/add_fingerprint_features_step.py
+++ b/src/tabpfn/preprocessing/steps/add_fingerprint_features_step.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Add Fingerprint Features Step."""
 
 from __future__ import annotations

--- a/src/tabpfn/preprocessing/steps/add_svd_features_step.py
+++ b/src/tabpfn/preprocessing/steps/add_svd_features_step.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Adds SVD features to the data."""
 
 from __future__ import annotations

--- a/src/tabpfn/preprocessing/steps/differentiable_z_norm_step.py
+++ b/src/tabpfn/preprocessing/steps/differentiable_z_norm_step.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Differentiable Z-Norm Step."""
 
 from __future__ import annotations

--- a/src/tabpfn/preprocessing/steps/encode_categorical_features_step.py
+++ b/src/tabpfn/preprocessing/steps/encode_categorical_features_step.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Encode Categorical Features Step."""
 
 from __future__ import annotations

--- a/src/tabpfn/preprocessing/steps/kdi_transformer.py
+++ b/src/tabpfn/preprocessing/steps/kdi_transformer.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """KDI Transformer with NaN."""
 
 from __future__ import annotations

--- a/src/tabpfn/preprocessing/steps/nan_handling_polynomial_features_step.py
+++ b/src/tabpfn/preprocessing/steps/nan_handling_polynomial_features_step.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Nan Handling Polynomial Features Step."""
 
 from __future__ import annotations

--- a/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
+++ b/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Feature Preprocessing Transformer Step."""
 
 from __future__ import annotations

--- a/src/tabpfn/preprocessing/steps/remove_constant_features_step.py
+++ b/src/tabpfn/preprocessing/steps/remove_constant_features_step.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Remove Constant Features Step."""
 
 from __future__ import annotations

--- a/src/tabpfn/preprocessing/steps/reshape_feature_distribution_step.py
+++ b/src/tabpfn/preprocessing/steps/reshape_feature_distribution_step.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Reshape the feature distributions using different transformations."""
 
 from __future__ import annotations

--- a/src/tabpfn/preprocessing/steps/safe_power_transformer.py
+++ b/src/tabpfn/preprocessing/steps/safe_power_transformer.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Safe Power Transformer."""
 
 from __future__ import annotations

--- a/src/tabpfn/preprocessing/steps/shuffle_features_step.py
+++ b/src/tabpfn/preprocessing/steps/shuffle_features_step.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Shuffle Features Step."""
 
 from __future__ import annotations

--- a/src/tabpfn/preprocessing/steps/utils.py
+++ b/src/tabpfn/preprocessing/steps/utils.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Utility functions for preprocessing steps."""
 
 from __future__ import annotations

--- a/src/tabpfn/preprocessing/torch/ops.py
+++ b/src/tabpfn/preprocessing/torch/ops.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Torch operations for preprocessing with NaN handling."""
 
 from __future__ import annotations

--- a/src/tabpfn/preprocessing/torch/torch_quantile_transformer.py
+++ b/src/tabpfn/preprocessing/torch/torch_quantile_transformer.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Torch implementation of QuantileTransformer with NaN handling."""
 
 from __future__ import annotations

--- a/src/tabpfn/preprocessing/torch/torch_soft_clip_outliers.py
+++ b/src/tabpfn/preprocessing/torch/torch_soft_clip_outliers.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Torch implementation of outlier clipping with NaN handling."""
 
 from __future__ import annotations

--- a/src/tabpfn/preprocessing/torch/torch_standard_scaler.py
+++ b/src/tabpfn/preprocessing/torch/torch_standard_scaler.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Torch implementation of StandardScaler with NaN handling."""
 
 from __future__ import annotations

--- a/src/tabpfn/preprocessing/torch/torch_svd.py
+++ b/src/tabpfn/preprocessing/torch/torch_svd.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Torch implementation of TruncatedSVD."""
 
 from __future__ import annotations

--- a/src/tabpfn/preprocessing/transform.py
+++ b/src/tabpfn/preprocessing/transform.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Module for fitting and transforming preprocessing pipelines."""
 
 from __future__ import annotations

--- a/src/tabpfn/preprocessing/type_detection.py
+++ b/src/tabpfn/preprocessing/type_detection.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Module to infer feature types."""
 
 from __future__ import annotations

--- a/src/tabpfn/settings.py
+++ b/src/tabpfn/settings.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Settings module for TabPFN configuration."""
 
 from __future__ import annotations

--- a/src/tabpfn/utils.py
+++ b/src/tabpfn/utils.py
@@ -510,9 +510,9 @@ def pad_tensors(
             tensors that are padded only along this dimension.
             If false, rows and feature dimensions are padded.
     """
-    max_size_clms = max([item.size(-1) for item in tensor_list])
+    max_size_clms = max(item.size(-1) for item in tensor_list)
     if not labels:
-        max_size_rows = max([item.size(-2) for item in tensor_list])
+        max_size_rows = max(item.size(-2) for item in tensor_list)
     ret_list = []
     for item in tensor_list:
         pad_seqence = [0, max_size_clms - item.size(-1)]

--- a/src/tabpfn/validation.py
+++ b/src/tabpfn/validation.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Module for validation logic.
 
 This includes input validation with sklearn's methods,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Pytest configuration for TabPFN tests.
 
 This module sets up global test configuration, including disabling telemetry

--- a/tests/quick_test.py
+++ b/tests/quick_test.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """TabPFN Example Usage.
 
 Toy script to check that the TabPFN is working.

--- a/tests/test_architectures/__init__.py
+++ b/tests/test_architectures/__init__.py
@@ -1,0 +1,2 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+

--- a/tests/test_architectures/test_chunked_evaluate.py
+++ b/tests/test_architectures/test_chunked_evaluate.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 from __future__ import annotations
 
 import pytest

--- a/tests/test_architectures/test_init.py
+++ b/tests/test_architectures/test_init.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Tests for tabpfn.architectures.__init__."""
 
 from __future__ import annotations

--- a/tests/test_architectures/test_tabpfn_v2_5.py
+++ b/tests/test_architectures/test_tabpfn_v2_5.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Tests for the v2.5 single-file model."""
 
 from __future__ import annotations

--- a/tests/test_architectures/test_tabpfn_v2_6.py
+++ b/tests/test_architectures/test_tabpfn_v2_6.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Tests for the v2.5 single-file model."""
 
 from __future__ import annotations

--- a/tests/test_architectures/test_tabpfn_v3.py
+++ b/tests/test_architectures/test_tabpfn_v3.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Tests for the v3 single-file model."""
 
 from __future__ import annotations

--- a/tests/test_browser_auth.py
+++ b/tests/test_browser_auth.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Tests for the browser-based license acceptance module."""
 
 from __future__ import annotations

--- a/tests/test_browser_auth.py
+++ b/tests/test_browser_auth.py
@@ -164,7 +164,7 @@ class TestVerifyToken:
                 url="",
                 code=401,
                 msg="",
-                hdrs=None,
+                hdrs=None,  # type: ignore[arg-type]
                 fp=None,  # type: ignore[arg-type]
             ),
         ):
@@ -178,7 +178,7 @@ class TestVerifyToken:
                 url="",
                 code=403,
                 msg="",
-                hdrs=None,
+                hdrs=None,  # type: ignore[arg-type]
                 fp=None,  # type: ignore[arg-type]
             ),
         ):
@@ -200,7 +200,7 @@ class TestVerifyToken:
                 url="",
                 code=500,
                 msg="",
-                hdrs=None,
+                hdrs=None,  # type: ignore[arg-type]
                 fp=None,  # type: ignore[arg-type]
             ),
         ):
@@ -486,7 +486,7 @@ class TestHeadlessCbreakLoop:
         """KeyboardInterrupt during read returns None."""
         cbreak_loop = self._import_cbreak_loop()
         fake = self._fake_stdin("")
-        fake.read = lambda _n: (_ for _ in ()).throw(KeyboardInterrupt)  # type: ignore[assignment,method-assign]
+        fake.read = lambda _n: (_ for _ in ()).throw(KeyboardInterrupt)  # type: ignore[assignment,method-assign,misc]
         monkeypatch.setattr("tabpfn.browser_auth.sys.stdin", fake)
 
         with self._patch_termios():

--- a/tests/test_classifier_interface.py
+++ b/tests/test_classifier_interface.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 from __future__ import annotations
 
 import io

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 from __future__ import annotations
 
 from dataclasses import asdict, field

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Check that the current output of the model matches reference predictions.
 
 This ensures that the output of a model does not change once it has been released, and

--- a/tests/test_debug_versions.py
+++ b/tests/test_debug_versions.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 from __future__ import annotations
 
 import io

--- a/tests/test_download_fallbacks.py
+++ b/tests/test_download_fallbacks.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 from __future__ import annotations
 
 import urllib.error

--- a/tests/test_encoders/__init__.py
+++ b/tests/test_encoders/__init__.py
@@ -1,0 +1,2 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+

--- a/tests/test_encoders/test_encoders.py
+++ b/tests/test_encoders/test_encoders.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Tests for the encoders."""
 
 from __future__ import annotations

--- a/tests/test_encoders/test_ops.py
+++ b/tests/test_encoders/test_ops.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Tests for custom PyTorch operations in encoders/ops.py."""
 
 from __future__ import annotations

--- a/tests/test_encoders/test_projections.py
+++ b/tests/test_encoders/test_projections.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Tests for the projections from cell-level tensors to embedding space."""
 
 from __future__ import annotations

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Tests that cover both the classification and regression interfaces."""
 
 from __future__ import annotations

--- a/tests/test_finetuning_classifier.py
+++ b/tests/test_finetuning_classifier.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Tests for TabPFN classifier finetuning functionality.
 
 This module contains tests for:

--- a/tests/test_finetuning_logging.py
+++ b/tests/test_finetuning_logging.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Tests for the finetuning experiment logging module."""
 
 from __future__ import annotations

--- a/tests/test_finetuning_regressor.py
+++ b/tests/test_finetuning_regressor.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Tests for TabPFN regressor finetuning functionality.
 
 This module contains regressor-specific tests for:

--- a/tests/test_ft_utils.py
+++ b/tests/test_ft_utils.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 from __future__ import annotations
 
 import numpy as np

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Test the inference engines."""
 
 from __future__ import annotations

--- a/tests/test_inference_config.py
+++ b/tests/test_inference_config.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Tests for the InferenceConfig."""
 
 from __future__ import annotations

--- a/tests/test_inference_tuning.py
+++ b/tests/test_inference_tuning.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 from __future__ import annotations
 
 import numpy as np

--- a/tests/test_model/__init__.py
+++ b/tests/test_model/__init__.py
@@ -1,0 +1,2 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+

--- a/tests/test_model/test_attention.py
+++ b/tests/test_model/test_attention.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 from __future__ import annotations
 
 import pytest

--- a/tests/test_model/test_bar_distribution.py
+++ b/tests/test_model/test_bar_distribution.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 from __future__ import annotations
 
 import pytest
@@ -70,5 +72,5 @@ def test_average_bar_distributions_into_different_one():
     ).item() == pytest.approx(1.0)
     pos = torch.tensor([new_small_d.borders[-2]])
     assert new_small_d.cdf(new_small_logits, pos).item() == pytest.approx(
-        sum([bd.cdf(lo, pos)[0].item() for bd, lo in zip(bar_dists, logits)]) / 4
+        sum(bd.cdf(lo, pos)[0].item() for bd, lo in zip(bar_dists, logits)) / 4
     )

--- a/tests/test_model/test_seperate_train_inference.py
+++ b/tests/test_model/test_seperate_train_inference.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 from __future__ import annotations
 
 import pytest

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 from __future__ import annotations
 
 import threading

--- a/tests/test_model_move_backwards_compatibility.py
+++ b/tests/test_model_move_backwards_compatibility.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 from __future__ import annotations
 
 
@@ -11,8 +13,8 @@ def test__packages_can_still_be_imported_from_old_location() -> None:
     import tabpfn.model.config  # noqa: PLC0415
     import tabpfn.model.encoders  # noqa: PLC0415
     import tabpfn.model.layer  # noqa: PLC0415
-    import tabpfn.model.loading  # noqa: PLC0415
-    import tabpfn.model.memory  # noqa: PLC0415
+    import tabpfn.model.loading  # noqa: PLC0415, F401
+    import tabpfn.model.memory  # noqa: PLC0415, F401
     import tabpfn.model.mlp  # noqa: PLC0415
     import tabpfn.model.preprocessing  # noqa: PLC0415
     import tabpfn.model.transformer  # noqa: PLC0415

--- a/tests/test_notebook_installs.py
+++ b/tests/test_notebook_installs.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Verify each example notebook resolves `tabpfn` to the latest PyPI release.
 
 Reproduces the install sequence from each `examples/notebooks/*.ipynb` in a

--- a/tests/test_parallel_execute.py
+++ b/tests/test_parallel_execute.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Tests for tabpfn.parallel_execute."""
 
 from __future__ import annotations

--- a/tests/test_preprocessing/__init__.py
+++ b/tests/test_preprocessing/__init__.py
@@ -1,0 +1,2 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+

--- a/tests/test_preprocessing/test_adaptive_quantile_transformer.py
+++ b/tests/test_preprocessing/test_adaptive_quantile_transformer.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 from __future__ import annotations
 
 import numpy as np

--- a/tests/test_preprocessing/test_add_fingerprint_features_step.py
+++ b/tests/test_preprocessing/test_add_fingerprint_features_step.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Tests for AddFingerprintFeaturesStep."""
 
 from __future__ import annotations

--- a/tests/test_preprocessing/test_add_svd_features_step.py
+++ b/tests/test_preprocessing/test_add_svd_features_step.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Tests for AddSVDFeaturesStep."""
 
 from __future__ import annotations

--- a/tests/test_preprocessing/test_data_cleaning.py
+++ b/tests/test_preprocessing/test_data_cleaning.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Tests for validation.ensure_compatible_fit_inputs function."""
 
 from __future__ import annotations

--- a/tests/test_preprocessing/test_datamodel.py
+++ b/tests/test_preprocessing/test_datamodel.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Tests for the preprocessing datamodel module."""
 
 from __future__ import annotations

--- a/tests/test_preprocessing/test_differentiable_znorm_step.py
+++ b/tests/test_preprocessing/test_differentiable_znorm_step.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 from __future__ import annotations
 
 import pytest

--- a/tests/test_preprocessing/test_encode_categorical_features_step.py
+++ b/tests/test_preprocessing/test_encode_categorical_features_step.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Tests for EncodeCategoricalFeaturesStep, focusing on feature modality handling."""
 
 from __future__ import annotations

--- a/tests/test_preprocessing/test_ensemble.py
+++ b/tests/test_preprocessing/test_ensemble.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 from __future__ import annotations
 
 import sys

--- a/tests/test_preprocessing/test_kdi_transformer.py
+++ b/tests/test_preprocessing/test_kdi_transformer.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 from __future__ import annotations
 
 import numpy as np

--- a/tests/test_preprocessing/test_label_encoder.py
+++ b/tests/test_preprocessing/test_label_encoder.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Tests for TabPFNLabelEncoder."""
 
 from __future__ import annotations

--- a/tests/test_preprocessing/test_modality_detection.py
+++ b/tests/test_preprocessing/test_modality_detection.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Tests for feature type detection functionality."""
 
 from __future__ import annotations

--- a/tests/test_preprocessing/test_nan_handling_polynomial_features_step.py
+++ b/tests/test_preprocessing/test_nan_handling_polynomial_features_step.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Tests for NanHandlingPolynomialFeaturesStep."""
 
 from __future__ import annotations

--- a/tests/test_preprocessing/test_pipeline_consistency.py
+++ b/tests/test_preprocessing/test_pipeline_consistency.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Check that preprocessing pipeline output matches reference transformations.
 
 This ensures that the preprocessing behavior does not change unintentionally

--- a/tests/test_preprocessing/test_power_transformer.py
+++ b/tests/test_preprocessing/test_power_transformer.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 from __future__ import annotations
 
 import warnings

--- a/tests/test_preprocessing/test_preprocessing_steps.py
+++ b/tests/test_preprocessing/test_preprocessing_steps.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 from __future__ import annotations
 
 import inspect

--- a/tests/test_preprocessing/test_remove_constant_features_step.py
+++ b/tests/test_preprocessing/test_remove_constant_features_step.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Tests for RemoveConstantFeaturesStep."""
 
 from __future__ import annotations

--- a/tests/test_preprocessing/test_reshape_feature_distribution_step.py
+++ b/tests/test_preprocessing/test_reshape_feature_distribution_step.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Tests for ReshapeFeatureDistributionsStep, focusing on feature modality handling."""
 
 from __future__ import annotations

--- a/tests/test_regressor_interface.py
+++ b/tests/test_regressor_interface.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 from __future__ import annotations
 
 import io

--- a/tests/test_save_load_fitted_model.py
+++ b/tests/test_save_load_fitted_model.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Test saving and loading of a fitted TabPFN classifier/regressor."""
 
 from __future__ import annotations

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/tests/test_telemetry_disabled.py
+++ b/tests/test_telemetry_disabled.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Test to verify that telemetry is disabled during test execution."""
 
 from __future__ import annotations

--- a/tests/test_thinking_tokens.py
+++ b/tests/test_thinking_tokens.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 from __future__ import annotations
 
 import torch

--- a/tests/test_torch_preprocessing/__init__.py
+++ b/tests/test_torch_preprocessing/__init__.py
@@ -1,0 +1,2 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+

--- a/tests/test_torch_preprocessing/test_gpu_preprocessing_consistency.py
+++ b/tests/test_torch_preprocessing/test_gpu_preprocessing_consistency.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Tests verifying CPU-only vs CPU+GPU preprocessing pipeline consistency.
 
 When ``enable_gpu_preprocessing=True``, the quantile transform, SVD, and shuffle

--- a/tests/test_torch_preprocessing/test_pipeline_interface.py
+++ b/tests/test_torch_preprocessing/test_pipeline_interface.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Tests for TorchPreprocessingPipeline."""
 
 from __future__ import annotations

--- a/tests/test_torch_preprocessing/test_torch_quantile_transformer.py
+++ b/tests/test_torch_preprocessing/test_torch_quantile_transformer.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Tests for TorchQuantileTransformer."""
 
 from __future__ import annotations

--- a/tests/test_torch_preprocessing/test_torch_shuffle_features_step.py
+++ b/tests/test_torch_preprocessing/test_torch_shuffle_features_step.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Tests for TorchShuffleFeaturesStep."""
 
 from __future__ import annotations

--- a/tests/test_torch_preprocessing/test_torch_soft_clip_outliers.py
+++ b/tests/test_torch_preprocessing/test_torch_soft_clip_outliers.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Tests for TorchSoftClipOutliers."""
 
 from __future__ import annotations

--- a/tests/test_torch_preprocessing/test_torch_standard_scaler.py
+++ b/tests/test_torch_preprocessing/test_torch_standard_scaler.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Tests for TorchStandardScaler."""
 
 from __future__ import annotations

--- a/tests/test_torch_preprocessing/test_torch_svd.py
+++ b/tests/test_torch_preprocessing/test_torch_svd.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 """Tests for TorchTruncatedSVD, TorchSafeStandardScaler, and AddSVDFeaturesStep."""
 
 from __future__ import annotations

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 from __future__ import annotations
 
 from dataclasses import replace

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 from __future__ import annotations
 
 from unittest.mock import MagicMock

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,5 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
 from __future__ import annotations
 
 import functools


### PR DESCRIPTION
## Issue
This PR adds a copyright notice as header of our code files.

Note: this is a lot of files changed. Most of them are just headers. Three files contain linter changes that are not header changes:

- src/tabpfn/utils.py
- tests/test_model/test_bar_distribution.py
- tests/test_model_move_backwards_compatibility.py

The result is functionally equivalent.

## Motivation and Context
The goal is to show that this code is the intellectual property of Prior Labs.

---

## Public API Changes

-   [x] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?
Ran pytest tests/

---

## Checklist

-   [x] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [x] A changelog entry has been added (see `changelog/README.md`), or "no changelog needed" label requested.
-   [ ] The code follows the project's style guidelines.
-   [x] I have considered the impact of these changes on the public API.

---
