### PR TITLE
Free unused KV heads from ICL cache backing storage

### DIFF
--- a/changelog/933.fixed.md
+++ b/changelog/933.fixed.md
@@ -1,0 +1,1 @@
+Reduce KV cache GPU memory in `fit_with_cache` by materialising only the kept KV head(s) at cache-build time. Output is unchanged.

--- a/src/tabpfn/architectures/tabpfn_v3.py
+++ b/src/tabpfn/architectures/tabpfn_v3.py
@@ -926,8 +926,11 @@ class ICLAttention(nn.Module):
             k_cache, v_cache = k, v
             if self.num_kv_heads_test is not None:
                 nh_test_heads = self.num_kv_heads_test
-                k_cache = k_cache[:, :, :nh_test_heads]
-                v_cache = v_cache[:, :, :nh_test_heads]
+                # .contiguous() so the kept slice owns its storage and the
+                # full-projection backing tensor can be freed; otherwise the
+                # cache silently retains all KV heads via the slice view.
+                k_cache = k_cache[:, :, :nh_test_heads].contiguous()
+                v_cache = v_cache[:, :, :nh_test_heads].contiguous()
             kv_entry = KVCacheEntry(key=k_cache.detach(), value=v_cache.detach())
         return result, kv_entry
 


### PR DESCRIPTION
## Summary
In `ICLAttention.forward`, when `num_kv_heads_test` is set, the cached K/V is a slice (view) of the full-projection tensor. `.detach()` does not copy, so the cache silently retains storage for all KV heads even though only the first head(s) are used for test rows. Adding `.contiguous()` materialises just the kept slice and lets the rest be freed.

Effect: KV cache GPU memory at `fit_with_cache` shrinks to the actual MQA size (no functional change).

## Test plan
- [ ] Existing unit tests (`tests/test_consistency.py`, `tests/test_inference.py`) still pass
- [ ] Verify cache `key`/`value` storage size matches the kept-head shape