### PR TITLE
Match cached train_embeddings dtype to ICL KV cache dtype

### DIFF
--- a/changelog/934.fixed.md
+++ b/changelog/934.fixed.md
@@ -1,1 +1,0 @@
-Reduce `fit_with_cache` GPU memory by storing cached `train_embeddings` at the same dtype as the ICL KV cache. Output is unchanged.

--- a/changelog/934.fixed.md
+++ b/changelog/934.fixed.md
@@ -1,0 +1,1 @@
+Reduce `fit_with_cache` GPU memory by storing cached `train_embeddings` at the same dtype as the ICL KV cache. Output is unchanged.

--- a/src/tabpfn/architectures/tabpfn_v3.py
+++ b/src/tabpfn/architectures/tabpfn_v3.py
@@ -1812,16 +1812,8 @@ class TabPFNV3(Architecture):
                 built_cache = kv_cache  # pass through unchanged
             else:
                 scaler_stats = self.standard_scaler.fit(x_RiBC[:num_train])
-                # Match train_embeddings dtype to the ICL cache K/V dtype so
-                # the cached tensor isn't kept at the (post-norm) higher
-                # precision when downstream consumers run in lower precision
-                # under autocast. .to(same_dtype) is a no-op when no cast is
-                # needed.
-                cache_dtype = (
-                    next(iter(icl_cache_out.kv.values())).key.dtype
-                    if icl_cache_out is not None and icl_cache_out.kv
-                    else train_emb.dtype
-                )
+                # Store train_embeddings at the ICL KV cache dtype.
+                cache_dtype = next(iter(icl_cache_out.kv.values())).key.dtype
                 built_cache = TabPFNV3Cache(
                     icl_cache=icl_cache_out,
                     train_embeddings=train_emb.detach().to(cache_dtype),

--- a/src/tabpfn/architectures/tabpfn_v3.py
+++ b/src/tabpfn/architectures/tabpfn_v3.py
@@ -1809,9 +1809,19 @@ class TabPFNV3(Architecture):
                 built_cache = kv_cache  # pass through unchanged
             else:
                 scaler_stats = self.standard_scaler.fit(x_RiBC[:num_train])
+                # Match train_embeddings dtype to the ICL cache K/V dtype so
+                # the cached tensor isn't kept at the (post-norm) higher
+                # precision when downstream consumers run in lower precision
+                # under autocast. .to(same_dtype) is a no-op when no cast is
+                # needed.
+                cache_dtype = (
+                    next(iter(icl_cache_out.kv.values())).key.dtype
+                    if icl_cache_out is not None and icl_cache_out.kv
+                    else train_emb.dtype
+                )
                 built_cache = TabPFNV3Cache(
                     icl_cache=icl_cache_out,
-                    train_embeddings=train_emb.detach(),
+                    train_embeddings=train_emb.detach().to(cache_dtype),
                     train_shape=(B, num_train),
                     scaler_cache={k: v.detach() for k, v in scaler_stats.items()},
                     inducing_hidden=(

--- a/src/tabpfn/architectures/tabpfn_v3.py
+++ b/src/tabpfn/architectures/tabpfn_v3.py
@@ -408,11 +408,7 @@ class ManyClassDecoder(nn.Module):
         """Perform a forward pass."""
         B, M, _ = test_embeddings.shape
         q_BME = self.q_projection(test_embeddings)
-        # Defensive: align cached train_embeddings dtype with the current
-        # q_projection output so a cache reused across precision contexts
-        # (e.g. via attribute mutation or external cache transport) doesn't
-        # error on a Linear dtype mismatch. Mirrors the guard in
-        # ICLAttention's cached path.
+        # Mirrors the dtype guard in ICLAttention's cached path.
         if train_embeddings.dtype != q_BME.dtype:
             train_embeddings = train_embeddings.to(q_BME.dtype)
         k_BNE = self.k_projection(train_embeddings)

--- a/src/tabpfn/architectures/tabpfn_v3.py
+++ b/src/tabpfn/architectures/tabpfn_v3.py
@@ -408,6 +408,13 @@ class ManyClassDecoder(nn.Module):
         """Perform a forward pass."""
         B, M, _ = test_embeddings.shape
         q_BME = self.q_projection(test_embeddings)
+        # Defensive: align cached train_embeddings dtype with the current
+        # q_projection output so a cache reused across precision contexts
+        # (e.g. via attribute mutation or external cache transport) doesn't
+        # error on a Linear dtype mismatch. Mirrors the guard in
+        # ICLAttention's cached path.
+        if train_embeddings.dtype != q_BME.dtype:
+            train_embeddings = train_embeddings.to(q_BME.dtype)
         k_BNE = self.k_projection(train_embeddings)
 
         if M == 0:


### PR DESCRIPTION
Seems to make the kv cache 12% smaller with identical output.

## Summary
`train_embeddings` is taken from the post-`output_norm` output. Under autocast, layer/RMS norms keep their output in fp32 even when the residual stream is in lower precision, so the cached tensor ends up fp32 while the K/V cache is fp16/bf16. Casting `train_embeddings` to the cache's K dtype at cache-build time aligns the storage precision with what the decoder will actually use under autocast — output is unchanged.

`.to(same_dtype)` is a no-op when no cast is needed, so this works under fp16 / bf16 / no-autocast configurations.

## Test plan
- [ ] Existing unit tests pass
- [ ] `predict_proba` output is bit-identical against the pre-change baseline on a smoke test (verified locally)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: the change only adds dtype casts to keep cached `train_embeddings` consistent with attention projection/cache dtypes under autocast, with minimal behavioral impact beyond potential tiny numeric differences.
> 
> **Overview**
> Ensures TabPFN v3’s multiclass decoder and KV-cache path use consistent dtypes under autocast.
> 
> When building a `TabPFNV3Cache`, `train_embeddings` are now cast to the ICL KV-cache key dtype before storing, and `ManyClassDecoder.forward` now casts `train_embeddings` to match the query projection dtype to avoid mixed-precision mismatches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 777f949ddf3ba87749d2ee708b89fe8b0f704ed4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->