### PR TITLE
Add FlashAttention-3 backend selector to v3

### DIFF
--- a/changelog/935.added.md
+++ b/changelog/935.added.md
@@ -1,0 +1,1 @@
+Add opt-in FlashAttention-3 backend selector for v3 (`PerformanceOptions.attention_backend`). On Hopper GPUs, "auto" routes to FA3 once the sequence length amortises FA3's dispatch overhead; otherwise falls back to PyTorch SDPA.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,8 @@ log_level = "DEBUG"
 xfail_strict = true
 addopts = "--durations=10 -vv"
 markers = [
-    "slow: slow tests that we run only on merge, rather than in PRs"
+    "slow: slow tests that we run only on merge, rather than in PRs",
+    "hopper: tests requiring a Hopper-class GPU (sm90+) and the flash_attn_interface package; skipped automatically elsewhere",
 ]
 
 # https://github.com/charliermarsh/ruff

--- a/src/tabpfn/architectures/interface.py
+++ b/src/tabpfn/architectures/interface.py
@@ -107,6 +107,21 @@ class PerformanceOptions:
     compile and autotune will be run. Tuning results are cached, so should
     persist across runs."""
 
+    attention_backend: Literal["auto", "sdpa", "fa3"] = "auto"
+    """Attention kernel selection.
+
+    - ``"auto"`` (default): prefer FlashAttention-3 when the call is eligible
+      (Hopper GPU, fp16/bf16, supported head_dim, FA3 package importable);
+      otherwise fall back to PyTorch SDPA with the standard backend list.
+    - ``"sdpa"``: always use PyTorch SDPA — same behaviour as before this option
+      existed.
+    - ``"fa3"``: force FA3. Raises ``RuntimeError`` if FA3 is not eligible for
+      a given call (e.g. wrong GPU class, head_dim, or dtype). Use only when
+      benchmarking FA3 specifically.
+
+    Architectures that don't support FA3 ignore this option silently.
+    """
+
 
 class ArchitectureModule(Protocol):
     """Interface that modules containing model architectures should implement."""

--- a/src/tabpfn/architectures/interface.py
+++ b/src/tabpfn/architectures/interface.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import dataclasses
 from abc import ABC, abstractmethod
 from dataclasses import asdict
+from enum import Enum
 from typing import Any, Literal, Protocol, overload
 from typing_extensions import override
 
@@ -52,6 +53,19 @@ def _get_unused_items(
             if len(subconfig_unused) > 0:
                 unused[k] = subconfig_unused
     return unused
+
+
+class AttentionBackend(str, Enum):
+    """Attention kernel selection for :attr:`PerformanceOptions.attention_backend`.
+
+    The class is a ``str``-mixin so members compare equal to their underlying
+    string value (``AttentionBackend.AUTO == "auto"``); callers may pass either
+    enum members or the bare strings.
+    """
+
+    AUTO = "auto"
+    SDPA = "sdpa"
+    FA3 = "fa3"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -107,19 +121,22 @@ class PerformanceOptions:
     compile and autotune will be run. Tuning results are cached, so should
     persist across runs."""
 
-    attention_backend: Literal["auto", "sdpa", "fa3"] = "auto"
+    attention_backend: AttentionBackend = AttentionBackend.AUTO
     """Attention kernel selection.
 
-    - ``"auto"`` (default): prefer FlashAttention-3 when the call is eligible
-      (Hopper GPU, fp16/bf16, supported head_dim, FA3 package importable);
-      otherwise fall back to PyTorch SDPA with the standard backend list.
-    - ``"sdpa"``: always use PyTorch SDPA — same behaviour as before this option
-      existed.
-    - ``"fa3"``: force FA3. Raises ``RuntimeError`` if FA3 is not eligible for
-      a given call (e.g. wrong GPU class, head_dim, or dtype). Use only when
-      benchmarking FA3 specifically.
+    - :attr:`AttentionBackend.AUTO` (default): prefer FlashAttention-3 when the
+      call is eligible (Hopper GPU, fp16/bf16, supported head_dim, FA3 package
+      importable); otherwise fall back to PyTorch SDPA with the standard
+      backend list.
+    - :attr:`AttentionBackend.SDPA`: always use PyTorch SDPA — same behaviour
+      as before this option existed.
+    - :attr:`AttentionBackend.FA3`: force FA3. Raises ``RuntimeError`` if FA3
+      is not eligible for a given call (e.g. wrong GPU class, head_dim, or
+      dtype). Use only when benchmarking FA3 specifically.
 
-    Architectures that don't support FA3 ignore this option silently.
+    The enum is a ``str``-mixin, so the literal strings ``"auto"``, ``"sdpa"``
+    and ``"fa3"`` are also accepted. Architectures that don't support FA3
+    ignore this option silently.
     """
 
 

--- a/src/tabpfn/architectures/shared/fa3_backend.py
+++ b/src/tabpfn/architectures/shared/fa3_backend.py
@@ -1,0 +1,128 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
+"""FlashAttention-3 (Hopper) backend availability and dispatch.
+
+FA3 ships as the ``flash_attn_interface`` package built from the ``hopper/``
+directory of Dao-AILab/flash-attention. It is Hopper-only (sm_90 WGMMA/TMA);
+Blackwell will need FA4. See ``fa3_setup.md`` next to this file for build
+instructions. FA3 supports head dims ``{64, 96, 128, 192, 256}`` and requires
+fp16/bf16 inputs.
+"""
+
+from __future__ import annotations
+
+import functools
+from typing import Callable
+
+import torch
+
+_HOPPER_COMPUTE_CAPABILITY_MAJOR = 9
+_FA3_SUPPORTED_HEAD_DIMS = frozenset({64, 96, 128, 192, 256})
+
+# Below this Q/K sequence length, FA3's per-call dispatch overhead exceeds
+# its kernel-throughput win, so SDPA is faster end-to-end. Used by
+# ``is_fa3_preferred_for`` to gate the ``auto`` dispatch only — forcing
+# ``attention_backend="fa3"`` still routes to FA3 below the threshold.
+# Crossover measured on H100 + v3 ICL self-attention: SDPA wins at n_train=1k
+# by 10-15%; FA3 wins at n_train=10k (decisively at n_features=10, ~parity at
+# n_features=100/500); FA3 wins uniformly from n_train=100k upward.
+_FA3_MIN_SEQLEN_FOR_SPEEDUP = 10_000
+
+
+@functools.cache
+def _load_fa3_func() -> Callable | None:
+    """Lazily import ``flash_attn_interface.flash_attn_func``; ``None`` if missing."""
+    try:
+        from flash_attn_interface import (  # type: ignore[import-not-found]  # noqa: PLC0415
+            flash_attn_func,
+        )
+    except ImportError:
+        return None
+    return flash_attn_func
+
+
+def is_fa3_importable() -> bool:
+    """True iff the FA3 Hopper Python package (``flash_attn_interface``) imports."""
+    return _load_fa3_func() is not None
+
+
+@functools.cache
+def _is_hopper(device: torch.device) -> bool:
+    """True iff ``device`` is an Nvidia Hopper GPU (compute capability 9.x)."""
+    # Reject ROCm: torch.cuda.is_available() is True on ROCm and gfx90a reports
+    # capability (9, 0) — same as Hopper sm_90 — but FA3 is Nvidia/CUDA only.
+    if torch.version.hip is not None:
+        return False
+    if not torch.cuda.is_available() or device.type != "cuda":
+        return False
+    cap = torch.cuda.get_device_capability(device)
+    return cap[0] == _HOPPER_COMPUTE_CAPABILITY_MAJOR
+
+
+def is_fa3_eligible_for(q: torch.Tensor) -> bool:
+    """True iff FA3 can serve this attention call (capability gate, not perf)."""
+    if not is_fa3_importable():
+        return False
+    if not q.is_cuda:
+        return False
+    if not _is_hopper(q.device):
+        return False
+    if q.dtype not in (torch.float16, torch.bfloat16):
+        return False
+    head_dim = q.shape[-1]
+    return head_dim in _FA3_SUPPORTED_HEAD_DIMS
+
+
+def is_fa3_preferred_for(q: torch.Tensor, k: torch.Tensor) -> bool:
+    """True iff FA3 is eligible and past the speedup threshold.
+
+    Compares ``max(seq_q, seq_kv)`` against :data:`_FA3_MIN_SEQLEN_FOR_SPEEDUP`.
+    """
+    if not is_fa3_eligible_for(q):
+        return False
+    # max(seq_q, seq_kv) so cross-attention with small Q against a large K
+    # (test queries vs train cache) still routes through FA3.
+    return max(q.shape[1], k.shape[1]) >= _FA3_MIN_SEQLEN_FOR_SPEEDUP
+
+
+def fa3_unavailable_reason(q: torch.Tensor) -> str:
+    """Human-readable explanation of why FA3 cannot be used for this call."""
+    if not is_fa3_importable():
+        return (
+            "FA3 package 'flash_attn_interface' not importable; "
+            "see fa3_setup.md (next to this file) to build from source on Hopper."
+        )
+    if not q.is_cuda:
+        return f"FA3 requires CUDA tensors; got device {q.device}."
+    if not _is_hopper(q.device):
+        return (
+            "FA3 requires a Hopper Nvidia GPU (H100/H200, compute capability "
+            "9.x). Blackwell needs FlashAttention-4, a separate toolchain."
+        )
+    if q.dtype not in (torch.float16, torch.bfloat16):
+        return f"FA3 requires fp16/bf16; got {q.dtype}."
+    head_dim = q.shape[-1]
+    if head_dim not in _FA3_SUPPORTED_HEAD_DIMS:
+        return (
+            f"FA3 supports head_dim in {sorted(_FA3_SUPPORTED_HEAD_DIMS)}; "
+            f"got {head_dim}."
+        )
+    return ""  # eligible
+
+
+def fa3_attn_func(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+) -> torch.Tensor:
+    """Call ``flash_attn_func`` with the v3 attention layout (B, S, H, D).
+
+    GQA is handled natively by FA3 when ``nheads_q % nheads_k == 0``.
+    """
+    fn = _load_fa3_func()
+    if fn is None:
+        raise RuntimeError(
+            "FA3 path requested but flash_attn_interface is not importable; "
+            "see fa3_setup.md (next to this file)."
+        )
+    return fn(q, k, v)

--- a/src/tabpfn/architectures/shared/fa3_setup.md
+++ b/src/tabpfn/architectures/shared/fa3_setup.md
@@ -1,0 +1,135 @@
+# FlashAttention-3 (Hopper) backend
+
+TabPFN v3 can dispatch attention to FlashAttention-3 instead of PyTorch's
+SDPA. FA3 is expected to be meaningfully faster on Hopper-class GPUs
+(H100, H200): an externally contributed micro-benchmark on v2.5 attention
+shapes reported ~1.5–1.7× over SDPA (we plan to re-run this internally
+before citing in the v3 model report). v3 numbers will land alongside the
+v3 report itself.
+
+This is **opt-in**. Default is `attention_backend="auto"`, which uses FA3
+when eligible and SDPA otherwise.
+
+## When FA3 is used
+
+The dispatcher routes a call to FA3 only when **all** of the following hold:
+
+- The `flash_attn_interface` Python package is importable.
+- The attention is on a CUDA tensor whose device is Hopper-class
+  (compute capability 9.0+).
+- The dtype is `torch.float16` or `torch.bfloat16`.
+- The head dimension is one of `{64, 96, 128, 192, 256}`.
+
+Calls that don't satisfy these (e.g. v3's `dist_embedder` with head_dim=16)
+fall back to SDPA in `auto` mode, or raise in `fa3` mode.
+
+### `auto` also applies a sequence-length threshold
+
+Beyond the capability gates above, `auto` mode additionally requires
+`max(seq_q, seq_kv) >= _FA3_MIN_SEQLEN_FOR_SPEEDUP` (currently `10_000`,
+defined in `fa3_backend.py`). Below that threshold, FA3's per-call
+dispatch overhead exceeds its kernel-throughput win and SDPA is faster
+end-to-end — so `auto` falls back to SDPA. The threshold is a pure
+performance tuning, not a capability gate, and is therefore **bypassed
+when `attention_backend="fa3"` is forced** (force still requires the
+capability gates, but always picks FA3 once those pass, even on small
+shapes).
+
+The 10 000 crossover comes from a v3 forward-pass H100 benchmark: SDPA wins
+by 10–15 % at `n_train=1k`; FA3 starts to win at `n_train=10k` (decisively
+at `n_features=10`, near parity at `n_features=100/500`); FA3 wins uniformly
+from `n_train=100k` upward, reaching 1.49–1.73× at `n_train=10⁶`. Update the
+constant if later kernels move the crossover.
+
+`max(seq_q, seq_kv)` rather than `seq_q` alone so cross-attention with
+small queries against a large support set (e.g. test rows querying a
+million-row train cache) still routes through FA3 — the per-call work
+there is dominated by the K/V side and amortises FA3's overhead.
+
+## Building the FA3 wheel
+
+FA3 is not on PyPI — it's built from source against your CUDA toolkit.
+
+### On a Hopper machine (in-place install)
+
+```bash
+git clone https://github.com/Dao-AILab/flash-attention.git
+cd flash-attention/hopper
+python setup.py install
+```
+
+This installs `flash_attn_interface`. Verify with:
+
+```python
+from flash_attn_interface import flash_attn_func  # noqa: F401
+```
+
+### Cross-compile on a non-Hopper / no-GPU node
+
+You can build the wheel on a CPU-only build node (a VM or login node with
+the CUDA toolkit but no GPU attached) and run it on an H100 elsewhere. Tell
+`nvcc` the target arch explicitly so it doesn't introspect the build host's
+GPU:
+
+```bash
+export TORCH_CUDA_ARCH_LIST="9.0a"   # FA3 uses sm_90a (WGMMA + TMA)
+export MAX_JOBS=4                     # tune to login-node RAM (~32 GB needed)
+
+git clone https://github.com/Dao-AILab/flash-attention.git
+cd flash-attention/hopper
+pip wheel . --no-build-isolation -w /tmp/fa3-wheel/
+```
+
+`pip wheel` produces a transferable `.whl` (preferable to
+`python setup.py install`, which installs in place on the build node).
+On the H100 node:
+
+```bash
+pip install /tmp/fa3-wheel/flash_attn_3-*.whl
+python -c "from flash_attn_interface import flash_attn_func; print('ok')"
+```
+
+The build node and runtime node must agree on:
+
+- **CUDA toolkit major version** — ≥ 12.3 for FA3 hopper (12.4+ recommended).
+  The login node needs the toolkit installed; the H100 node only needs a
+  compatible driver.
+- **PyTorch version + Python minor version** — build against the same
+  `torch` wheel that the runtime env will use.
+- **glibc** — usually fine when build and runtime nodes share an image; can
+  bite when they diverge.
+
+Build takes ~30–60 min and ~32 GB RAM; cache the wheel on shared storage so
+later H100 nodes can `pip install` directly without rebuilding.
+
+## Selecting the backend
+
+Pass `attention_backend` via `PerformanceOptions`:
+
+```python
+from tabpfn.architectures.interface import PerformanceOptions
+
+# Auto: FA3 if eligible, SDPA otherwise (recommended)
+options = PerformanceOptions(attention_backend="auto")
+
+# Force SDPA — useful for A/B comparison
+options = PerformanceOptions(attention_backend="sdpa")
+
+# Force FA3 — raises RuntimeError if ineligible. Bypasses the
+# auto-mode seqlen threshold, so FA3 will run even at small shapes
+# where SDPA would win — useful for A/B comparison and for users
+# who know their workload sits above the crossover anyway.
+options = PerformanceOptions(attention_backend="fa3")
+
+model(x, y, performance_options=options)
+```
+
+The setting applies for the duration of one `forward()` call only.
+
+## Numerical equivalence
+
+`tests/test_architectures/test_attention_backends.py` carries Hopper-marked
+tests (`@pytest.mark.hopper`) that assert FA3 matches SDPA within
+`atol=rtol=5e-3` on fp16/bf16 over v3's attention shapes. They skip on
+non-Hopper hosts; run them manually on an H100 until a Hopper CI runner is
+in place.

--- a/src/tabpfn/architectures/shared/fa3_setup.md
+++ b/src/tabpfn/architectures/shared/fa3_setup.md
@@ -1,14 +1,15 @@
 # FlashAttention-3 (Hopper) backend
 
 TabPFN v3 can dispatch attention to FlashAttention-3 instead of PyTorch's
-SDPA. FA3 is expected to be meaningfully faster on Hopper-class GPUs
-(H100, H200): an externally contributed micro-benchmark on v2.5 attention
-shapes reported ~1.5–1.7× over SDPA (we plan to re-run this internally
-before citing in the v3 model report). v3 numbers will land alongside the
-v3 report itself.
+SDPA. On Hopper-class GPUs (H100, H200), FA3 outperforms SDPA above a
+sequence-length crossover empirically measured on v3 ICL self-attention —
+see the comment on `_FA3_MIN_SEQLEN_FOR_SPEEDUP` in `fa3_backend.py` (next
+to this file) for the measured numbers and the [auto-mode threshold
+section](#auto-also-applies-a-sequence-length-threshold) below for how the
+constant is applied at dispatch time.
 
-This is **opt-in**. Default is `attention_backend="auto"`, which uses FA3
-when eligible and SDPA otherwise.
+This is **opt-in**. Default is `AttentionBackend.AUTO`, which uses FA3 when
+eligible and SDPA otherwise.
 
 ## When FA3 is used
 
@@ -104,22 +105,24 @@ later H100 nodes can `pip install` directly without rebuilding.
 
 ## Selecting the backend
 
-Pass `attention_backend` via `PerformanceOptions`:
+Pass `attention_backend` via `PerformanceOptions`. The
+`AttentionBackend` enum is a `str`-mixin, so the bare strings `"auto"`,
+`"sdpa"` and `"fa3"` are also accepted.
 
 ```python
-from tabpfn.architectures.interface import PerformanceOptions
+from tabpfn.architectures.interface import AttentionBackend, PerformanceOptions
 
 # Auto: FA3 if eligible, SDPA otherwise (recommended)
-options = PerformanceOptions(attention_backend="auto")
+options = PerformanceOptions(attention_backend=AttentionBackend.AUTO)
 
 # Force SDPA — useful for A/B comparison
-options = PerformanceOptions(attention_backend="sdpa")
+options = PerformanceOptions(attention_backend=AttentionBackend.SDPA)
 
 # Force FA3 — raises RuntimeError if ineligible. Bypasses the
 # auto-mode seqlen threshold, so FA3 will run even at small shapes
 # where SDPA would win — useful for A/B comparison and for users
 # who know their workload sits above the crossover anyway.
-options = PerformanceOptions(attention_backend="fa3")
+options = PerformanceOptions(attention_backend=AttentionBackend.FA3)
 
 model(x, y, performance_options=options)
 ```

--- a/src/tabpfn/architectures/tabpfn_v3.py
+++ b/src/tabpfn/architectures/tabpfn_v3.py
@@ -30,7 +30,7 @@ import logging as _logging
 import math
 from collections.abc import Callable
 from functools import partial
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 from typing_extensions import override
 
 import numpy as np
@@ -49,6 +49,12 @@ from tabpfn.architectures.interface import (
 from tabpfn.architectures.kv_cache import KVCache, KVCacheEntry
 from tabpfn.architectures.shared.attention_gqa_check import gqa_is_supported
 from tabpfn.architectures.shared.chunked_evaluate import chunked_evaluate_maybe_inplace
+from tabpfn.architectures.shared.fa3_backend import (
+    fa3_attn_func,
+    fa3_unavailable_reason,
+    is_fa3_eligible_for,
+    is_fa3_preferred_for,
+)
 from tabpfn.preprocessing.torch.torch_standard_scaler import TorchStandardScaler
 
 if TYPE_CHECKING:
@@ -264,6 +270,10 @@ _SDPA_BACKENDS = [
     SDPBackend.CUDNN_ATTENTION,
 ]
 _SDPA_BACKENDS_CPU = [*_SDPA_BACKENDS, SDPBackend.MATH]
+
+
+AttentionBackend = Literal["auto", "sdpa", "fa3"]
+
 
 # ---------------------------------------------------------------------------
 # Utility helpers
@@ -634,12 +644,31 @@ def _batched_scaled_dot_product_attention(
     v_BSJD: torch.Tensor,
     softmax_scaling_layer: nn.Module | None = None,
     _backends_override: list[SDPBackend] | None = None,
+    *,
+    attention_backend: AttentionBackend = "sdpa",
 ) -> torch.Tensor:
     """Scaled dot-product attention chunked over the batch dimension.
 
     For large batch sizes (> CUDA max-grid), we split into sub-batches.
     Softmax scaling is applied to queries before the SDPA call when provided.
+
+    ``attention_backend``:
+
+    - ``"auto"``: use FA3 if eligible (Hopper, fp16/bf16, supported head_dim,
+      FA3 importable) AND :func:`is_fa3_preferred_for` is True; else SDPA.
+    - ``"sdpa"`` (default): always SDPA.
+    - ``"fa3"``: force FA3; raise if ineligible (bypasses seqlen threshold).
     """
+    if attention_backend == "fa3":
+        if not is_fa3_eligible_for(q_BSHD):
+            raise RuntimeError(
+                "attention_backend='fa3' was requested but FA3 is not "
+                f"eligible for this call: {fa3_unavailable_reason(q_BSHD)}"
+            )
+        return _fa3_attention(q_BSHD, k_BSJD, v_BSJD, softmax_scaling_layer)
+    if attention_backend == "auto" and is_fa3_preferred_for(q_BSHD, k_BSJD):
+        return _fa3_attention(q_BSHD, k_BSJD, v_BSJD, softmax_scaling_layer)
+
     q_BHSD = q_BSHD.permute(0, 2, 1, 3)
     k_BJSD = k_BSJD.permute(0, 2, 1, 3)
     v_BJSD = v_BSJD.permute(0, 2, 1, 3)
@@ -693,6 +722,32 @@ def _batched_scaled_dot_product_attention(
             )
     output_BHSD = outputs[0] if len(outputs) == 1 else torch.cat(outputs)
     return output_BHSD.permute(0, 2, 1, 3)
+
+
+def _fa3_attention(
+    q_BSHD: torch.Tensor,
+    k_BSJD: torch.Tensor,
+    v_BSJD: torch.Tensor,
+    softmax_scaling_layer: nn.Module | None,
+) -> torch.Tensor:
+    """Run attention via FA3, preserving (B, S, H, D) layout. GQA is native.
+
+    ``softmax_scaling_layer`` (if any) operates in (B, H, S, D), hence the
+    permutes around it.
+    """
+    assert q_BSHD.dim() == 4, (
+        f"FA3 expects (B, S, H, D); got tensor of shape {tuple(q_BSHD.shape)}"
+    )
+    assert k_BSJD.dim() == 4
+    assert v_BSJD.dim() == 4
+    if softmax_scaling_layer is not None:
+        q_BHSD = q_BSHD.permute(0, 2, 1, 3)
+        src_len = k_BSJD.shape[1]
+        q_BHSD = softmax_scaling_layer(q_BHSD, src_len)
+        q_BSHD = q_BHSD.permute(0, 2, 1, 3).contiguous()
+    else:
+        q_BSHD = q_BSHD.contiguous()
+    return fa3_attn_func(q_BSHD, k_BSJD.contiguous(), v_BSJD.contiguous())
 
 
 # ---------------------------------------------------------------------------
@@ -849,6 +904,7 @@ class ICLAttention(nn.Module):
         *,
         cached_kv: KVCacheEntry | None = None,
         return_kv: bool = False,
+        attention_backend: AttentionBackend = "sdpa",
     ) -> tuple[torch.Tensor, KVCacheEntry | None]:
         """Self-attention where k/v are restricted to train rows.
 
@@ -862,6 +918,8 @@ class ICLAttention(nn.Module):
                 directly.
             return_kv: If True, also return the computed K/V as a
                 :class:`KVCacheEntry`.
+            attention_backend: Backend selector forwarded to
+                :func:`_batched_scaled_dot_product_attention`.
 
         Returns:
             ``(output, kv_entry)`` where ``kv_entry`` is ``None`` unless
@@ -889,7 +947,11 @@ class ICLAttention(nn.Module):
                 assert k.shape[2] == nh_test_heads, "cached key has wrong num heads"
                 assert v.shape[2] == nh_test_heads, "cached value has wrong num heads"
             out = _batched_scaled_dot_product_attention(
-                q, k, v, softmax_scaling_layer=self.softmax_scaling_layer
+                q,
+                k,
+                v,
+                softmax_scaling_layer=self.softmax_scaling_layer,
+                attention_backend=attention_backend,
             )
         else:
             N = R if single_eval_pos is None else single_eval_pos
@@ -904,7 +966,11 @@ class ICLAttention(nn.Module):
             ):
                 # Train rows: full KV heads
                 out_train = _batched_scaled_dot_product_attention(
-                    q[:, :N], k, v, softmax_scaling_layer=self.softmax_scaling_layer
+                    q[:, :N],
+                    k,
+                    v,
+                    softmax_scaling_layer=self.softmax_scaling_layer,
+                    attention_backend=attention_backend,
                 )
                 # Test rows: fewer KV heads (GQA / MQA)
                 nh_test_heads = self.num_kv_heads_test
@@ -913,11 +979,16 @@ class ICLAttention(nn.Module):
                     k[:, :, :nh_test_heads],
                     v[:, :, :nh_test_heads],
                     softmax_scaling_layer=self.softmax_scaling_layer,
+                    attention_backend=attention_backend,
                 )
                 out = torch.cat([out_train, out_test], dim=1)
             else:
                 out = _batched_scaled_dot_product_attention(
-                    q, k, v, softmax_scaling_layer=self.softmax_scaling_layer
+                    q,
+                    k,
+                    v,
+                    softmax_scaling_layer=self.softmax_scaling_layer,
+                    attention_backend=attention_backend,
                 )
 
         result = self.out_projection(out.reshape(B, R, self.head_dim * self.num_heads))
@@ -1120,6 +1191,7 @@ class ICLTransformerBlock(nn.Module):
         *,
         cached_kv: KVCacheEntry | None = None,
         return_kv: bool = False,
+        attention_backend: AttentionBackend = "sdpa",
     ) -> tuple[torch.Tensor, KVCacheEntry | None]:
         """Forward pass with optional KV cache support.
 
@@ -1129,6 +1201,7 @@ class ICLTransformerBlock(nn.Module):
             save_peak_memory_factor: Chunking factor for memory saving.
             cached_kv: Pre-computed K/V for this layer.
             return_kv: If True, also return the K/V cache entry.
+            attention_backend: Backend selector forwarded to ``ICLAttention``.
 
         Returns:
             ``(output, kv_entry)`` where ``kv_entry`` is ``None`` unless
@@ -1142,6 +1215,7 @@ class ICLTransformerBlock(nn.Module):
                 self.layernorm(x_BRE),
                 single_eval_pos=single_eval_pos,
                 return_kv=True,
+                attention_backend=attention_backend,
             )
             x_BRE = x_BRE + attn_out
         elif cached_kv is not None:
@@ -1155,6 +1229,7 @@ class ICLTransformerBlock(nn.Module):
                     self.layernorm(x),
                     single_eval_pos=single_eval_pos,
                     cached_kv=cached_kv,
+                    attention_backend=attention_backend,
                 )
                 return out
 
@@ -1175,6 +1250,7 @@ class ICLTransformerBlock(nn.Module):
                 out, _ = self.icl_attention(
                     self.layernorm(x),
                     single_eval_pos=single_eval_pos,
+                    attention_backend=attention_backend,
                 )
                 return out
 
@@ -1697,6 +1773,7 @@ class TabPFNV3(Architecture):
         """
         del task_type
         del test_targets_MB
+        del categorical_inds
         if isinstance(x, dict):
             x = x["main"]
         if isinstance(y, dict):
@@ -1721,8 +1798,6 @@ class TabPFNV3(Architecture):
                 "x_is_test_only=True requires kv_cache to be provided; "
                 "the non-cache forward needs the full train+test tensor."
             )
-
-        del categorical_inds
 
         if (
             not self.training
@@ -1756,6 +1831,7 @@ class TabPFNV3(Architecture):
 
         icl_cache_out: KVCache | None = None  # Populated if return_kv_cache is True.
 
+        attention_backend = performance_options.attention_backend
         if kv_cache is not None and not kv_cache.is_empty():
             # Cache path: no y_icl embedding; use cached K/V pairs
             for layer_idx, block in enumerate(self.icl_blocks):
@@ -1764,6 +1840,7 @@ class TabPFNV3(Architecture):
                     0,
                     performance_options.save_peak_memory_factor,
                     cached_kv=kv_cache.icl_cache.kv[layer_idx],
+                    attention_backend=attention_backend,
                 )
         else:
             if num_train > 0:
@@ -1779,6 +1856,7 @@ class TabPFNV3(Architecture):
                         num_train,
                         performance_options.save_peak_memory_factor,
                         return_kv=True,
+                        attention_backend=attention_backend,
                     )
                     icl_cache_out.kv[layer_idx] = kv_entry
             else:
@@ -1790,12 +1868,14 @@ class TabPFNV3(Architecture):
                             num_train,
                             use_reentrant=False,
                             save_peak_memory_factor=performance_options.save_peak_memory_factor,
+                            attention_backend=attention_backend,
                         )
                     else:
                         x_BRiD, _ = block(
                             x_BRiD,
                             num_train,
                             performance_options.save_peak_memory_factor,
+                            attention_backend=attention_backend,
                         )
 
         x_BRiD = self.output_norm(x_BRiD)

--- a/src/tabpfn/architectures/tabpfn_v3.py
+++ b/src/tabpfn/architectures/tabpfn_v3.py
@@ -30,7 +30,7 @@ import logging as _logging
 import math
 from collections.abc import Callable
 from functools import partial
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, cast
 from typing_extensions import override
 
 import numpy as np
@@ -44,6 +44,7 @@ from torch.nn.attention import SDPBackend, sdpa_kernel
 from tabpfn.architectures.interface import (
     Architecture,
     ArchitectureConfig,
+    AttentionBackend,
     PerformanceOptions,
 )
 from tabpfn.architectures.kv_cache import KVCache, KVCacheEntry
@@ -270,9 +271,6 @@ _SDPA_BACKENDS = [
     SDPBackend.CUDNN_ATTENTION,
 ]
 _SDPA_BACKENDS_CPU = [*_SDPA_BACKENDS, SDPBackend.MATH]
-
-
-AttentionBackend = Literal["auto", "sdpa", "fa3"]
 
 
 # ---------------------------------------------------------------------------
@@ -645,7 +643,7 @@ def _batched_scaled_dot_product_attention(
     softmax_scaling_layer: nn.Module | None = None,
     _backends_override: list[SDPBackend] | None = None,
     *,
-    attention_backend: AttentionBackend = "sdpa",
+    attention_backend: AttentionBackend = AttentionBackend.SDPA,
 ) -> torch.Tensor:
     """Scaled dot-product attention chunked over the batch dimension.
 
@@ -654,19 +652,23 @@ def _batched_scaled_dot_product_attention(
 
     ``attention_backend``:
 
-    - ``"auto"``: use FA3 if eligible (Hopper, fp16/bf16, supported head_dim,
-      FA3 importable) AND :func:`is_fa3_preferred_for` is True; else SDPA.
-    - ``"sdpa"`` (default): always SDPA.
-    - ``"fa3"``: force FA3; raise if ineligible (bypasses seqlen threshold).
+    - :attr:`AttentionBackend.AUTO`: use FA3 if eligible (Hopper, fp16/bf16,
+      supported head_dim, FA3 importable) AND :func:`is_fa3_preferred_for` is
+      True; else SDPA.
+    - :attr:`AttentionBackend.SDPA` (default): always SDPA.
+    - :attr:`AttentionBackend.FA3`: force FA3; raise if ineligible (bypasses
+      seqlen threshold).
     """
-    if attention_backend == "fa3":
+    if attention_backend == AttentionBackend.FA3:
         if not is_fa3_eligible_for(q_BSHD):
             raise RuntimeError(
-                "attention_backend='fa3' was requested but FA3 is not "
-                f"eligible for this call: {fa3_unavailable_reason(q_BSHD)}"
+                "AttentionBackend.FA3 was requested but FA3 is not eligible "
+                f"for this call: {fa3_unavailable_reason(q_BSHD)}"
             )
         return _fa3_attention(q_BSHD, k_BSJD, v_BSJD, softmax_scaling_layer)
-    if attention_backend == "auto" and is_fa3_preferred_for(q_BSHD, k_BSJD):
+    if attention_backend == AttentionBackend.AUTO and is_fa3_preferred_for(
+        q_BSHD, k_BSJD
+    ):
         return _fa3_attention(q_BSHD, k_BSJD, v_BSJD, softmax_scaling_layer)
 
     q_BHSD = q_BSHD.permute(0, 2, 1, 3)
@@ -744,10 +746,8 @@ def _fa3_attention(
         q_BHSD = q_BSHD.permute(0, 2, 1, 3)
         src_len = k_BSJD.shape[1]
         q_BHSD = softmax_scaling_layer(q_BHSD, src_len)
-        q_BSHD = q_BHSD.permute(0, 2, 1, 3).contiguous()
-    else:
-        q_BSHD = q_BSHD.contiguous()
-    return fa3_attn_func(q_BSHD, k_BSJD.contiguous(), v_BSJD.contiguous())
+        q_BSHD = q_BHSD.permute(0, 2, 1, 3)
+    return fa3_attn_func(q_BSHD.contiguous(), k_BSJD.contiguous(), v_BSJD.contiguous())
 
 
 # ---------------------------------------------------------------------------
@@ -904,7 +904,7 @@ class ICLAttention(nn.Module):
         *,
         cached_kv: KVCacheEntry | None = None,
         return_kv: bool = False,
-        attention_backend: AttentionBackend = "sdpa",
+        attention_backend: AttentionBackend = AttentionBackend.SDPA,
     ) -> tuple[torch.Tensor, KVCacheEntry | None]:
         """Self-attention where k/v are restricted to train rows.
 
@@ -1191,7 +1191,7 @@ class ICLTransformerBlock(nn.Module):
         *,
         cached_kv: KVCacheEntry | None = None,
         return_kv: bool = False,
-        attention_backend: AttentionBackend = "sdpa",
+        attention_backend: AttentionBackend = AttentionBackend.SDPA,
     ) -> tuple[torch.Tensor, KVCacheEntry | None]:
         """Forward pass with optional KV cache support.
 

--- a/tests/test_architectures/test_attention_backends.py
+++ b/tests/test_architectures/test_attention_backends.py
@@ -1,0 +1,206 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
+"""Numerical-equivalence tests for the v3 attention backend selector.
+
+The non-Hopper tests (sdpa-only, eligibility checks, error paths) run on
+any GPU — or CPU — and exercise the dispatch logic with FA3 unavailable.
+
+The ``hopper``-marked tests require a Hopper-class GPU (compute
+capability 9.0+) AND the ``flash_attn_interface`` package built from
+Dao-AILab/flash-attention's ``hopper/`` directory. They ``skip``
+automatically on any other host; run them manually on an H100 until a
+Hopper CI runner is in place.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from tabpfn.architectures.shared import fa3_backend
+from tabpfn.architectures.shared.fa3_backend import (
+    is_fa3_eligible_for,
+    is_fa3_importable,
+    is_fa3_preferred_for,
+)
+from tabpfn.architectures.tabpfn_v3 import _batched_scaled_dot_product_attention
+
+
+def _has_hopper() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    return torch.cuda.get_device_capability(0)[0] >= 9
+
+
+_FA3_RUNNABLE = _has_hopper() and is_fa3_importable()
+_skip_unless_fa3 = pytest.mark.skipif(
+    not _FA3_RUNNABLE, reason="requires Hopper GPU and flash_attn_interface"
+)
+
+
+def _make_qkv(
+    *,
+    batch: int,
+    seq_q: int,
+    seq_kv: int,
+    n_heads_q: int,
+    n_heads_kv: int,
+    head_dim: int,
+    device: str,
+    dtype: torch.dtype,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    g = torch.Generator(device=device).manual_seed(0)
+    kw = {"device": device, "dtype": dtype, "generator": g}
+    q = torch.randn(batch, seq_q, n_heads_q, head_dim, **kw)
+    k = torch.randn(batch, seq_kv, n_heads_kv, head_dim, **kw)
+    v = torch.randn(batch, seq_kv, n_heads_kv, head_dim, **kw)
+    return q, k, v
+
+
+# ---------------------------------------------------------------------
+# Eligibility & dispatch logic — runnable anywhere
+# ---------------------------------------------------------------------
+
+
+def test__sdpa_backend_default_path_unchanged_when_fa3_unavailable() -> None:
+    """Auto on CPU/non-Hopper falls back silently to SDPA; matches explicit sdpa."""
+    q, k, v = _make_qkv(
+        batch=1,
+        seq_q=8,
+        seq_kv=8,
+        n_heads_q=2,
+        n_heads_kv=2,
+        head_dim=16,
+        device="cpu",
+        dtype=torch.float32,
+    )
+
+    out_auto = _batched_scaled_dot_product_attention(q, k, v, attention_backend="auto")
+    out_sdpa = _batched_scaled_dot_product_attention(q, k, v, attention_backend="sdpa")
+
+    torch.testing.assert_close(out_auto, out_sdpa)
+
+
+def test__forced_fa3_raises_with_actionable_message_when_ineligible() -> None:
+    """Forced 'fa3' on CPU/non-Hopper raises a clear error, not a silent fallback."""
+    q, k, v = _make_qkv(
+        batch=1,
+        seq_q=4,
+        seq_kv=4,
+        n_heads_q=2,
+        n_heads_kv=2,
+        head_dim=16,
+        device="cpu",
+        dtype=torch.float32,
+    )
+
+    with pytest.raises(RuntimeError, match="FA3"):
+        _batched_scaled_dot_product_attention(q, k, v, attention_backend="fa3")
+
+
+def test__eligibility_rejects_unsupported_head_dim() -> None:
+    """Eligibility gate rules out head_dim=16 (v3 dist-embedder shape)."""
+    if not torch.cuda.is_available():
+        pytest.skip("eligibility check needs CUDA tensor")
+    q = torch.zeros(1, 4, 2, 16, device="cuda", dtype=torch.float16)
+    assert not is_fa3_eligible_for(q)
+
+
+def test__preferred_falls_back_to_sdpa_below_seqlen_threshold(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Auto dispatch must skip FA3 when both seq_q and seq_kv are too small.
+
+    Capability is mocked True so we exercise just the perf threshold; this
+    keeps the test runnable on any host (no Hopper required).
+    """
+    monkeypatch.setattr(fa3_backend, "is_fa3_eligible_for", lambda _q: True)
+
+    seq_below = fa3_backend._FA3_MIN_SEQLEN_FOR_SPEEDUP - 1
+    seq_at = fa3_backend._FA3_MIN_SEQLEN_FOR_SPEEDUP
+    q_small = torch.zeros(1, seq_below, 8, 64)
+    k_small = torch.zeros(1, seq_below, 8, 64)
+    assert not is_fa3_preferred_for(q_small, k_small)
+
+    q_at = torch.zeros(1, seq_at, 8, 64)
+    k_at = torch.zeros(1, seq_at, 8, 64)
+    assert is_fa3_preferred_for(q_at, k_at)
+
+    # Cross-attention with small Q but large K (e.g. test queries against
+    # a large support set) should still route through FA3 — the per-call
+    # work is dominated by K and amortises FA3's overhead.
+    q_small_q = torch.zeros(1, 256, 8, 64)
+    k_large_k = torch.zeros(1, 100_000, 8, 64)
+    assert is_fa3_preferred_for(q_small_q, k_large_k)
+
+
+# ---------------------------------------------------------------------
+# Numerical equivalence on Hopper — needs the FA3 wheel
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.hopper
+@_skip_unless_fa3
+def test__fa3_batch_heads_above_cuda_max_grid() -> None:
+    """FA3 must handle B*H > CUDA_MAX_GRID (65536) without silent failure.
+
+    The SDPA path explicitly chunks at 65536 to work around pytorch
+    issue #142228; we want to know whether FA3's kernels have the same
+    constraint. The current ``_fa3_attention`` doesn't chunk, so this
+    test settles whether that's safe. If FA3 has the same grid limit,
+    this test will fail (with crash or numerical mismatch) and we
+    should add chunking to ``_fa3_attention``.
+
+    Designed to put B*H comfortably past 65536 with a tiny tensor
+    footprint so it runs in seconds on a single H100.
+    """
+    batch = 70_000  # > 65_536
+    seq, head_dim = 16, 64
+    n_heads = 1
+    q = torch.randn(batch, seq, n_heads, head_dim, device="cuda", dtype=torch.float16)
+    k = torch.randn(batch, seq, n_heads, head_dim, device="cuda", dtype=torch.float16)
+    v = torch.randn(batch, seq, n_heads, head_dim, device="cuda", dtype=torch.float16)
+
+    out_sdpa = _batched_scaled_dot_product_attention(q, k, v, attention_backend="sdpa")
+    out_fa3 = _batched_scaled_dot_product_attention(q, k, v, attention_backend="fa3")
+
+    torch.testing.assert_close(out_fa3, out_sdpa, atol=5e-3, rtol=5e-3)
+
+
+@pytest.mark.hopper
+@_skip_unless_fa3
+@pytest.mark.parametrize(
+    ("seq_q", "seq_kv", "n_heads_q", "n_heads_kv"),
+    [
+        # MHA self-attn over training rows (icl_emsize=512, 8 heads, head_dim=64)
+        (1024, 1024, 8, 8),
+        # MQA cross-attn for test rows (test queries vs train keys)
+        (256, 1024, 8, 1),
+        # GQA mid-point (e.g. icl_num_kv_heads=2)
+        (512, 512, 8, 2),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test__fa3_matches_sdpa_within_tolerance(
+    seq_q: int,
+    seq_kv: int,
+    n_heads_q: int,
+    n_heads_kv: int,
+    dtype: torch.dtype,
+) -> None:
+    q, k, v = _make_qkv(
+        batch=2,
+        seq_q=seq_q,
+        seq_kv=seq_kv,
+        n_heads_q=n_heads_q,
+        n_heads_kv=n_heads_kv,
+        head_dim=64,
+        device="cuda",
+        dtype=dtype,
+    )
+
+    out_sdpa = _batched_scaled_dot_product_attention(q, k, v, attention_backend="sdpa")
+    out_fa3 = _batched_scaled_dot_product_attention(q, k, v, attention_backend="fa3")
+
+    # 5e-3 abs matches the contributor's test_fa3.py for the same shapes.
+    torch.testing.assert_close(out_fa3, out_sdpa, atol=5e-3, rtol=5e-3)

--- a/tests/test_architectures/test_attention_backends.py
+++ b/tests/test_architectures/test_attention_backends.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import pytest
 import torch
 
+from tabpfn.architectures.interface import AttentionBackend
 from tabpfn.architectures.shared import fa3_backend
 from tabpfn.architectures.shared.fa3_backend import (
     is_fa3_eligible_for,
@@ -75,14 +76,23 @@ def test__sdpa_backend_default_path_unchanged_when_fa3_unavailable() -> None:
         dtype=torch.float32,
     )
 
-    out_auto = _batched_scaled_dot_product_attention(q, k, v, attention_backend="auto")
-    out_sdpa = _batched_scaled_dot_product_attention(q, k, v, attention_backend="sdpa")
+    out_auto = _batched_scaled_dot_product_attention(
+        q, k, v, attention_backend=AttentionBackend.AUTO
+    )
+    out_sdpa = _batched_scaled_dot_product_attention(
+        q, k, v, attention_backend=AttentionBackend.SDPA
+    )
+    # The enum is a ``str``-mixin, so passing the bare string should also work.
+    out_sdpa_str = _batched_scaled_dot_product_attention(
+        q, k, v, attention_backend="sdpa"
+    )
 
     torch.testing.assert_close(out_auto, out_sdpa)
+    torch.testing.assert_close(out_sdpa, out_sdpa_str)
 
 
 def test__forced_fa3_raises_with_actionable_message_when_ineligible() -> None:
-    """Forced 'fa3' on CPU/non-Hopper raises a clear error, not a silent fallback."""
+    """Forced FA3 on CPU/non-Hopper raises a clear error, not a silent fallback."""
     q, k, v = _make_qkv(
         batch=1,
         seq_q=4,
@@ -95,7 +105,9 @@ def test__forced_fa3_raises_with_actionable_message_when_ineligible() -> None:
     )
 
     with pytest.raises(RuntimeError, match="FA3"):
-        _batched_scaled_dot_product_attention(q, k, v, attention_backend="fa3")
+        _batched_scaled_dot_product_attention(
+            q, k, v, attention_backend=AttentionBackend.FA3
+        )
 
 
 def test__eligibility_rejects_unsupported_head_dim() -> None:
@@ -161,8 +173,12 @@ def test__fa3_batch_heads_above_cuda_max_grid() -> None:
     k = torch.randn(batch, seq, n_heads, head_dim, device="cuda", dtype=torch.float16)
     v = torch.randn(batch, seq, n_heads, head_dim, device="cuda", dtype=torch.float16)
 
-    out_sdpa = _batched_scaled_dot_product_attention(q, k, v, attention_backend="sdpa")
-    out_fa3 = _batched_scaled_dot_product_attention(q, k, v, attention_backend="fa3")
+    out_sdpa = _batched_scaled_dot_product_attention(
+        q, k, v, attention_backend=AttentionBackend.SDPA
+    )
+    out_fa3 = _batched_scaled_dot_product_attention(
+        q, k, v, attention_backend=AttentionBackend.FA3
+    )
 
     torch.testing.assert_close(out_fa3, out_sdpa, atol=5e-3, rtol=5e-3)
 
@@ -199,8 +215,12 @@ def test__fa3_matches_sdpa_within_tolerance(
         dtype=dtype,
     )
 
-    out_sdpa = _batched_scaled_dot_product_attention(q, k, v, attention_backend="sdpa")
-    out_fa3 = _batched_scaled_dot_product_attention(q, k, v, attention_backend="fa3")
+    out_sdpa = _batched_scaled_dot_product_attention(
+        q, k, v, attention_backend=AttentionBackend.SDPA
+    )
+    out_fa3 = _batched_scaled_dot_product_attention(
+        q, k, v, attention_backend=AttentionBackend.FA3
+    )
 
     # 5e-3 abs matches the contributor's test_fa3.py for the same shapes.
     torch.testing.assert_close(out_fa3, out_sdpa, atol=5e-3, rtol=5e-3)


### PR DESCRIPTION
## Summary

Adds an opt-in FlashAttention-3 attention path on v3, dispatched via a new `PerformanceOptions.attention_backend` field (`"auto"` | `"sdpa"` | `"fa3"`, default `"auto"`). The dispatcher routes to FA3 only when the call is eligible (Hopper sm90+, fp16/bf16, `head_dim ∈ {64, 96, 128, 192, 256}`, `flash_attn_interface` importable); otherwise it falls back to PyTorch SDPA unchanged.

In `"auto"` mode the dispatcher additionally requires `max(seq_q, seq_kv) >= 10_000` — below that, FA3's per-call dispatch overhead exceeds its kernel-throughput win and SDPA is faster end-to-end. `"fa3"` (forced) bypasses the seqlen threshold; capability gates still apply and a clear error is raised when ineligible. `"sdpa"` always uses SDPA.

The backend selector is threaded explicitly through the ICL stage only — non-ICL call sites (`dist_embedder`, decoder, cross-attention) have FA3-ineligible head_dims and would always fall back to SDPA anyway.

FA3 is shipped only when Hopper kernels are present, since they are sm_90-specific (WGMMA, TMA). Blackwell will need FlashAttention-4 when upstream lands it.

## Implementation

- `src/tabpfn/architectures/shared/fa3_backend.py`: lazy FA3 import + capability/eligibility/preference gates.
- `tabpfn_v3._batched_scaled_dot_product_attention`: `attention_backend` kwarg threaded through `ICLAttention` → `ICLTransformerBlock` → the `icl_blocks` loop.
- `tests/test_architectures/test_attention_backends.py`: dispatch-logic tests (eligibility, fall-back, error path) run anywhere; numerical-equivalence tests gated by `@pytest.mark.hopper` and skip on non-Hopper hosts.
- `src/tabpfn/architectures/shared/fa3_setup.md`: build-from-source instructions (in-place install on Hopper, plus a cross-compile recipe for CPU-only build nodes).

## Public API changes

- New optional field `PerformanceOptions.attention_backend`. Default `"auto"` preserves existing SDPA-only behaviour everywhere FA3 isn't eligible.

## Test plan

- [x] `pytest tests/test_architectures/test_attention_backends.py tests/test_architectures/test_tabpfn_v3.py` — 17 passed locally on CPU (8 hopper-marked tests skip)
- [x] ruff + mypy + pre-commit hooks pass
- [x] Numerical equivalence on H100 (`atol=rtol=5e-3` over MHA / MQA / GQA shapes) — verified manually on internal H100 against an earlier revision of this code
- [x] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)