### PR TITLE
docs(readme): keep only the pip install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,19 +24,8 @@
 > No GPU? Use our free hosted inference via [TabPFN Client](https://github.com/PriorLabs/tabpfn-client).
 
 ### Installation
-Official installation (pip)
 ```bash
 pip install tabpfn
-```
-OR installation from source
-```bash
-pip install "tabpfn @ git+https://github.com/PriorLabs/TabPFN.git"
-```
-OR local development installation: First [install uv](https://docs.astral.sh/uv/getting-started/installation) (version 0.10.0 or higher recommended), which we use for development, then run
-```bash
-git clone https://github.com/PriorLabs/TabPFN.git --depth 1
-cd TabPFN
-uv sync
 ```
 
 ### Basic Usage

--- a/changelog/952.changed.md
+++ b/changelog/952.changed.md
@@ -1,0 +1,1 @@
+Trim the README Installation section to a single pip command (drop the source-install and uv local-dev paths).


### PR DESCRIPTION
## Summary

Per Noah's request: the README's Installation section listed three paths (pip, install-from-source, local-dev with `uv`). Most readers just want to start using TabPFN — the source-install and dev-install variants belong in CONTRIBUTING-style docs, not at the top of the README. Trim to just `pip install tabpfn`.

Supersedes the equivalent change in #951 (which also bundles other v3 / extras-list edits that overlap with #945).

🤖 Generated with [Claude Code](https://claude.com/claude-code)