### PR TITLE
Disable Xet, allow passing raw filename and still hit the cache.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,10 @@ jobs:
       TABPFN_MODEL_CACHE_DIR: ${{ github.workspace }}/model_cache
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
       TABPFN_TOKEN: ${{ secrets.TABPFN_TOKEN }}
+      # Disable xet chunk cache to prevent disk exhaustion from 40+ model downloads.
+      # Xet caches each downloaded file's chunks in ~/.cache/huggingface/xet/,
+      # roughly doubling the effective disk footprint on the runner.
+      HF_HUB_DISABLE_XET: "1"
 
     steps:
       - name: Checkout TabPFN at current ref

--- a/src/tabpfn/model_loading.py
+++ b/src/tabpfn/model_loading.py
@@ -855,6 +855,11 @@ def resolve_model_path(
         model_path: An optional path to a model file. If None, the default
             model for the given `which` and `version` will be used, resolving
             to the local cache directory.
+
+            When a bare filename is given (no directory component, e.g.
+            ``"tabpfn-v3-regressor-v3_default.ckpt"``), the path is first
+            interpreted relative to the current working directory. If no file
+            exists there, it falls back to the TabPFN cache directory.
         which: The type of model ('regressor' or 'classifier').
         version: The model version (currently only 'v2').
 
@@ -871,9 +876,14 @@ def resolve_model_path(
         resolved_model_dirs = [get_cache_dir()]
         resolved_model_paths = [resolved_model_dirs[0] / resolved_model_names[0]]
     elif isinstance(model_path, (str, Path)):
-        resolved_model_paths = [Path(model_path)]
-        resolved_model_dirs = [resolved_model_paths[0].parent]
-        resolved_model_names = [resolved_model_paths[0].name]
+        path = Path(model_path)
+        # A bare filename is checked against the CWD first, otherwise the cache dir as a
+        # fallback so callers can refer to a checkpoint by name alone.
+        if not path.is_absolute() and path.parent == Path() and not path.exists():
+            path = get_cache_dir() / path
+        resolved_model_paths = [path]
+        resolved_model_dirs = [path.parent]
+        resolved_model_names = [path.name]
     else:
         resolved_model_paths = [Path(p) for p in model_path]
         resolved_model_dirs = [p.parent for p in resolved_model_paths]


### PR DESCRIPTION
Timeseries tests run out of disk space - this PR removes the xet format, which we don't require, and allows to specify specific model names, which we first try to find in the current dir and then in the cache (this is the pattern that the timeseries package uses).