### PR TITLE
Conditionally clear MPS cache on OOM error

### DIFF
--- a/src/tabpfn/architectures/tabpfn_v3.py
+++ b/src/tabpfn/architectures/tabpfn_v3.py
@@ -2048,7 +2048,8 @@ class TabPFNV3(Architecture):
                     if not is_oom_error(e) or eff_col_chunk <= 1:
                         raise
                     torch.cuda.empty_cache()
-                    torch.mps.empty_cache()
+                    if torch.backends.mps.is_available():
+                        torch.mps.empty_cache()
                     eff_col_chunk //= 2
                     _logger.warning("OOM: halving col_chunk_size to %d", eff_col_chunk)
                     self.inference_col_chunk_size = eff_col_chunk


### PR DESCRIPTION
This commit will fix error on CUDA-only system. 
Otherwise, the following error will occur:
"Cannot execute emptyCache() without MPS backend."

## Issue
Please link the corresponding GitHub issue. If an issue does not already exist,
please open one to describe the bug or feature request before creating a pull request.

This allows us to discuss the proposal and helps avoid unnecessary work.

## Motivation and Context

I encounterd error on my CUDA system. In torch, torch.backends.mps.is_available() must be verified before calling torch.mps.empty_cache() or the error "Cannot execute emptyCache() without MPS backend."  will be raised.
This is a torch-specific behavior.

---

## Public API Changes

-   [*] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?

---

## Checklist

-   [*] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [ ] A changelog entry has been added (see `changelog/README.md`), or "no changelog needed" label requested.
-   [*] The code follows the project's style guidelines.
-   [ ] I have considered the impact of these changes on the public API.

---
