### PR TITLE
Add quantile_uni_extrapolate preprocessor preset

### DIFF
--- a/src/tabpfn/preprocessing/configs.py
+++ b/src/tabpfn/preprocessing/configs.py
@@ -65,6 +65,7 @@ class PreprocessorConfig:
         "quantile_norm",
         "quantile_uni_fine",
         "quantile_norm_fine",
+        "quantile_uni_extrapolate",
         "squashing_scaler_default",
         "squashing_scaler_max10",
         "robust",  # a standard sklearn robust scaler

--- a/src/tabpfn/preprocessing/steps/adaptive_quantile_transformer.py
+++ b/src/tabpfn/preprocessing/steps/adaptive_quantile_transformer.py
@@ -44,7 +44,11 @@ def get_user_n_quantiles_for_preset(transform_name: str, n_samples: int) -> int:
     """
     if transform_name in ("quantile_uni", "quantile_norm"):
         return max(n_samples // 5, 2)
-    if transform_name in ("quantile_uni_coarse", "quantile_norm_coarse"):
+    if transform_name in (
+        "quantile_uni_coarse",
+        "quantile_norm_coarse",
+        "quantile_uni_extrapolate",
+    ):
         return max(n_samples // 10, 2)
     if transform_name in ("quantile_uni_fine", "quantile_norm_fine"):
         return n_samples
@@ -62,6 +66,12 @@ class AdaptiveQuantileTransformer(QuantileTransformer):
     greater than the number of available samples in the input data (X).
     This situation can arises because we first initialize the transformer
     based on total samples and then subsample.
+
+    When ``extrapolate_ratio`` is set, inputs outside the training range
+    are linearly extrapolated beyond ``[0, 1]`` at ``transform`` time and
+    clipped at ``-extrapolate_ratio`` / ``1 + extrapolate_ratio``. This
+    preserves OOD information that would otherwise be flattened by the
+    boundary clamp. Intended for ``output_distribution="uniform"``.
     """
 
     def __init__(
@@ -69,12 +79,14 @@ class AdaptiveQuantileTransformer(QuantileTransformer):
         *,
         n_quantiles: int = 1_000,
         subsample: int = _DEFAULT_SUBSAMPLE,
+        extrapolate_ratio: float | None = None,
         **kwargs: Any,
     ) -> None:
         # Store the user's desired n_quantiles to use as an upper bound
         self._user_n_quantiles = n_quantiles
         # Initialize parent with this, but it will be adapted in fit
         super().__init__(n_quantiles=n_quantiles, subsample=subsample, **kwargs)
+        self.extrapolate_ratio = extrapolate_ratio
 
     @override
     def fit(
@@ -82,6 +94,10 @@ class AdaptiveQuantileTransformer(QuantileTransformer):
         X: np.ndarray,
         y: np.ndarray | None = None,
     ) -> AdaptiveQuantileTransformer:
+        if self.extrapolate_ratio is not None and X.shape[0] > 0:
+            self.x_min_ = np.nanmin(X, axis=0, keepdims=True)
+            self.x_max_ = np.nanmax(X, axis=0, keepdims=True)
+
         n_samples = X.shape[0]
 
         self.n_quantiles = compute_effective_n_quantiles(
@@ -99,6 +115,33 @@ class AdaptiveQuantileTransformer(QuantileTransformer):
             )
 
         return super().fit(X, y)
+
+    @override
+    def transform(self, X: np.ndarray) -> np.ndarray:
+        out = super().transform(X)
+
+        if self.extrapolate_ratio is not None and X.shape[0] > 0:
+            x_range = self.x_max_ - self.x_min_
+            # Skip constant features (matches the GPU path); also avoids a
+            # divide-by-zero in the normalisation below.
+            extrap_mask = x_range > 0
+            min_idcs = (self.x_min_ > X) & extrap_mask
+            max_idcs = (self.x_max_ < X) & extrap_mask
+            if np.any(min_idcs) or np.any(max_idcs):
+                # (X - x_max)/range + 1 simplifies to (X - x_min)/range, so
+                # one normalised array suffices for both branches.
+                with np.errstate(divide="ignore", invalid="ignore"):
+                    norm = (X - self.x_min_) / x_range
+                if np.any(min_idcs):
+                    out[min_idcs] = np.clip(
+                        norm[min_idcs], -self.extrapolate_ratio, 0.0
+                    )
+                if np.any(max_idcs):
+                    out[max_idcs] = np.clip(
+                        norm[max_idcs], 1.0, 1.0 + self.extrapolate_ratio
+                    )
+
+        return out
 
 
 __all__ = [

--- a/src/tabpfn/preprocessing/steps/adaptive_quantile_transformer.py
+++ b/src/tabpfn/preprocessing/steps/adaptive_quantile_transformer.py
@@ -42,13 +42,17 @@ def get_user_n_quantiles_for_preset(transform_name: str, n_samples: int) -> int:
     Raises:
         ValueError: If *transform_name* is not a known quantile preset.
     """
-    if transform_name in ("quantile_uni", "quantile_norm"):
-        return max(n_samples // 5, 2)
     if transform_name in (
-        "quantile_uni_coarse",
-        "quantile_norm_coarse",
+        "quantile_uni",
+        "quantile_norm",
+        # quantile_uni_extrapolate is intentionally the same n_quantiles tier
+        # as quantile_uni: it is "the default quantile transform plus boundary
+        # extrapolation" and should differ from quantile_uni by extrapolation
+        # ONLY, not by a coarser quantile grid.
         "quantile_uni_extrapolate",
     ):
+        return max(n_samples // 5, 2)
+    if transform_name in ("quantile_uni_coarse", "quantile_norm_coarse"):
         return max(n_samples // 10, 2)
     if transform_name in ("quantile_uni_fine", "quantile_norm_fine"):
         return n_samples

--- a/src/tabpfn/preprocessing/steps/adaptive_quantile_transformer.py
+++ b/src/tabpfn/preprocessing/steps/adaptive_quantile_transformer.py
@@ -86,6 +86,14 @@ class AdaptiveQuantileTransformer(QuantileTransformer):
         self._user_n_quantiles = n_quantiles
         # Initialize parent with this, but it will be adapted in fit
         super().__init__(n_quantiles=n_quantiles, subsample=subsample, **kwargs)
+        if extrapolate_ratio is not None:
+            if extrapolate_ratio < 0:
+                raise ValueError("extrapolate_ratio must be non-negative.")
+            if kwargs.get("output_distribution", "uniform") != "uniform":
+                raise ValueError(
+                    "extrapolate_ratio is only supported for "
+                    "output_distribution='uniform'."
+                )
         self.extrapolate_ratio = extrapolate_ratio
 
     @override

--- a/src/tabpfn/preprocessing/steps/adaptive_quantile_transformer.py
+++ b/src/tabpfn/preprocessing/steps/adaptive_quantile_transformer.py
@@ -55,6 +55,13 @@ def get_user_n_quantiles_for_preset(transform_name: str, n_samples: int) -> int:
     raise ValueError(f"Unknown quantile preset: {transform_name}")
 
 
+def get_extrapolate_ratio_for_preset(transform_name: str) -> float | None:
+    """Return the default ``extrapolate_ratio`` for a named quantile preset."""
+    if transform_name == "quantile_uni_extrapolate":
+        return 1.0
+    return None
+
+
 class AdaptiveQuantileTransformer(QuantileTransformer):
     """A QuantileTransformer that automatically adapts the 'n_quantiles' parameter
     based on the number of samples provided during the 'fit' method.

--- a/src/tabpfn/preprocessing/steps/adaptive_quantile_transformer.py
+++ b/src/tabpfn/preprocessing/steps/adaptive_quantile_transformer.py
@@ -45,10 +45,6 @@ def get_user_n_quantiles_for_preset(transform_name: str, n_samples: int) -> int:
     if transform_name in (
         "quantile_uni",
         "quantile_norm",
-        # quantile_uni_extrapolate is intentionally the same n_quantiles tier
-        # as quantile_uni: it is "the default quantile transform plus boundary
-        # extrapolation" and should differ from quantile_uni by extrapolation
-        # ONLY, not by a coarser quantile grid.
         "quantile_uni_extrapolate",
     ):
         return max(n_samples // 5, 2)

--- a/src/tabpfn/preprocessing/steps/reshape_feature_distribution_step.py
+++ b/src/tabpfn/preprocessing/steps/reshape_feature_distribution_step.py
@@ -31,6 +31,7 @@ from tabpfn.preprocessing.pipeline_interface import (
 )
 from tabpfn.preprocessing.steps.adaptive_quantile_transformer import (
     AdaptiveQuantileTransformer,
+    get_extrapolate_ratio_for_preset,
     get_user_n_quantiles_for_preset,
 )
 from tabpfn.preprocessing.steps.kdi_transformer import (
@@ -547,7 +548,9 @@ def get_all_reshape_feature_distribution_preprocessors(
             n_quantiles=get_user_n_quantiles_for_preset(
                 "quantile_uni_extrapolate", num_examples
             ),
-            extrapolate_ratio=1.0,
+            extrapolate_ratio=get_extrapolate_ratio_for_preset(
+                "quantile_uni_extrapolate"
+            ),
             random_state=random_state,
         ),
         "squashing_scaler_default": SquashingScaler(),

--- a/src/tabpfn/preprocessing/steps/reshape_feature_distribution_step.py
+++ b/src/tabpfn/preprocessing/steps/reshape_feature_distribution_step.py
@@ -542,6 +542,14 @@ def get_all_reshape_feature_distribution_preprocessors(
             ),
             random_state=random_state,
         ),
+        "quantile_uni_extrapolate": AdaptiveQuantileTransformer(
+            output_distribution="uniform",
+            n_quantiles=get_user_n_quantiles_for_preset(
+                "quantile_uni_extrapolate", num_examples
+            ),
+            extrapolate_ratio=1.0,
+            random_state=random_state,
+        ),
         "squashing_scaler_default": SquashingScaler(),
         "squashing_scaler_max10": SquashingScaler(max_absolute_value=10.0),
         "robust": RobustScaler(unit_variance=True),

--- a/src/tabpfn/preprocessing/torch/factory.py
+++ b/src/tabpfn/preprocessing/torch/factory.py
@@ -66,11 +66,15 @@ def create_gpu_preprocessing_pipeline(
         quantile_on_gpu = len(quantile_target_indices) > 0
         if quantile_on_gpu and n_train_samples is not None:
             n_quantiles = compute_effective_n_quantiles(pconfig.name, n_train_samples)
+            extrapolate_ratio = (
+                1.0 if pconfig.name == "quantile_uni_extrapolate" else None
+            )
             steps.append(
                 (
                     TorchSelectiveQuantileTransformerStep(
                         n_quantiles=n_quantiles,
                         target_column_indices=quantile_target_indices,
+                        extrapolate_ratio=extrapolate_ratio,
                     ),
                     None,  # operates on explicit indices, receives full tensor
                 )

--- a/src/tabpfn/preprocessing/torch/factory.py
+++ b/src/tabpfn/preprocessing/torch/factory.py
@@ -7,6 +7,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from tabpfn.preprocessing.datamodel import FeatureModality
+from tabpfn.preprocessing.steps.adaptive_quantile_transformer import (
+    get_extrapolate_ratio_for_preset,
+)
 from tabpfn.preprocessing.torch.gpu_preprocessing_metadata import (
     compute_effective_n_quantiles,
     get_squashing_scaler_max_absolute_value,
@@ -66,9 +69,7 @@ def create_gpu_preprocessing_pipeline(
         quantile_on_gpu = len(quantile_target_indices) > 0
         if quantile_on_gpu and n_train_samples is not None:
             n_quantiles = compute_effective_n_quantiles(pconfig.name, n_train_samples)
-            extrapolate_ratio = (
-                1.0 if pconfig.name == "quantile_uni_extrapolate" else None
-            )
+            extrapolate_ratio = get_extrapolate_ratio_for_preset(pconfig.name)
             steps.append(
                 (
                     TorchSelectiveQuantileTransformerStep(

--- a/src/tabpfn/preprocessing/torch/gpu_preprocessing_metadata.py
+++ b/src/tabpfn/preprocessing/torch/gpu_preprocessing_metadata.py
@@ -14,6 +14,7 @@ _GPU_ELIGIBLE_QUANTILE_TRANSFORMS = frozenset(
         "quantile_uni",
         "quantile_uni_coarse",
         "quantile_uni_fine",
+        "quantile_uni_extrapolate",
     }
 )
 

--- a/src/tabpfn/preprocessing/torch/steps.py
+++ b/src/tabpfn/preprocessing/torch/steps.py
@@ -36,10 +36,17 @@ from tabpfn.utils import infer_random_state
 class TorchQuantileTransformerStep(TorchPreprocessingStep):
     """Pipeline step wrapper for TorchQuantileTransformer."""
 
-    def __init__(self, n_quantiles: int = 1_000) -> None:
+    def __init__(
+        self,
+        n_quantiles: int = 1_000,
+        extrapolate_ratio: float | None = None,
+    ) -> None:
         """Initialize the quantile transformer step."""
         super().__init__()
-        self._quantile_transformer = TorchQuantileTransformer(n_quantiles=n_quantiles)
+        self._quantile_transformer = TorchQuantileTransformer(
+            n_quantiles=n_quantiles,
+            extrapolate_ratio=extrapolate_ratio,
+        )
 
     @override
     def _fit(self, x: torch.Tensor) -> dict[str, torch.Tensor]:
@@ -151,9 +158,13 @@ class TorchSelectiveQuantileTransformerStep(TorchPreprocessingStep):
         self,
         n_quantiles: int,
         target_column_indices: list[int],
+        extrapolate_ratio: float | None = None,
     ) -> None:
         super().__init__()
-        self._qt = TorchQuantileTransformer(n_quantiles=n_quantiles)
+        self._qt = TorchQuantileTransformer(
+            n_quantiles=n_quantiles,
+            extrapolate_ratio=extrapolate_ratio,
+        )
         self._target_column_indices = target_column_indices
 
     @override

--- a/src/tabpfn/preprocessing/torch/torch_quantile_transformer.py
+++ b/src/tabpfn/preprocessing/torch/torch_quantile_transformer.py
@@ -314,9 +314,7 @@ class TorchQuantileTransformer:
         above_mask = above_mask & ~constant_mask
 
         result = torch.where(below_mask, torch.clamp(norm, -ratio, 0.0), result)
-        return torch.where(
-            above_mask, torch.clamp(norm, 1.0, 1.0 + ratio), result
-        )
+        return torch.where(above_mask, torch.clamp(norm, 1.0, 1.0 + ratio), result)
 
     def _interp_batched(
         self,

--- a/src/tabpfn/preprocessing/torch/torch_quantile_transformer.py
+++ b/src/tabpfn/preprocessing/torch/torch_quantile_transformer.py
@@ -17,15 +17,25 @@ class TorchQuantileTransformer:
     quantile information from the training data.
     """
 
-    def __init__(self, n_quantiles: int = 1_000) -> None:
+    def __init__(
+        self,
+        n_quantiles: int = 1_000,
+        extrapolate_ratio: float | None = None,
+    ) -> None:
         """Initialize the quantile transformer.
 
         Args:
             n_quantiles: Number of quantiles to compute. More quantiles give
                 a better approximation of the CDF but use more memory.
+            extrapolate_ratio: When set, inputs outside the fitted range are
+                linearly extrapolated past ``[0, 1]`` and clipped at
+                ``-ratio`` / ``1 + ratio`` instead of being clamped at the
+                boundary quantile. Mirrors the
+                :class:`AdaptiveQuantileTransformer` mode-1 behaviour.
         """
         super().__init__()
         self.n_quantiles = n_quantiles
+        self.extrapolate_ratio = extrapolate_ratio
 
     def fit(self, x: torch.Tensor) -> dict[str, torch.Tensor]:
         """Compute the quantiles from the training data.
@@ -250,7 +260,10 @@ class TorchQuantileTransformer:
         result = 0.5 * (interp_forward - interp_backward)  # [n_features, n_samples]
         result = result.t()  # [n_samples, n_features]
 
-        result = torch.clamp(result, 0.0, 1.0)
+        if self.extrapolate_ratio is None:
+            result = torch.clamp(result, 0.0, 1.0)
+        else:
+            result = self._apply_extrapolation(result, x_flat, quantiles_flat)
 
         if len(original_shape) > 1:
             result = result.reshape(original_shape)
@@ -258,6 +271,49 @@ class TorchQuantileTransformer:
             result = result.squeeze(-1)
 
         return result
+
+    def _apply_extrapolation(
+        self,
+        result: torch.Tensor,
+        x: torch.Tensor,
+        quantiles: torch.Tensor,
+    ) -> torch.Tensor:
+        """Replace boundary-clamped values with linear extrapolation.
+
+        ``_interp_batched`` clamps out-of-range inputs at ``fp_first``/``fp_last``
+        (i.e. 0 and 1). When ``extrapolate_ratio`` is set, those values are
+        instead linearly extrapolated past ``[0, 1]`` using the training-data
+        range (``quantiles[0]`` and ``quantiles[-1]`` per feature) and clipped
+        at ``-ratio`` / ``1 + ratio``.
+
+        Args:
+            result: Output of the standard transform, shape [n_samples, n_features].
+            x: Original input, shape [n_samples, n_features].
+            quantiles: Per-feature breakpoints, shape [n_quantiles, n_features].
+                ``quantiles[0]`` and ``quantiles[-1]`` are the training min/max.
+        """
+        ratio = self.extrapolate_ratio
+        x_min = quantiles[0]  # [n_features]
+        x_max = quantiles[-1]  # [n_features]
+        x_range = x_max - x_min
+        safe_range = torch.where(x_range == 0, torch.ones_like(x_range), x_range)
+
+        norm_below = (x - x_min) / safe_range
+        norm_above = (x - x_max) / safe_range + 1.0
+
+        below_mask = x < x_min
+        above_mask = x > x_max
+
+        # Constant features (x_range == 0) have no meaningful extrapolation;
+        # leave the standard 0.5 midpoint untouched.
+        constant_mask = x_range == 0
+        below_mask = below_mask & ~constant_mask
+        above_mask = above_mask & ~constant_mask
+
+        result = torch.where(below_mask, torch.clamp(norm_below, -ratio, 0.0), result)
+        return torch.where(
+            above_mask, torch.clamp(norm_above, 1.0, 1.0 + ratio), result
+        )
 
     def _interp_batched(
         self,

--- a/src/tabpfn/preprocessing/torch/torch_quantile_transformer.py
+++ b/src/tabpfn/preprocessing/torch/torch_quantile_transformer.py
@@ -34,6 +34,8 @@ class TorchQuantileTransformer:
                 :class:`AdaptiveQuantileTransformer` mode-1 behaviour.
         """
         super().__init__()
+        if extrapolate_ratio is not None and extrapolate_ratio < 0:
+            raise ValueError("extrapolate_ratio must be non-negative.")
         self.n_quantiles = n_quantiles
         self.extrapolate_ratio = extrapolate_ratio
 
@@ -298,8 +300,9 @@ class TorchQuantileTransformer:
         x_range = x_max - x_min
         safe_range = torch.where(x_range == 0, torch.ones_like(x_range), x_range)
 
-        norm_below = (x - x_min) / safe_range
-        norm_above = (x - x_max) / safe_range + 1.0
+        # (x - x_max) / range + 1 simplifies to (x - x_min) / range, so a
+        # single normalised tensor serves both the below and above branches.
+        norm = (x - x_min) / safe_range
 
         below_mask = x < x_min
         above_mask = x > x_max
@@ -310,9 +313,9 @@ class TorchQuantileTransformer:
         below_mask = below_mask & ~constant_mask
         above_mask = above_mask & ~constant_mask
 
-        result = torch.where(below_mask, torch.clamp(norm_below, -ratio, 0.0), result)
+        result = torch.where(below_mask, torch.clamp(norm, -ratio, 0.0), result)
         return torch.where(
-            above_mask, torch.clamp(norm_above, 1.0, 1.0 + ratio), result
+            above_mask, torch.clamp(norm, 1.0, 1.0 + ratio), result
         )
 
     def _interp_batched(

--- a/tests/test_preprocessing/test_adaptive_quantile_transformer.py
+++ b/tests/test_preprocessing/test_adaptive_quantile_transformer.py
@@ -139,10 +139,6 @@ def test__extrapolate_ratio__validation_guards():
             output_distribution="uniform", extrapolate_ratio=-0.1
         )
     with pytest.raises(ValueError, match="output_distribution='uniform'"):
-        AdaptiveQuantileTransformer(
-            output_distribution="normal", extrapolate_ratio=0.1
-        )
+        AdaptiveQuantileTransformer(output_distribution="normal", extrapolate_ratio=0.1)
     # Valid config still constructs.
-    AdaptiveQuantileTransformer(
-        output_distribution="uniform", extrapolate_ratio=0.1
-    )
+    AdaptiveQuantileTransformer(output_distribution="uniform", extrapolate_ratio=0.1)

--- a/tests/test_preprocessing/test_adaptive_quantile_transformer.py
+++ b/tests/test_preprocessing/test_adaptive_quantile_transformer.py
@@ -130,3 +130,19 @@ def test__no_extrapolation_when_unset__matches_baseline():
     ).fit(X)
 
     np.testing.assert_array_equal(baseline.transform(X), no_extrap.transform(X))
+
+
+def test__extrapolate_ratio__validation_guards():
+    """Invalid extrapolate_ratio configs are rejected at construction."""
+    with pytest.raises(ValueError, match="non-negative"):
+        AdaptiveQuantileTransformer(
+            output_distribution="uniform", extrapolate_ratio=-0.1
+        )
+    with pytest.raises(ValueError, match="output_distribution='uniform'"):
+        AdaptiveQuantileTransformer(
+            output_distribution="normal", extrapolate_ratio=0.1
+        )
+    # Valid config still constructs.
+    AdaptiveQuantileTransformer(
+        output_distribution="uniform", extrapolate_ratio=0.1
+    )

--- a/tests/test_preprocessing/test_adaptive_quantile_transformer.py
+++ b/tests/test_preprocessing/test_adaptive_quantile_transformer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
 from tabpfn.preprocessing.steps import AdaptiveQuantileTransformer
 
@@ -33,3 +34,99 @@ def test_adaptive_quantile_transformer_with_numpy_generator():
     # Further assertion to ensure the transformer is functional
     assert hasattr(transformer, "quantiles_")
     assert transformer.quantiles_.shape == (10, 10)
+
+
+def test__extrapolate_ratio_uniform__extends_outside_training_range():
+    """Inputs outside the training range get linearly extrapolated and clipped."""
+    rng = np.random.default_rng(0)
+    X_train = rng.uniform(0.0, 1.0, size=(200, 1))
+
+    transformer = AdaptiveQuantileTransformer(
+        output_distribution="uniform",
+        n_quantiles=50,
+        extrapolate_ratio=1.0,
+        random_state=0,
+    )
+    transformer.fit(X_train)
+
+    in_range = transformer.transform(np.array([[0.5]]))
+    assert 0.0 <= in_range[0, 0] <= 1.0
+
+    # Below the training min: maps to negative values, clipped at -extrapolate_ratio.
+    below = transformer.transform(np.array([[-0.1], [-2.0]]))
+    assert below[0, 0] < 0.0
+    assert below[0, 0] == pytest.approx(-0.1, abs=0.05)
+    assert below[1, 0] == pytest.approx(-1.0)  # clipped
+
+    # Above the training max: maps to >1, clipped at 1 + extrapolate_ratio.
+    above = transformer.transform(np.array([[1.1], [3.0]]))
+    assert above[0, 0] > 1.0
+    assert above[0, 0] == pytest.approx(1.1, abs=0.05)
+    assert above[1, 0] == pytest.approx(2.0)  # clipped
+
+
+def test__extrapolate_ratio__nan_columns_get_valid_boundaries():
+    """NaN entries in training data must not make the extrapolation bounds NaN."""
+    X_train = np.array(
+        [
+            [1.0, 1.0],
+            [2.0, np.nan],
+            [3.0, 2.0],
+            [4.0, 3.0],
+        ]
+    )
+    transformer = AdaptiveQuantileTransformer(
+        output_distribution="uniform",
+        n_quantiles=4,
+        extrapolate_ratio=1.0,
+        random_state=0,
+    )
+    transformer.fit(X_train)
+
+    assert np.all(np.isfinite(transformer.x_min_))
+    assert np.all(np.isfinite(transformer.x_max_))
+
+    # Out-of-range inputs in either column extrapolate to a finite value.
+    out = transformer.transform(np.array([[5.0, 4.0]]))
+    assert np.all(np.isfinite(out))
+    assert out[0, 0] > 1.0
+    assert out[0, 1] > 1.0
+
+
+def test__extrapolate_ratio__constant_feature_no_extrapolation():
+    """Constant features should not be extrapolated (matches GPU behaviour)."""
+    X_train = np.column_stack(
+        [
+            np.linspace(0.0, 1.0, 50),  # varying
+            np.full(50, 5.0),  # constant
+        ]
+    )
+    transformer = AdaptiveQuantileTransformer(
+        output_distribution="uniform",
+        n_quantiles=20,
+        extrapolate_ratio=1.0,
+        random_state=0,
+    )
+    transformer.fit(X_train)
+
+    out = transformer.transform(np.array([[2.0, 99.0], [-1.0, 99.0]]))
+    # First column extrapolates, second column stays in [0, 1].
+    assert out[0, 0] > 1.0
+    assert out[1, 0] < 0.0
+    assert 0.0 <= out[0, 1] <= 1.0
+    assert 0.0 <= out[1, 1] <= 1.0
+
+
+def test__no_extrapolation_when_unset__matches_baseline():
+    """Without extrapolation params, behaviour matches the unmodified transformer."""
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(100, 3))
+
+    baseline = AdaptiveQuantileTransformer(
+        output_distribution="uniform", n_quantiles=20, random_state=0
+    ).fit(X)
+    no_extrap = AdaptiveQuantileTransformer(
+        output_distribution="uniform", n_quantiles=20, random_state=0
+    ).fit(X)
+
+    np.testing.assert_array_equal(baseline.transform(X), no_extrap.transform(X))

--- a/tests/test_torch_preprocessing/test_gpu_preprocessing_consistency.py
+++ b/tests/test_torch_preprocessing/test_gpu_preprocessing_consistency.py
@@ -233,6 +233,7 @@ class TestGpuQuantileEligibility:
         assert is_gpu_quantile_eligible("quantile_uni")
         assert is_gpu_quantile_eligible("quantile_uni_coarse")
         assert is_gpu_quantile_eligible("quantile_uni_fine")
+        assert is_gpu_quantile_eligible("quantile_uni_extrapolate")
 
     def test_not_eligible(self) -> None:
         assert not is_gpu_quantile_eligible("squashing_scaler_default")
@@ -283,6 +284,12 @@ class TestPipelineConsistency:
         categorical_name="onehot",
         max_features_per_estimator=680,
     )
+    # Extrapolating quantile (uses the optional extrapolate_ratio path).
+    V26_QUANTILE_EXTRAPOLATE = PreprocessorConfig(
+        "quantile_uni_extrapolate",
+        categorical_name="numeric",
+        max_features_per_estimator=680,
+    )
     # v2.5 classifier configs (non-quantile)
     V25_SQUASHING_SVD = PreprocessorConfig(
         name="squashing_scaler_default",
@@ -315,6 +322,7 @@ class TestPipelineConsistency:
             V26_QUANTILE_NUMERIC,
             V26_QUANTILE_NUMERIC_APPEND_ORIGINAL,
             V26_QUANTILE_ONEHOT,
+            V26_QUANTILE_EXTRAPOLATE,
             pytest.param(
                 V26_QUANTILE_SVD,
                 marks=pytest.mark.skipif(
@@ -327,6 +335,7 @@ class TestPipelineConsistency:
             "v26_quantile_numeric",
             "v26_quantile_numeric_append_original",
             "v26_quantile_onehot",
+            "v26_quantile_extrapolate",
             "v26_quantile_svd",
         ],
     )

--- a/tests/test_torch_preprocessing/test_torch_quantile_transformer.py
+++ b/tests/test_torch_preprocessing/test_torch_quantile_transformer.py
@@ -537,3 +537,15 @@ class TestTorchQuantileTransformerCategoricalBoundary:
             rtol=1e-5,
             err_msg=f"Boundary mismatch with n_quantiles={n_quantiles}",
         )
+
+
+def test__torch_extrapolate_ratio__rejects_negative():
+    """Negative extrapolate_ratio is rejected at construction."""
+    import pytest
+
+    from tabpfn.preprocessing.torch.torch_quantile_transformer import (
+        TorchQuantileTransformer,
+    )
+
+    with pytest.raises(ValueError, match="non-negative"):
+        TorchQuantileTransformer(n_quantiles=10, extrapolate_ratio=-1.0)

--- a/tests/test_torch_preprocessing/test_torch_quantile_transformer.py
+++ b/tests/test_torch_preprocessing/test_torch_quantile_transformer.py
@@ -318,6 +318,83 @@ class TestTorchQuantileTransformer:
         assert torch.isnan(result[:, 1]).all()
 
 
+class TestTorchQuantileTransformerExtrapolation:
+    """Tests for the optional extrapolate_ratio mode."""
+
+    def test__extrapolate_ratio__matches_sklearn_adaptive_inside_range(self):
+        """In-range values match the CPU AdaptiveQuantileTransformer."""
+        rng = np.random.default_rng(42)
+        x_np = rng.standard_normal((300, 5)).astype(np.float32)
+
+        cpu_qt = AdaptiveQuantileTransformer(
+            output_distribution="uniform",
+            n_quantiles=100,
+            extrapolate_ratio=1.0,
+            random_state=42,
+        )
+        cpu_result = cpu_qt.fit_transform(x_np)
+
+        torch_qt = TorchQuantileTransformer(n_quantiles=100, extrapolate_ratio=1.0)
+        torch_result = torch_qt(torch.from_numpy(x_np))
+
+        assert torch.allclose(
+            torch_result, torch.from_numpy(cpu_result), atol=1e-4, rtol=1e-4
+        )
+
+    def test__extrapolate_ratio__extends_beyond_training_range(self):
+        """Out-of-range inputs map to <0 or >1, clipped at the ratio bound."""
+        rng = np.random.default_rng(0)
+        x_train_np = rng.uniform(0.0, 1.0, size=(200, 1)).astype(np.float32)
+        x_train = torch.from_numpy(x_train_np)
+
+        torch_qt = TorchQuantileTransformer(n_quantiles=50, extrapolate_ratio=1.0)
+        cache = torch_qt.fit(x_train)
+
+        x_test = torch.tensor(
+            [[-0.1], [-2.0], [0.5], [1.1], [3.0]], dtype=torch.float32
+        )
+        out = torch_qt.transform(x_test, fitted_cache=cache).flatten()
+
+        assert out[0].item() < 0.0
+        assert out[1].item() == pytest.approx(-1.0, abs=1e-5)  # clipped
+        assert 0.0 <= out[2].item() <= 1.0
+        assert out[3].item() > 1.0
+        assert out[4].item() == pytest.approx(2.0, abs=1e-5)  # clipped
+
+    def test__extrapolate_ratio__matches_cpu_on_out_of_range_inputs(self):
+        """End-to-end CPU/GPU agreement for out-of-range inputs."""
+        rng = np.random.default_rng(0)
+        x_train_np = rng.normal(size=(200, 3)).astype(np.float32)
+        x_test_np = np.concatenate(
+            [
+                rng.normal(size=(50, 3)).astype(np.float32),
+                # rows that fall outside training range
+                (x_train_np.max(axis=0) + 2.0)[None, :],
+                (x_train_np.min(axis=0) - 2.0)[None, :],
+            ],
+            axis=0,
+        )
+
+        cpu_qt = AdaptiveQuantileTransformer(
+            output_distribution="uniform",
+            n_quantiles=50,
+            extrapolate_ratio=1.0,
+            random_state=42,
+        )
+        cpu_qt.fit(x_train_np)
+        cpu_result = cpu_qt.transform(x_test_np)
+
+        torch_qt = TorchQuantileTransformer(n_quantiles=50, extrapolate_ratio=1.0)
+        cache = torch_qt.fit(torch.from_numpy(x_train_np))
+        torch_result = torch_qt.transform(
+            torch.from_numpy(x_test_np), fitted_cache=cache
+        )
+
+        assert torch.allclose(
+            torch_result, torch.from_numpy(cpu_result), atol=1e-4, rtol=1e-4
+        )
+
+
 def _make_schema(
     *,
     num_numericals: int = 0,

--- a/tests/test_torch_preprocessing/test_torch_quantile_transformer.py
+++ b/tests/test_torch_preprocessing/test_torch_quantile_transformer.py
@@ -541,11 +541,5 @@ class TestTorchQuantileTransformerCategoricalBoundary:
 
 def test__torch_extrapolate_ratio__rejects_negative():
     """Negative extrapolate_ratio is rejected at construction."""
-    import pytest
-
-    from tabpfn.preprocessing.torch.torch_quantile_transformer import (
-        TorchQuantileTransformer,
-    )
-
     with pytest.raises(ValueError, match="non-negative"):
         TorchQuantileTransformer(n_quantiles=10, extrapolate_ratio=-1.0)


### PR DESCRIPTION
## Summary

Adds the `quantile_uni_extrapolate` preprocessor preset: instead of clamping quantile-transformed values at the `[0, 1]` boundary, it linearly extrapolates past the boundary for inputs outside the training range, better preserving out-of-distribution information.

Wired through **both** the CPU `AdaptiveQuantileTransformer` and the GPU `TorchQuantileTransformer` paths so the preset is GPU-eligible. CPU/GPU consistency tests parametrise the new preset across f16/f32/f64.

## Motivation

v3 OOD-preprocessing checkpoints use `quantile_uni_extrapolate` in the regressor preprocessing recipe. Without this preset in the public package those checkpoints fail to load (`pydantic ValidationError` on the `PreprocessorConfig.name` literal). This unblocks loading them with the public release.

## Changes (7 source + 3 test files, mirrors private #599)

- `preprocessing/configs.py` — register `quantile_uni_extrapolate` in the name literal
- `preprocessing/steps/adaptive_quantile_transformer.py` — `extrapolate_ratio` logic (CPU)
- `preprocessing/steps/reshape_feature_distribution_step.py` — preset wiring
- `preprocessing/torch/{factory,steps,gpu_preprocessing_metadata,torch_quantile_transformer}.py` — GPU path
- tests for CPU transform, torch transform, and CPU/GPU consistency

## Test plan

- `test_adaptive_quantile_transformer.py` — 5/5 pass (incl. NaN-column & constant-feature edge cases)
- `test_torch_quantile_transformer.py` extrapolation suite — 3/3 pass (incl. `matches_cpu_on_out_of_range_inputs`)

Note: repo policy is "open an issue first" — happy to file/link one; opening this so the diff is reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes numeric preprocessing for a new checkpoint-critical preset and must keep CPU/GPU paths aligned; mistakes could shift model inputs at inference, though scope is limited to quantile uniform extrapolation with tests guarding parity.
> 
> **Overview**
> Adds **`quantile_uni_extrapolate`** as a registered `PreprocessorConfig` name so v3 OOD regressor checkpoints can load without validation errors.
> 
> The preset uses uniform quantile mapping with an optional **`extrapolate_ratio`** (default **1.0** for this preset): values outside the training min/max are linearly scaled past `[0, 1]` and clipped to `[-ratio, 1 + ratio]` instead of being flattened at the boundary, preserving more OOD signal. **CPU** `AdaptiveQuantileTransformer` stores `x_min_`/`x_max_` at fit and overrides `transform`; **GPU** `TorchQuantileTransformer` mirrors the same logic and is marked GPU-eligible. Wiring runs through reshape presets, `get_extrapolate_ratio_for_preset`, and the torch factory/selective quantile steps. Tests cover extrapolation, NaN/constant features, validation, CPU/GPU parity, and pipeline consistency (including the new preset across dtypes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e89320abb05deeee87ae9fe68fa109c8fbcb2283. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->