### PR TITLE
Remove feature selection cell from TabPFN_Demo_Local notebook

### DIFF
--- a/changelog/978.changed.md
+++ b/changelog/978.changed.md
@@ -1,0 +1,1 @@
+Remove the feature selection cell from the TabPFN_Demo_Local example notebook.

--- a/examples/notebooks/TabPFN_Demo_Local.ipynb
+++ b/examples/notebooks/TabPFN_Demo_Local.ipynb
@@ -3180,56 +3180,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "PkphS4vSFNvg"
-   },
-   "source": [
-    "### Feature selection\n",
-    "\n",
-    "Feature selection is the process of selecting a subset of relevant features for use in model construction. It's useful for reducing model complexity, improving performance by removing noise, and decreasing training time. Here, we'll use Sequential Forward Selection (SFS), which starts with no features and iteratively adds the feature that most improves the model's performance.\n",
-    "\n",
-    "The goal is to see if we can create a simpler, faster model with fewer features without a significant drop in accuracy.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "GPJtNDLnFPPW"
-   },
-   "outputs": [],
-   "source": [
-    "from tabpfn_extensions import interpretability\n",
-    "\n",
-    "# Load data\n",
-    "data = load_breast_cancer()\n",
-    "X, y = data.data, data.target\n",
-    "feature_names = data.feature_names\n",
-    "\n",
-    "# Initialize model\n",
-    "clf = TabPFNClassifier(n_estimators=1)\n",
-    "\n",
-    "# Feature selection\n",
-    "sfs = interpretability.feature_selection.feature_selection(\n",
-    "    estimator=clf,\n",
-    "    X=X,\n",
-    "    y=y,\n",
-    "    n_features_to_select=4,\n",
-    "    feature_names=feature_names,\n",
-    "    cv=3,\n",
-    ")\n",
-    "\n",
-    "# Print selected features\n",
-    "selected_features = [\n",
-    "    feature_names[i] for i in range(len(feature_names)) if sfs.get_support()[i]\n",
-    "]\n",
-    "print(\"\\nSelected features:\")\n",
-    "for feature in selected_features:\n",
-    "    print(f\"- {feature}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
     "id": "lmPJW5NSK7ut"
    },
    "source": [


### PR DESCRIPTION
## Summary
- Removes the "### Feature selection" markdown header and the accompanying SFS code cell from `examples/notebooks/TabPFN_Demo_Local.ipynb`. -> This is because feature selection is pretty expensive and generally not very helpful for TabPFN (at least using the feature selection extensions).

## Test plan
- [x] Open the notebook and confirm the Feature selection section no longer appears between the Embeddings section and the "Predictive Behavior of TabPFN" section.