### PR TITLE
Register v3 OOD classifier + regressor checkpoints

### DIFF
--- a/changelog/982.added.md
+++ b/changelog/982.added.md
@@ -1,1 +1,1 @@
-Register `tabpfn-v3-classifier-v3_ood.ckpt` and `tabpfn-v3-regressor-v3_ood.ckpt` so they can be loaded from Hugging Face by filename.
+Register `tabpfn-v3-classifier-v3_20260506_ood.ckpt` and `tabpfn-v3-regressor-v3_20260506_ood.ckpt` so they can be loaded from Hugging Face by filename.

--- a/changelog/982.added.md
+++ b/changelog/982.added.md
@@ -1,0 +1,1 @@
+Register `tabpfn-v3-classifier-v3_ood.ckpt` and `tabpfn-v3-regressor-v3_ood.ckpt` so they can be loaded from Hugging Face by filename.

--- a/src/tabpfn/model_loading.py
+++ b/src/tabpfn/model_loading.py
@@ -172,7 +172,7 @@ class ModelSource:  # noqa: D101
             "tabpfn-v3-classifier-v3_default.ckpt",
             "tabpfn-v3-classifier-v3_20260417_binary.ckpt",
             "tabpfn-v3-classifier-v3_20260417_multiclass.ckpt",
-            "tabpfn-v3-classifier-v3_ood.ckpt",
+            "tabpfn-v3-classifier-v3_20260506_ood.ckpt",
         ]
         return cls(
             repo_id="Prior-Labs/tabpfn_3",
@@ -186,7 +186,7 @@ class ModelSource:  # noqa: D101
             "tabpfn-v3-regressor-v3_default.ckpt",
             "tabpfn-v3-regressor-v3_20260417_mediumdata.ckpt",
             "tabpfn-v3-regressor-v3_20260506_timeseries.ckpt",
-            "tabpfn-v3-regressor-v3_ood.ckpt",
+            "tabpfn-v3-regressor-v3_20260506_ood.ckpt",
         ]
         return cls(
             repo_id="Prior-Labs/tabpfn_3",

--- a/src/tabpfn/model_loading.py
+++ b/src/tabpfn/model_loading.py
@@ -172,6 +172,7 @@ class ModelSource:  # noqa: D101
             "tabpfn-v3-classifier-v3_default.ckpt",
             "tabpfn-v3-classifier-v3_20260417_binary.ckpt",
             "tabpfn-v3-classifier-v3_20260417_multiclass.ckpt",
+            "tabpfn-v3-classifier-v3_ood.ckpt",
         ]
         return cls(
             repo_id="Prior-Labs/tabpfn_3",
@@ -185,6 +186,7 @@ class ModelSource:  # noqa: D101
             "tabpfn-v3-regressor-v3_default.ckpt",
             "tabpfn-v3-regressor-v3_20260417_mediumdata.ckpt",
             "tabpfn-v3-regressor-v3_20260506_timeseries.ckpt",
+            "tabpfn-v3-regressor-v3_ood.ckpt",
         ]
         return cls(
             repo_id="Prior-Labs/tabpfn_3",


### PR DESCRIPTION
## Summary

Adds the two new v3 OOD checkpoints to `ModelSource.get_classifier_v3` / `get_regressor_v3` so they're downloadable from `Prior-Labs/tabpfn_3` by short name. Defaults are unchanged.

## Added filenames
- `tabpfn-v3-classifier-v3_ood.ckpt`
- `tabpfn-v3-regressor-v3_ood.ckpt`

## What they contain

Same trained weights as the v3 release defaults (verified: identical `state_dict` sha) — only `inference_config.PREPROCESS_TRANSFORMS` differs. Built by loading each HF default ckpt and swapping its preprocessor list:

- **Classifier**: `squashing_scaler_max10` + `none` (OOD-robust squashing scaler clamped at ±10σ; quantile transform dropped)
- **Regressor**: `quantile_uni_extrapolate` + `squashing_scaler_max10` (the extrapolating quantile transform from #971, which preserves OOD information by linearly extrapolating past `[0, 1]` instead of clamping)

Everything else in the bundled `inference_config` (MAX_NUMBER_OF_SAMPLES=1_000_000, MAX_NUMBER_OF_FEATURES=2_000, FEATURE_SUBSAMPLING_METHOD=auto, FEATURE_SUBSAMPLING_IMPORTANCE_TOP_K_COUNT=150, max_features_per_estimator 200/500 for clf/reg) is inherited from the v3 release defaults unchanged.

## Depends on
- **#971** (merged): adds `quantile_uni_extrapolate` to the public preprocessor presets so the regressor ckpt can load.

## Linked HF PR
The ckpt files themselves will be uploaded via a separate HF PR against `Prior-Labs/tabpfn_3` (link to be added).

## Test plan
- [x] Both ckpts load + fit + predict locally (CPU)
- [x] `quantile_uni_extrapolate` GPU consistency CI green on #971
- [ ] HF upload PR opened/merged before this PR is released so the filename lookup actually resolves at download time

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry-only change to allowed checkpoint names; no logic, defaults, or inference code paths are modified.
> 
> **Overview**
> Registers two new v3 checkpoint filenames in `ModelSource` so they can be resolved, downloaded from `Prior-Labs/tabpfn_3`, and included in bulk download—without changing the v3 default checkpoints.
> 
> **Classifier:** `tabpfn-v3-classifier-v3_20260506_ood.ckpt` is added to `get_classifier_v3()`. **Regressor:** `tabpfn-v3-regressor-v3_20260506_ood.ckpt` is added to `get_regressor_v3()`. A changelog entry documents the same names.
> 
> These OOD variants are intended to reuse default v3 weights while shipping different `PREPROCESS_TRANSFORMS` in the bundled `inference_config` (OOD-oriented preprocessing); that behavior lives in the checkpoint files on Hugging Face, not in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c20b5644d6c7d32196a898623d396eaf3a9d5fee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->