### PR TITLE
test(nightly): enforce latest tabpfn-extensions in notebook install check

### DIFF
--- a/changelog/984.changed.md
+++ b/changelog/984.changed.md
@@ -1,0 +1,1 @@
+Nightly notebook install check now also asserts `tabpfn-extensions` resolves to PyPI latest for every example notebook that installs it, catching the case where a stale upper pin or transitive constraint would silently install an outdated `tabpfn-extensions`.

--- a/changelog/984.changed.md
+++ b/changelog/984.changed.md
@@ -1,1 +1,0 @@
-Nightly notebook install check now also asserts `tabpfn-extensions` resolves to PyPI latest for every example notebook that installs it, catching the case where a stale upper pin or transitive constraint would silently install an outdated `tabpfn-extensions`.

--- a/tests/test_notebook_installs.py
+++ b/tests/test_notebook_installs.py
@@ -1,10 +1,12 @@
 #  Copyright (c) Prior Labs GmbH 2026.
 
-"""Verify each example notebook resolves `tabpfn` to the latest PyPI release.
+"""Verify each example notebook resolves pinned packages to PyPI latest.
 
 Reproduces the install sequence from each `examples/notebooks/*.ipynb` in a
-fresh venv and asserts that `tabpfn` resolves to the version currently
-published as latest on PyPI.
+fresh venv and asserts that `tabpfn` (always) and `tabpfn-extensions` (when
+the notebook installs it) resolve to the version currently published as
+latest on PyPI. Catches the case where a stale upper pin or transitive
+constraint silently downgrades a package below its latest release.
 
 Skipped by default. Set `RUN_NOTEBOOK_INSTALL_CHECK=1` to enable.
 Intended to run from `.github/workflows/nightly-notebook-check.yml`, not
@@ -52,24 +54,49 @@ def _extract_install_lines(notebook_path: Path) -> list[str]:
     return lines
 
 
-@functools.lru_cache(maxsize=1)
-def _latest_tabpfn_version() -> str:
-    """Fetch latest tabpfn version from PyPI.
+@functools.cache
+def _latest_pypi_version(package: str) -> str:
+    """Fetch latest version of `package` from PyPI.
 
-    Cached so we only hit PyPI once per session regardless of notebook count.
-    Network failures crash the test loudly — the workflow surfaces them as
-    nightly-failure issues for the maintainer to investigate or rerun.
+    Cached so we only hit PyPI once per (session, package) regardless of
+    notebook count. Network failures crash the test loudly — the workflow
+    surfaces them as nightly-failure issues for the maintainer to
+    investigate or rerun.
     """
     req = Request(
-        "https://pypi.org/pypi/tabpfn/json",
+        f"https://pypi.org/pypi/{package}/json",
         headers={"User-Agent": "tabpfn-notebook-check/1.0"},
     )
     with urlopen(req, timeout=15) as r:  # noqa: S310
         return cast("str", json.load(r)["info"]["version"])
 
 
+def _installed_version(package: str, env: dict[str, str]) -> str | None:
+    """Return the installed version of `package` in `env`'s venv, or None."""
+    show = subprocess.run(  # noqa: S603
+        ["uv", "pip", "show", package],  # noqa: S607
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if show.returncode != 0:
+        return None
+    return next(
+        (
+            line.split(":", 1)[1].strip()
+            for line in show.stdout.splitlines()
+            if line.startswith("Version:")
+        ),
+        None,
+    )
+
+
 @pytest.mark.parametrize("notebook", NOTEBOOKS, ids=lambda p: p.name)
-def test_notebook_resolves_latest_tabpfn(notebook: Path, tmp_path: Path) -> None:
+def test_notebook_resolves_latest_pinned_packages(
+    notebook: Path,
+    tmp_path: Path,
+) -> None:
     if shutil.which("uv") is None:
         pytest.skip("uv not on PATH")
 
@@ -104,20 +131,34 @@ def test_notebook_resolves_latest_tabpfn(notebook: Path, tmp_path: Path) -> None
             timeout=600,
         )
 
-    show = subprocess.run(
-        ["uv", "pip", "show", "tabpfn"],  # noqa: S607
-        env=env,
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    installed = next(
-        line.split(":", 1)[1].strip()
-        for line in show.stdout.splitlines()
-        if line.startswith("Version:")
-    )
+    # `tabpfn` must be installed by every notebook in this directory; the
+    # nightly check exists precisely to catch the case where a notebook's
+    # install sequence stops resolving it to latest. `tabpfn-extensions` is
+    # only installed by some notebooks (e.g. TabPFN_Demo_Local), so we only
+    # check it when present — a notebook that doesn't install it isn't
+    # expected to.
+    required = ["tabpfn"]
+    optional = ["tabpfn-extensions"]
 
-    latest = _latest_tabpfn_version()
-    assert installed == latest, (
-        f"{notebook.name}: installed tabpfn=={installed}, PyPI latest is {latest}."
-    )
+    failures = []
+    for package in required:
+        installed = _installed_version(package, env)
+        if installed is None:
+            failures.append(f"{package} not installed")
+            continue
+        latest = _latest_pypi_version(package)
+        if installed != latest:
+            failures.append(
+                f"{package}=={installed} (PyPI latest is {latest})",
+            )
+    for package in optional:
+        installed = _installed_version(package, env)
+        if installed is None:
+            continue
+        latest = _latest_pypi_version(package)
+        if installed != latest:
+            failures.append(
+                f"{package}=={installed} (PyPI latest is {latest})",
+            )
+
+    assert not failures, f"{notebook.name}: " + "; ".join(failures)


### PR DESCRIPTION
## Summary
- Extend the nightly notebook install check so that, in addition to `tabpfn`, any notebook that installs `tabpfn-extensions` also pins it to PyPI latest. This addresses [PRI-272](https://linear.app/priorlabs/issue/PRI-272/improve-tabpfn-extensions-test-launched-from-tabpfn) — the previous check only verified `tabpfn`, which is why an outdated `tabpfn-extensions` in `TabPFN_Demo_Local.ipynb` could regress without catching (cf. PRI-268 / PRI-269).
- Refactor the PyPI version lookup into a generic `_latest_pypi_version(package)` (cached per-package) and add `_installed_version(package, env)` returning `None` when the package isn't in the venv, so the check can stay silent for notebooks that don't install extensions.

## Test plan
- [x] Local positive run: `RUN_NOTEBOOK_INSTALL_CHECK=1 pytest --noconftest tests/test_notebook_installs.py -v` — both notebooks pass; `TabPFN_Demo_Local.ipynb` now also verifies `tabpfn-extensions`.
- [x] Local negative-control run with `_latest_pypi_version` monkey-patched to return a fake version: both notebooks fail on `tabpfn`, and `TabPFN_Demo_Local.ipynb` additionally fails on `tabpfn-extensions=={installed} (PyPI latest is …)`, confirming the new optional check actually fires.
- [ ] Trigger the nightly workflow via `workflow_dispatch` after merge to confirm CI behavior on all matrix Python versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)