### PR TITLE
Ensure .devices_ attribute is always defined.

### DIFF
--- a/changelog/985.fixed.md
+++ b/changelog/985.fixed.md
@@ -1,0 +1,1 @@
+Always define `.devices_` attribute on `TabPFNClassifier` and `TabPFNRegressor`, rather than leaving it undefined. It is `None` before `.fit()`.

--- a/src/tabpfn/classifier.py
+++ b/src/tabpfn/classifier.py
@@ -140,11 +140,11 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
     inference_config_: InferenceConfig
     """Additional configuration of the interface for expert users."""
 
-    devices_: tuple[torch.device, ...]
-    """The devices determined to be used.
+    devices_: tuple[torch.device, ...] | None
+    """The devices used by fit() and predict(), or None if fit() was not called yet.
 
-    The devices are determined based on the `device` argument to the constructor, and
-    the devices available on the system. See the constructor documentation for details.
+    The devices are selected based on the ``device`` argument to the constructor. See
+    the constructor documentation for details.
     """
 
     feature_names_in_: npt.NDArray[Any]
@@ -496,6 +496,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
         self.n_preprocessing_jobs = n_preprocessing_jobs
         self.eval_metric = eval_metric
         self.tuning_config = tuning_config
+        self.devices_ = None
         initialize_telemetry()
 
         # Only anonymously record `fit_mode` usage

--- a/src/tabpfn/regressor.py
+++ b/src/tabpfn/regressor.py
@@ -170,11 +170,11 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
     inference_config_: InferenceConfig
     """Additional configuration of inference for expert users."""
 
-    devices_: tuple[torch.device, ...]
-    """The devices determined to be used.
+    devices_: tuple[torch.device, ...] | None
+    """The devices used by fit() and predict(), or None if fit() was not called yet.
 
-    The devices are determined based on the `device` argument to the constructor, and
-    the devices available on the system. See the constructor documentation for details.
+    The devices are selected based on the ``device`` argument to the constructor. See
+    the constructor documentation for details.
     """
 
     feature_names_in_: npt.NDArray[Any]
@@ -484,6 +484,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
             )
         self.n_jobs = n_jobs
         self.n_preprocessing_jobs = n_preprocessing_jobs
+        self.devices_ = None
         initialize_telemetry()
 
         # Only anonymously record `fit_mode` usage

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -24,6 +24,19 @@ device_combinations = [
 ]
 
 
+@pytest.mark.parametrize("estimator_class", [TabPFNRegressor, TabPFNClassifier])
+def test__devices_attribute__is_None_before_fit_and_set_after(
+    estimator_class: type[TabPFNClassifier] | type[TabPFNRegressor],
+) -> None:
+    estimator = estimator_class(n_estimators=1)
+    assert estimator.devices_ is None
+
+    X_train, _, y_train = _get_tiny_dataset(estimator)
+    estimator.fit(X_train, y_train)
+    assert estimator.devices_ is not None
+    assert all(isinstance(d, torch.device) for d in estimator.devices_)
+
+
 @pytest.mark.parametrize(("device_1", "device_2"), device_combinations)
 @pytest.mark.parametrize("estimator_class", [TabPFNRegressor, TabPFNClassifier])
 @pytest.mark.parametrize("fit_mode", ["fit_preprocessors", "low_memory"])


### PR DESCRIPTION
Before it was undefined until `.fit()`. Now it's `None` until then.

Fixes PRI-175