### PR TITLE
[part of PRI-245] Single-file TabPFN v2: load base-architecture checkpoints

### DIFF
--- a/src/tabpfn/architectures/tabpfn_v2_sf.py
+++ b/src/tabpfn/architectures/tabpfn_v2_sf.py
@@ -22,6 +22,7 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Literal, cast
 from typing_extensions import override
 
+import pydantic
 import torch
 import torch.utils.checkpoint
 from torch import nn
@@ -40,7 +41,7 @@ if TYPE_CHECKING:
     from tabpfn.architectures.encoders import TorchPreprocessingPipeline
 
 
-@dataclasses.dataclass
+@pydantic.dataclasses.dataclass
 class TabPFNV2Config(ArchitectureConfig):
     """Configuration for the single-file TabPFN v2 architecture."""
 

--- a/src/tabpfn/architectures/tabpfn_v2_sf.py
+++ b/src/tabpfn/architectures/tabpfn_v2_sf.py
@@ -7,8 +7,9 @@ following features which are required for public deployment:
   device.
 - This implementation does not support the KV cache.
 
-Note that this version is not compatible with the original checkpoints as layers
-have been renamed/restructured.
+Although the transformer layers have been renamed/restructured relative to the base
+architecture, checkpoints trained with the base architecture can still be loaded: see
+:meth:`TabPFNV2.load_state_dict`, which translates the old key names on the fly.
 
 Copyright (c) Prior Labs GmbH 2025.
 """
@@ -17,6 +18,7 @@ from __future__ import annotations
 
 import dataclasses
 from abc import ABC
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Literal, cast
 from typing_extensions import override
 
@@ -543,6 +545,28 @@ class TabPFNV2(Architecture):
     def embedding_dim(self) -> int:
         return self.emsize
 
+    @override
+    def load_state_dict(
+        self,
+        state_dict: Mapping[str, Any],
+        strict: bool = True,
+        assign: bool = False,
+    ) -> Any:
+        """Load a state dict, translating old base-architecture key names if needed.
+
+        Checkpoints trained with the multi-file ``base`` architecture use a different
+        naming convention (and layout) for the transformer blocks and the decoder. If
+        such keys are detected, they are remapped to this architecture's names before
+        loading. The encoder/y-encoder keys are shared between the two architectures and
+        pass through unchanged.
+        """
+        has_base_keys = any(
+            k.startswith(("transformer_encoder.", "decoder_dict.")) for k in state_dict
+        )
+        if has_base_keys:
+            state_dict = _replace_keys_from_base_architecture(dict(state_dict))
+        return super().load_state_dict(state_dict, strict=strict, assign=assign)
+
     def muon_compatible_params(self) -> set[nn.Parameter]:
         """Return parameters suitable for the Muon optimizer.
 
@@ -672,6 +696,86 @@ class TabPFNV2(Architecture):
         output["test_embeddings"] = test_embeddings_TBE
 
         return output
+
+
+def _replace_keys_from_base_architecture(
+    state_dict: dict[str, torch.Tensor],
+) -> dict[str, torch.Tensor]:
+    """Translate a base-architecture state dict to the single-file v2 key names.
+
+    Only the transformer blocks and the decoder are renamed/restructured; the
+    encoder and y-encoder share their naming with the base architecture, so their keys
+    (and any other keys not in the mapping) are passed through unchanged.
+    """
+    n_layers = sum(k.endswith("self_attn_between_features._w_qkv") for k in state_dict)
+
+    base_to_v2_mapping = [
+        ("decoder_dict.standard.0.weight", "output_projection.0.weight"),
+        ("decoder_dict.standard.0.bias", "output_projection.0.bias"),
+        ("decoder_dict.standard.2.weight", "output_projection.2.weight"),
+        ("decoder_dict.standard.2.bias", "output_projection.2.bias"),
+    ]
+    for i in range(n_layers):
+        base_to_v2_mapping.extend(
+            [
+                (
+                    f"transformer_encoder.layers.{i}.mlp.linear1.weight",
+                    f"blocks.{i}.mlp.0.weight",
+                ),
+                (
+                    f"transformer_encoder.layers.{i}.mlp.linear2.weight",
+                    f"blocks.{i}.mlp.2.weight",
+                ),
+                (
+                    f"transformer_encoder.layers.{i}.self_attn_between_features._w_qkv",
+                    f"blocks.{i}.per_sample_attention_between_features.qkv_projection.weight",
+                ),
+                (
+                    f"transformer_encoder.layers.{i}.self_attn_between_features._w_out",
+                    f"blocks.{i}.per_sample_attention_between_features.out_projection.weight",
+                ),
+                (
+                    f"transformer_encoder.layers.{i}.self_attn_between_items._w_qkv",
+                    f"blocks.{i}.per_column_attention_between_cells.qkv_projection.weight",
+                ),
+                (
+                    f"transformer_encoder.layers.{i}.self_attn_between_items._w_out",
+                    f"blocks.{i}.per_column_attention_between_cells.out_projection.weight",
+                ),
+            ]
+        )
+
+    new_state_dict: dict[str, torch.Tensor] = {}
+    known_base_keys: set[str] = set()
+    for base_key, v2_key in base_to_v2_mapping:
+        known_base_keys.add(base_key)
+        if base_key not in state_dict:
+            continue
+
+        # The base QKV weight has shape (3, num_heads, head_size, input_size). Split it
+        # into separate q/k/v weights of shape (num_heads * head_size, input_size).
+        if "qkv_projection.weight" in v2_key:
+            q_key = v2_key.replace("qkv_projection", "q_projection")
+            k_key = v2_key.replace("qkv_projection", "k_projection")
+            v_key = v2_key.replace("qkv_projection", "v_projection")
+            new_state_dict[q_key] = state_dict[base_key][0].flatten(0, 1)
+            new_state_dict[k_key] = state_dict[base_key][1].flatten(0, 1)
+            new_state_dict[v_key] = state_dict[base_key][2].flatten(0, 1)
+            continue
+
+        # The base out-projection weight has shape (num_heads, head_size, output_size).
+        # Flatten the heads and transpose to the nn.Linear convention (output, input).
+        if "out_projection.weight" in v2_key:
+            new_state_dict[v2_key] = state_dict[base_key].flatten(0, 1).T
+            continue
+
+        new_state_dict[v2_key] = state_dict[base_key]
+
+    for key, value in state_dict.items():
+        if key not in known_base_keys:
+            new_state_dict[key] = value
+
+    return new_state_dict
 
 
 def parse_config(config: dict[str, Any]) -> tuple[TabPFNV2Config, dict[str, Any]]:

--- a/src/tabpfn/architectures/tabpfn_v2_sf.py
+++ b/src/tabpfn/architectures/tabpfn_v2_sf.py
@@ -556,10 +556,7 @@ class TabPFNV2(Architecture):
         """Load a state dict, translating old base-architecture key names if needed.
 
         Checkpoints trained with the multi-file ``base`` architecture use a different
-        naming convention (and layout) for the transformer blocks and the decoder. If
-        such keys are detected, they are remapped to this architecture's names before
-        loading. The encoder/y-encoder keys are shared between the two architectures and
-        pass through unchanged.
+        naming convention (and layout) for the transformer blocks and the decoder.
         """
         has_base_keys = any(
             k.startswith(("transformer_encoder.", "decoder_dict.")) for k in state_dict

--- a/tests/test_architectures/test_tabpfn_v2_sf.py
+++ b/tests/test_architectures/test_tabpfn_v2_sf.py
@@ -15,87 +15,6 @@ from tabpfn.architectures.base.transformer import PerFeatureTransformer
 from tabpfn.architectures.interface import PerformanceOptions
 
 
-def _convert_state_dict_base_to_v2(
-    base_state_dict: dict[str, torch.Tensor],
-) -> dict[str, torch.Tensor]:
-    """Convert a base architecture state dict to a v2 architecture state dict."""
-    n_layers = len(
-        [k for k in base_state_dict if k.endswith("self_attn_between_features._w_qkv")]
-    )
-    base_to_v2_mapping = [
-        ("encoder.5.layer.weight", "encoder.5.layer.weight"),
-        ("y_encoder.2.layer.weight", "y_encoder.2.layer.weight"),
-        ("y_encoder.2.layer.bias", "y_encoder.2.layer.bias"),
-        ("decoder_dict.standard.0.weight", "output_projection.0.weight"),
-        ("decoder_dict.standard.0.bias", "output_projection.0.bias"),
-        ("decoder_dict.standard.2.weight", "output_projection.2.weight"),
-        ("decoder_dict.standard.2.bias", "output_projection.2.bias"),
-        (
-            "feature_positional_embedding_embeddings.weight",
-            "feature_positional_embedding_embeddings.weight",
-        ),
-        (
-            "feature_positional_embedding_embeddings.bias",
-            "feature_positional_embedding_embeddings.bias",
-        ),
-    ]
-    for i in range(n_layers):
-        base_to_v2_mapping.extend(
-            [
-                (
-                    f"transformer_encoder.layers.{i}.mlp.linear1.weight",
-                    f"blocks.{i}.mlp.0.weight",
-                ),
-                (
-                    f"transformer_encoder.layers.{i}.mlp.linear2.weight",
-                    f"blocks.{i}.mlp.2.weight",
-                ),
-                (
-                    f"transformer_encoder.layers.{i}.self_attn_between_features._w_qkv",
-                    f"blocks.{i}.per_sample_attention_between_features.qkv_projection.weight",
-                ),
-                (
-                    f"transformer_encoder.layers.{i}.self_attn_between_features._w_out",
-                    f"blocks.{i}.per_sample_attention_between_features.out_projection.weight",
-                ),
-                (
-                    f"transformer_encoder.layers.{i}.self_attn_between_items._w_qkv",
-                    f"blocks.{i}.per_column_attention_between_cells.qkv_projection.weight",
-                ),
-                (
-                    f"transformer_encoder.layers.{i}.self_attn_between_items._w_out",
-                    f"blocks.{i}.per_column_attention_between_cells.out_projection.weight",
-                ),
-            ]
-        )
-
-    new_state_dict = {
-        v2_key: base_state_dict[base_key] for base_key, v2_key in base_to_v2_mapping
-    }
-    keys_to_delete = []
-    keys_to_add = {}
-    for key, weight in new_state_dict.items():
-        # QKV projection weight is 3, num_heads, output_size, input_size
-        if "qkv_projection.weight" in key:
-            q_key = key.replace("qkv_projection", "q_projection")
-            k_key = key.replace("qkv_projection", "k_projection")
-            v_key = key.replace("qkv_projection", "v_projection")
-            keys_to_add[q_key] = weight[0].flatten(0, 1)
-            keys_to_add[k_key] = weight[1].flatten(0, 1)
-            keys_to_add[v_key] = weight[2].flatten(0, 1)
-            keys_to_delete.append(key)
-        if "out_projection.weight" in key:
-            # Out projection is num_heads, head_size, output_size
-            # Note that this differs from torch linear weight format
-            # (output, input) and we need to transpose the output into the first
-            # dim.
-            new_state_dict[key] = new_state_dict[key].flatten(0, 1).T
-    for key in keys_to_delete:
-        new_state_dict.pop(key)
-    new_state_dict.update(keys_to_add)
-    return new_state_dict
-
-
 def _create_identical_small_v2_and_base() -> tuple[
     tabpfn_v2_sf.TabPFNV2, PerFeatureTransformer
 ]:
@@ -135,14 +54,31 @@ def _create_identical_small_v2_and_base() -> tuple[
         if param.abs().sum() < 1e-6:
             param.data += torch.randn_like(param) * 1e-1
 
-    arch_v2.load_state_dict(
-        _convert_state_dict_base_to_v2(arch_base.state_dict()), strict=True
-    )
+    # load_state_dict translates the base-architecture key names automatically.
+    arch_v2.load_state_dict(arch_base.state_dict(), strict=True)
 
     arch_v2.to(torch.float64)
     arch_base.to(torch.float64)
 
     return arch_v2, arch_base
+
+
+@torch.no_grad()
+def test__load_state_dict__from_base_checkpoint_strict() -> None:
+    """A base-architecture state dict can be loaded strictly (all keys consumed)."""
+    arch_v2, arch_base = _create_identical_small_v2_and_base()
+    # Re-loading the (already translated) base state dict must succeed with strict=True,
+    # i.e. the translated keys exactly cover the single-file architecture's parameters.
+    result = arch_v2.load_state_dict(arch_base.state_dict(), strict=True)
+    assert not result.missing_keys
+    assert not result.unexpected_keys
+
+
+@torch.no_grad()
+def test__load_state_dict__native_keys_still_work() -> None:
+    """A round-trip of the single-file architecture's own state dict still works."""
+    arch_v2, _ = _create_identical_small_v2_and_base()
+    arch_v2.load_state_dict(arch_v2.state_dict(), strict=True)
 
 
 class TestTabPFNv2NewVsOldImplementation:
@@ -172,9 +108,8 @@ class TestTabPFNv2NewVsOldImplementation:
             ),
             cache_trainset_representation=False,
         )
-        arch_v2.load_state_dict(
-            _convert_state_dict_base_to_v2(arch_base.state_dict()), strict=True
-        )
+        # load_state_dict translates the base-architecture key names automatically.
+        arch_v2.load_state_dict(arch_base.state_dict(), strict=True)
 
         arch_v2.to(torch.float64)
         arch_base.to(torch.float64)


### PR DESCRIPTION
## Why

Stacked on #996 (the verbatim copy + comparison test). First of three feature PRs that complete the single-file v2 (the others: disk embeddings, KV cache).

## What

- Adds a `load_state_dict` override that detects base-architecture key names (`transformer_encoder.*` / `decoder_dict.*`) and translates them to the single-file layout: split the fused QKV weight into q/k/v, transpose the out-projection, and rename the blocks and decoder. Encoder/y-encoder keys are shared and pass through unchanged.
- The comparison tests now rely on this conversion (the bespoke `_convert_state_dict_base_to_v2` test helper is removed), plus dedicated strict-load and native-round-trip tests.
- Addresses review: `TabPFNV2Config` now uses `@pydantic.dataclasses.dataclass` (like `TabPFNV3Config`/`TabPFNV2p5Config`) so it inherits the runtime validation documented in `parse_config`.

## Testing

`tests/test_architectures/test_tabpfn_v2_sf.py` — 6 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)