### PR TITLE
[part of PRI-245] Single-file TabPFN v2: load positional embeddings from disk

### DIFF
--- a/src/tabpfn/architectures/tabpfn_v2_sf.py
+++ b/src/tabpfn/architectures/tabpfn_v2_sf.py
@@ -1,11 +1,12 @@
 """The TabPFN v2 model.
 
-Compared to v2 as implemented by the base architecture, this version is missing the
-following features which are required for public deployment:
-- The base architecture loads the positional embeddings from disk, whereas this one
-  generates them using a fixed random seed. Thus, their values may vary from device to
-  device.
+Compared to v2 as implemented by the base architecture, this version is still missing
+the following feature required for public deployment:
 - This implementation does not support the KV cache.
+
+Like the base architecture, it loads the positional embeddings from disk for the
+production seed 42 (see :meth:`TabPFNV2.add_column_embeddings`), so their values are
+consistent across devices.
 
 Although the transformer layers have been renamed/restructured relative to the base
 architecture, checkpoints trained with the base architecture can still be loaded: see
@@ -36,6 +37,7 @@ from tabpfn.architectures.interface import (
 )
 from tabpfn.architectures.shared.attention_gqa_check import gqa_is_supported
 from tabpfn.architectures.shared.chunked_evaluate import chunked_evaluate_maybe_inplace
+from tabpfn.architectures.shared.column_embeddings import load_column_embeddings
 
 if TYPE_CHECKING:
     from tabpfn.architectures.encoders import TorchPreprocessingPipeline
@@ -54,6 +56,14 @@ class TabPFNV2Config(ArchitectureConfig):
     features_per_group: Literal[1, 2] = 2
     """If > 1, the features will be grouped into groups of this size and the attention
     is across groups."""
+
+    seed: int = 42
+    """Seed used to generate the per-column positional embeddings.
+
+    When ``seed == 42`` and the embedding subspace size is 48 (i.e. ``emsize == 192``),
+    the first 2000 columns use the pre-generated embeddings loaded from disk, matching
+    the production checkpoints. For any other seed the embeddings are generated purely
+    from the random generator, which is what the comparison tests rely on."""
 
 
 class Attention(nn.Module, ABC):
@@ -535,6 +545,11 @@ class TabPFNV2(Architecture):
         self.feature_positional_embedding_embeddings = nn.Linear(
             self.input_size // 4, self.input_size
         )
+        self.seed = config.seed
+        # Pre-generated column embeddings, persisted to disk so they are consistent
+        # across platforms (random number generation varies between devices even with a
+        # fixed seed). Used for the first 2000 columns of the production checkpoints.
+        self.pre_generated_column_embeddings = load_column_embeddings()
         self._do_encoder_nan_check = True
         # TODO(Phil): This is here to not fail the memory computation. We should make
         # this a proper API.
@@ -576,10 +591,7 @@ class TabPFNV2(Architecture):
 
     def add_column_embeddings(self, x_BRCX: torch.Tensor) -> torch.Tensor:
         """Add a random embedding to each column to prevent feature collapse."""
-        # Note: Don't use 42 as seed here. Otherwise we cannot compare this
-        # implementation to the old multi-file implementation, because the
-        # multi-file implementation has a special treatment for seed=42.
-        generator = torch.Generator(device=x_BRCX.device).manual_seed(420)
+        generator = torch.Generator(device=x_BRCX.device).manual_seed(self.seed)
         num_cols, encoding_size = x_BRCX.shape[2], x_BRCX.shape[3]
         embs = torch.randn(
             (num_cols, encoding_size // 4),
@@ -587,6 +599,16 @@ class TabPFNV2(Architecture):
             dtype=x_BRCX.dtype,
             generator=generator,
         )
+        # Random numbers vary between devices, even with a fixed seed. Thus, for the
+        # production checkpoints (seed 42, embedding subspace size 48 == 192 // 4), we
+        # overwrite the first 2000 columns with the pre-generated embeddings loaded from
+        # disk to ensure they are consistent between pretraining and inference. Some
+        # tests use a smaller embedding size or a different seed, in which case we use
+        # the random embeddings.
+        if embs.shape[1] == 48 and self.seed == 42:
+            embs[:2000] = self.pre_generated_column_embeddings[: embs.shape[0]].to(
+                device=embs.device, dtype=embs.dtype
+            )
         embs = self.feature_positional_embedding_embeddings(embs)
         return x_BRCX + embs[None, None]
 

--- a/src/tabpfn/architectures/tabpfn_v2_sf.py
+++ b/src/tabpfn/architectures/tabpfn_v2_sf.py
@@ -7,8 +7,9 @@ following features which are required for public deployment:
   device.
 - This implementation does not support the KV cache.
 
-Note that this version is not compatible with the original checkpoints as layers
-have been renamed/restructured.
+Although the transformer layers have been renamed/restructured relative to the base
+architecture, checkpoints trained with the base architecture can still be loaded: see
+:meth:`TabPFNV2.load_state_dict`, which translates the old key names on the fly.
 
 Copyright (c) Prior Labs GmbH 2025.
 """
@@ -17,9 +18,11 @@ from __future__ import annotations
 
 import dataclasses
 from abc import ABC
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Literal, cast
 from typing_extensions import override
 
+import pydantic
 import torch
 import torch.utils.checkpoint
 from torch import nn
@@ -38,7 +41,7 @@ if TYPE_CHECKING:
     from tabpfn.architectures.encoders import TorchPreprocessingPipeline
 
 
-@dataclasses.dataclass
+@pydantic.dataclasses.dataclass
 class TabPFNV2Config(ArchitectureConfig):
     """Configuration for the single-file TabPFN v2 architecture."""
 
@@ -543,6 +546,25 @@ class TabPFNV2(Architecture):
     def embedding_dim(self) -> int:
         return self.emsize
 
+    @override
+    def load_state_dict(
+        self,
+        state_dict: Mapping[str, Any],
+        strict: bool = True,
+        assign: bool = False,
+    ) -> Any:
+        """Load a state dict, translating old base-architecture key names if needed.
+
+        Checkpoints trained with the multi-file ``base`` architecture use a different
+        naming convention (and layout) for the transformer blocks and the decoder.
+        """
+        has_base_keys = any(
+            k.startswith(("transformer_encoder.", "decoder_dict.")) for k in state_dict
+        )
+        if has_base_keys:
+            state_dict = _replace_keys_from_base_architecture(dict(state_dict))
+        return super().load_state_dict(state_dict, strict=strict, assign=assign)
+
     def muon_compatible_params(self) -> set[nn.Parameter]:
         """Return parameters suitable for the Muon optimizer.
 
@@ -672,6 +694,86 @@ class TabPFNV2(Architecture):
         output["test_embeddings"] = test_embeddings_TBE
 
         return output
+
+
+def _replace_keys_from_base_architecture(
+    state_dict: dict[str, torch.Tensor],
+) -> dict[str, torch.Tensor]:
+    """Translate a base-architecture state dict to the single-file v2 key names.
+
+    Only the transformer blocks and the decoder are renamed/restructured; the
+    encoder and y-encoder share their naming with the base architecture, so their keys
+    (and any other keys not in the mapping) are passed through unchanged.
+    """
+    n_layers = sum(k.endswith("self_attn_between_features._w_qkv") for k in state_dict)
+
+    base_to_v2_mapping = [
+        ("decoder_dict.standard.0.weight", "output_projection.0.weight"),
+        ("decoder_dict.standard.0.bias", "output_projection.0.bias"),
+        ("decoder_dict.standard.2.weight", "output_projection.2.weight"),
+        ("decoder_dict.standard.2.bias", "output_projection.2.bias"),
+    ]
+    for i in range(n_layers):
+        base_to_v2_mapping.extend(
+            [
+                (
+                    f"transformer_encoder.layers.{i}.mlp.linear1.weight",
+                    f"blocks.{i}.mlp.0.weight",
+                ),
+                (
+                    f"transformer_encoder.layers.{i}.mlp.linear2.weight",
+                    f"blocks.{i}.mlp.2.weight",
+                ),
+                (
+                    f"transformer_encoder.layers.{i}.self_attn_between_features._w_qkv",
+                    f"blocks.{i}.per_sample_attention_between_features.qkv_projection.weight",
+                ),
+                (
+                    f"transformer_encoder.layers.{i}.self_attn_between_features._w_out",
+                    f"blocks.{i}.per_sample_attention_between_features.out_projection.weight",
+                ),
+                (
+                    f"transformer_encoder.layers.{i}.self_attn_between_items._w_qkv",
+                    f"blocks.{i}.per_column_attention_between_cells.qkv_projection.weight",
+                ),
+                (
+                    f"transformer_encoder.layers.{i}.self_attn_between_items._w_out",
+                    f"blocks.{i}.per_column_attention_between_cells.out_projection.weight",
+                ),
+            ]
+        )
+
+    new_state_dict: dict[str, torch.Tensor] = {}
+    known_base_keys: set[str] = set()
+    for base_key, v2_key in base_to_v2_mapping:
+        known_base_keys.add(base_key)
+        if base_key not in state_dict:
+            continue
+
+        # The base QKV weight has shape (3, num_heads, head_size, input_size). Split it
+        # into separate q/k/v weights of shape (num_heads * head_size, input_size).
+        if "qkv_projection.weight" in v2_key:
+            q_key = v2_key.replace("qkv_projection", "q_projection")
+            k_key = v2_key.replace("qkv_projection", "k_projection")
+            v_key = v2_key.replace("qkv_projection", "v_projection")
+            new_state_dict[q_key] = state_dict[base_key][0].flatten(0, 1)
+            new_state_dict[k_key] = state_dict[base_key][1].flatten(0, 1)
+            new_state_dict[v_key] = state_dict[base_key][2].flatten(0, 1)
+            continue
+
+        # The base out-projection weight has shape (num_heads, head_size, output_size).
+        # Flatten the heads and transpose to the nn.Linear convention (output, input).
+        if "out_projection.weight" in v2_key:
+            new_state_dict[v2_key] = state_dict[base_key].flatten(0, 1).T
+            continue
+
+        new_state_dict[v2_key] = state_dict[base_key]
+
+    for key, value in state_dict.items():
+        if key not in known_base_keys:
+            new_state_dict[key] = value
+
+    return new_state_dict
 
 
 def parse_config(config: dict[str, Any]) -> tuple[TabPFNV2Config, dict[str, Any]]:

--- a/tests/test_architectures/test_tabpfn_v2_sf.py
+++ b/tests/test_architectures/test_tabpfn_v2_sf.py
@@ -15,87 +15,6 @@ from tabpfn.architectures.base.transformer import PerFeatureTransformer
 from tabpfn.architectures.interface import PerformanceOptions
 
 
-def _convert_state_dict_base_to_v2(
-    base_state_dict: dict[str, torch.Tensor],
-) -> dict[str, torch.Tensor]:
-    """Convert a base architecture state dict to a v2 architecture state dict."""
-    n_layers = len(
-        [k for k in base_state_dict if k.endswith("self_attn_between_features._w_qkv")]
-    )
-    base_to_v2_mapping = [
-        ("encoder.5.layer.weight", "encoder.5.layer.weight"),
-        ("y_encoder.2.layer.weight", "y_encoder.2.layer.weight"),
-        ("y_encoder.2.layer.bias", "y_encoder.2.layer.bias"),
-        ("decoder_dict.standard.0.weight", "output_projection.0.weight"),
-        ("decoder_dict.standard.0.bias", "output_projection.0.bias"),
-        ("decoder_dict.standard.2.weight", "output_projection.2.weight"),
-        ("decoder_dict.standard.2.bias", "output_projection.2.bias"),
-        (
-            "feature_positional_embedding_embeddings.weight",
-            "feature_positional_embedding_embeddings.weight",
-        ),
-        (
-            "feature_positional_embedding_embeddings.bias",
-            "feature_positional_embedding_embeddings.bias",
-        ),
-    ]
-    for i in range(n_layers):
-        base_to_v2_mapping.extend(
-            [
-                (
-                    f"transformer_encoder.layers.{i}.mlp.linear1.weight",
-                    f"blocks.{i}.mlp.0.weight",
-                ),
-                (
-                    f"transformer_encoder.layers.{i}.mlp.linear2.weight",
-                    f"blocks.{i}.mlp.2.weight",
-                ),
-                (
-                    f"transformer_encoder.layers.{i}.self_attn_between_features._w_qkv",
-                    f"blocks.{i}.per_sample_attention_between_features.qkv_projection.weight",
-                ),
-                (
-                    f"transformer_encoder.layers.{i}.self_attn_between_features._w_out",
-                    f"blocks.{i}.per_sample_attention_between_features.out_projection.weight",
-                ),
-                (
-                    f"transformer_encoder.layers.{i}.self_attn_between_items._w_qkv",
-                    f"blocks.{i}.per_column_attention_between_cells.qkv_projection.weight",
-                ),
-                (
-                    f"transformer_encoder.layers.{i}.self_attn_between_items._w_out",
-                    f"blocks.{i}.per_column_attention_between_cells.out_projection.weight",
-                ),
-            ]
-        )
-
-    new_state_dict = {
-        v2_key: base_state_dict[base_key] for base_key, v2_key in base_to_v2_mapping
-    }
-    keys_to_delete = []
-    keys_to_add = {}
-    for key, weight in new_state_dict.items():
-        # QKV projection weight is 3, num_heads, output_size, input_size
-        if "qkv_projection.weight" in key:
-            q_key = key.replace("qkv_projection", "q_projection")
-            k_key = key.replace("qkv_projection", "k_projection")
-            v_key = key.replace("qkv_projection", "v_projection")
-            keys_to_add[q_key] = weight[0].flatten(0, 1)
-            keys_to_add[k_key] = weight[1].flatten(0, 1)
-            keys_to_add[v_key] = weight[2].flatten(0, 1)
-            keys_to_delete.append(key)
-        if "out_projection.weight" in key:
-            # Out projection is num_heads, head_size, output_size
-            # Note that this differs from torch linear weight format
-            # (output, input) and we need to transpose the output into the first
-            # dim.
-            new_state_dict[key] = new_state_dict[key].flatten(0, 1).T
-    for key in keys_to_delete:
-        new_state_dict.pop(key)
-    new_state_dict.update(keys_to_add)
-    return new_state_dict
-
-
 def _create_identical_small_v2_and_base() -> tuple[
     tabpfn_v2_sf.TabPFNV2, PerFeatureTransformer
 ]:
@@ -135,14 +54,31 @@ def _create_identical_small_v2_and_base() -> tuple[
         if param.abs().sum() < 1e-6:
             param.data += torch.randn_like(param) * 1e-1
 
-    arch_v2.load_state_dict(
-        _convert_state_dict_base_to_v2(arch_base.state_dict()), strict=True
-    )
+    # load_state_dict translates the base-architecture key names automatically.
+    arch_v2.load_state_dict(arch_base.state_dict(), strict=True)
 
     arch_v2.to(torch.float64)
     arch_base.to(torch.float64)
 
     return arch_v2, arch_base
+
+
+@torch.no_grad()
+def test__load_state_dict__from_base_checkpoint_strict() -> None:
+    """A base-architecture state dict can be loaded strictly (all keys consumed)."""
+    arch_v2, arch_base = _create_identical_small_v2_and_base()
+    # Re-loading the (already translated) base state dict must succeed with strict=True,
+    # i.e. the translated keys exactly cover the single-file architecture's parameters.
+    result = arch_v2.load_state_dict(arch_base.state_dict(), strict=True)
+    assert not result.missing_keys
+    assert not result.unexpected_keys
+
+
+@torch.no_grad()
+def test__load_state_dict__native_keys_still_work() -> None:
+    """A round-trip of the single-file architecture's own state dict still works."""
+    arch_v2, _ = _create_identical_small_v2_and_base()
+    arch_v2.load_state_dict(arch_v2.state_dict(), strict=True)
 
 
 class TestTabPFNv2NewVsOldImplementation:
@@ -172,9 +108,8 @@ class TestTabPFNv2NewVsOldImplementation:
             ),
             cache_trainset_representation=False,
         )
-        arch_v2.load_state_dict(
-            _convert_state_dict_base_to_v2(arch_base.state_dict()), strict=True
-        )
+        # load_state_dict translates the base-architecture key names automatically.
+        arch_v2.load_state_dict(arch_base.state_dict(), strict=True)
 
         arch_v2.to(torch.float64)
         arch_base.to(torch.float64)

--- a/tests/test_architectures/test_tabpfn_v2_sf.py
+++ b/tests/test_architectures/test_tabpfn_v2_sf.py
@@ -13,6 +13,7 @@ from tabpfn import model_loading
 from tabpfn.architectures import base, tabpfn_v2_sf
 from tabpfn.architectures.base.transformer import PerFeatureTransformer
 from tabpfn.architectures.interface import PerformanceOptions
+from tabpfn.architectures.shared.column_embeddings import load_column_embeddings
 
 
 def _create_identical_small_v2_and_base() -> tuple[
@@ -26,6 +27,10 @@ def _create_identical_small_v2_and_base() -> tuple[
         nlayers=1,
         nhead=6,
         features_per_group=2,
+        # Use 420 (not the production default 42) so the column embeddings are
+        # generated purely from the random generator rather than loaded from disk,
+        # matching the base architecture configured below.
+        seed=420,
     )
     config_base = base.ModelConfig(
         max_num_classes=10,
@@ -96,15 +101,17 @@ class TestTabPFNv2NewVsOldImplementation:
             download_if_not_exists=True,
         )
         arch_base = cast(PerFeatureTransformer, loaded_models[0])
-        # This is the seed used by the v2 implementation. It's important not to use 42,
-        # as the base has special handling for this seed.
-        arch_base.random_embedding_seed = 420
         config_base = loaded_configs[0]
+        # Force seed 42 on both implementations, which makes them load the
+        # pre-generated column embeddings from disk for the first 2000 columns. This
+        # exercises the single-file implementation's disk-loading path end-to-end.
+        arch_base.random_embedding_seed = 42
 
         arch_v2 = tabpfn_v2_sf.get_architecture(
             tabpfn_v2_sf.TabPFNV2Config(
                 max_num_classes=config_base.max_num_classes,
                 num_buckets=config_base.num_buckets,
+                seed=42,
             ),
             cache_trainset_representation=False,
         )
@@ -196,3 +203,64 @@ def test__forward_pass_equal_with_checkpointing_enabled_and_disabled() -> None:
         assert torch.allclose(
             output_with_recomputation[key], output_without_recomputation[key]
         ), f"Outputs for {key} do not match between implementations."
+
+
+def _build_small_arch(seed: int, emsize: int = 192) -> tabpfn_v2_sf.TabPFNV2:
+    return tabpfn_v2_sf.get_architecture(
+        tabpfn_v2_sf.TabPFNV2Config(
+            max_num_classes=10,
+            num_buckets=5,
+            emsize=emsize,
+            nlayers=1,
+            nhead=6,
+            features_per_group=2,
+            seed=seed,
+        ),
+        cache_trainset_representation=False,
+    )
+
+
+@torch.no_grad()
+def test__column_embeddings__seed_42_loaded_from_disk() -> None:
+    """With the production seed (42) and 48-d subspace, embeddings come from disk."""
+    arch = _build_small_arch(seed=42)
+    disk_embeddings = load_column_embeddings()
+
+    num_cols = 7
+    x = torch.zeros(2, 3, num_cols, 192)
+    out = arch.add_column_embeddings(x.clone())
+
+    # The first `num_cols` rows of the disk embeddings, projected, should have been
+    # added to every (batch, row) position.
+    expected_subspace = disk_embeddings[:num_cols].to(dtype=x.dtype)
+    expected = arch.feature_positional_embedding_embeddings(expected_subspace)
+    assert torch.allclose(out[0, 0], expected, atol=1e-6)
+
+
+@torch.no_grad()
+def test__column_embeddings__non_production_seed_does_not_use_disk() -> None:
+    """A non-42 seed (or non-48 subspace) ignores the disk embeddings."""
+    disk_embeddings = load_column_embeddings()
+
+    num_cols = 7
+    x = torch.zeros(2, 3, num_cols, 192)
+
+    arch_420 = _build_small_arch(seed=420)
+    out_420 = arch_420.add_column_embeddings(x.clone())
+    expected_disk = arch_420.feature_positional_embedding_embeddings(
+        disk_embeddings[:num_cols].to(dtype=x.dtype)
+    )
+    # The random (seed 420) embeddings must differ from the disk-based ones.
+    assert not torch.allclose(out_420[0, 0], expected_disk, atol=1e-6)
+
+    # A smaller emsize (subspace != 48) also bypasses the disk embeddings even for
+    # seed 42, falling back to the random generator.
+    arch_small = _build_small_arch(seed=42, emsize=96)
+    x_small = torch.zeros(2, 3, num_cols, 96)
+    generator = torch.Generator().manual_seed(42)
+    expected_random = torch.randn((num_cols, 96 // 4), generator=generator)
+    expected_random = arch_small.feature_positional_embedding_embeddings(
+        expected_random
+    )
+    out_small = arch_small.add_column_embeddings(x_small.clone())
+    assert torch.allclose(out_small[0, 0], expected_random, atol=1e-6)


### PR DESCRIPTION
## Why

Stacked on #997. Second of the three feature PRs.

## What

Mirrors the base architecture: when the configured seed is 42 and the embedding subspace size is 48 (emsize 192), the first 2000 columns use the pre-generated column embeddings loaded from `architectures/shared/tabpfn_col_embedding.pt` instead of device-dependent random values. Adds a configurable `seed` field.

The full-model comparison test now forces seed 42 to exercise the disk path end-to-end; dedicated unit tests check both the disk path and the random fallback (non-42 seed / non-48 subspace).

## Testing

`tests/test_architectures/test_tabpfn_v2_sf.py` — 8 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)