### PR TITLE
Store Hugging Face cache in GitHub actions cache.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,12 +90,12 @@ jobs:
             -0
 
       # We use a persistent HuggingFace cache to avoid hitting rate limits.
-      - &hf-cache
-        name: HuggingFace cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - &restore-hf-cache
+        name: Restore HuggingFace cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ github.workspace }}/hf_cache
-          key: hf-cache-${{ github.run_id }}
+          key: hf-cache-${{ hashFiles('hf_cache/**') }}
           restore-keys: |
             hf-cache-
           enableCrossOsArchive: true
@@ -149,6 +149,16 @@ jobs:
           TABPFN_EXCLUDE_DEVICES: mps
         run: uv run --no-sync pytest -m "not slow" tests/
 
+      # Save even if tests failed: partial downloads still help future runs.
+      - &save-hf-cache
+        name: Save HuggingFace cache
+        if: always()
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ github.workspace }}/hf_cache
+          key: hf-cache-${{ hashFiles('hf_cache/**') }}
+          enableCrossOsArchive: true
+
   # -------------------------------------------------------------------
   # Ubuntu-latest + highest dependencies (used as gate for GPU)
   # -------------------------------------------------------------------
@@ -187,13 +197,15 @@ jobs:
             --show-only-failing \
             -0
 
-      - *hf-cache
+      - *restore-hf-cache
       - *restore-model-cache
       - *download-models
       - *save-model-cache
 
       - name: Run Tests
         run: uv run --no-sync pytest tests/
+
+      - *save-hf-cache
 
   # -------------------------------------------------------------------
   # First Party Packages
@@ -238,7 +250,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
 
-      - *hf-cache
+      - *restore-hf-cache
 
       - name: Restore model cache
         id: restore-model-cache
@@ -264,6 +276,8 @@ jobs:
         run: |
           cd ${{ matrix.repo-name }}
           uv run --with ../TabPFN --all-extras pytest -m "not uses_tabpfn_client"
+
+      - *save-hf-cache
 
   # -------------------------------------------------------------------
   # GPU: To save compute we only want to execute this workflow once
@@ -322,7 +336,7 @@ jobs:
             --extra-index-url https://download.pytorch.org/whl/cu128 \
             --index-strategy unsafe-best-match
 
-      - *hf-cache
+      - *restore-hf-cache
       - *restore-model-cache
       - *download-models
       - *save-model-cache
@@ -333,3 +347,5 @@ jobs:
           # skip cpu based tests that were run separately
           TABPFN_EXCLUDE_DEVICES: "cpu,cpu:0,mps"
         run: uv run --no-sync pytest tests/
+
+      - *save-hf-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,6 @@ concurrency:
 env:
   TABPFN_MODEL_CACHE_DIR: ${{ github.workspace }}/model_cache
   HF_HUB_CACHE: ${{ github.workspace }}/hf_cache
-  HF_TOKEN: ${{ secrets.HF_TOKEN }}
-  TABPFN_TOKEN: ${{ secrets.TABPFN_TOKEN }}
 
 jobs:
   check_python_linting:
@@ -62,6 +60,9 @@ jobs:
             python-version: "3.14"
             dependency-set: highest
     runs-on: ${{ matrix.os }}
+    env:
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      TABPFN_TOKEN: ${{ secrets.TABPFN_TOKEN }}
 
     steps:
       - uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231 # v4.3.1
@@ -97,7 +98,7 @@ jobs:
           key: hf-cache-${{ github.run_id }}
           restore-keys: |
             hf-cache-
-                enableCrossOsArchive: true
+          enableCrossOsArchive: true
 
       # We separately cache TabPFN model checkpoints. This is required so that PRs from
       # forks, which can't access HF_TOKEN/TABPFN_TOKEN, already have the checkpoint
@@ -156,6 +157,9 @@ jobs:
     needs: check_python_linting
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      TABPFN_TOKEN: ${{ secrets.TABPFN_TOKEN }}
 
     steps:
       - uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231 # v4.3.1
@@ -207,6 +211,8 @@ jobs:
           - tabpfn-extensions
           - tabpfn-time-series
     env:
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      TABPFN_TOKEN: ${{ secrets.TABPFN_TOKEN }}
       # Disable xet chunk cache to prevent disk exhaustion from 40+ model downloads.
       # Xet caches each downloaded file's chunks in ~/.cache/huggingface/xet/,
       # roughly doubling the effective disk footprint on the runner.
@@ -288,6 +294,9 @@ jobs:
             torch-override: "torch==2.10.0+cu128"
 
     runs-on: ubuntu-22.04-4core-gpu
+    env:
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      TABPFN_TOKEN: ${{ secrets.TABPFN_TOKEN }}
 
     steps:
       - uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231 # v4.3.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,12 @@ concurrency:
   group: pr-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  TABPFN_MODEL_CACHE_DIR: ${{ github.workspace }}/model_cache
+  HF_HUB_CACHE: ${{ github.workspace }}/hf_cache
+  HF_TOKEN: ${{ secrets.HF_TOKEN }}
+  TABPFN_TOKEN: ${{ secrets.TABPFN_TOKEN }}
+
 jobs:
   check_python_linting:
     name: Ruff Linting & Formatting
@@ -56,10 +62,6 @@ jobs:
             python-version: "3.14"
             dependency-set: highest
     runs-on: ${{ matrix.os }}
-    env:
-      TABPFN_MODEL_CACHE_DIR: ${{ github.workspace }}/model_cache
-      HF_TOKEN: ${{ secrets.HF_TOKEN }}
-      TABPFN_TOKEN: ${{ secrets.TABPFN_TOKEN }}
 
     steps:
       - uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231 # v4.3.1
@@ -86,9 +88,20 @@ jobs:
             --show-only-failing \
             -0
 
-      # We use a cache for the model checkpoints. This allows PRs from forks, which
-      # can't access the HF_TOKEN, to have access to the model files. It also speeds up
-      # PRs and avoids flakes.
+      # We use a persistent HuggingFace cache to avoid hitting rate limits.
+      - &hf-cache
+        name: HuggingFace cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ github.workspace }}/hf_cache
+          key: hf-cache-${{ github.run_id }}
+          restore-keys: |
+            hf-cache-
+                enableCrossOsArchive: true
+
+      # We separately cache TabPFN model checkpoints. This is required so that PRs from
+      # forks, which can't access HF_TOKEN/TABPFN_TOKEN, already have the checkpoint
+      # files they need.
       - &restore-model-cache
         name: Restore model cache
         id: restore-model-cache
@@ -143,10 +156,6 @@ jobs:
     needs: check_python_linting
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    env:
-      TABPFN_MODEL_CACHE_DIR: ${{ github.workspace }}/model_cache
-      HF_TOKEN: ${{ secrets.HF_TOKEN }}
-      TABPFN_TOKEN: ${{ secrets.TABPFN_TOKEN }}
 
     steps:
       - uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231 # v4.3.1
@@ -174,6 +183,7 @@ jobs:
             --show-only-failing \
             -0
 
+      - *hf-cache
       - *restore-model-cache
       - *download-models
       - *save-model-cache
@@ -197,9 +207,6 @@ jobs:
           - tabpfn-extensions
           - tabpfn-time-series
     env:
-      TABPFN_MODEL_CACHE_DIR: ${{ github.workspace }}/model_cache
-      HF_TOKEN: ${{ secrets.HF_TOKEN }}
-      TABPFN_TOKEN: ${{ secrets.TABPFN_TOKEN }}
       # Disable xet chunk cache to prevent disk exhaustion from 40+ model downloads.
       # Xet caches each downloaded file's chunks in ~/.cache/huggingface/xet/,
       # roughly doubling the effective disk footprint on the runner.
@@ -224,6 +231,8 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
+
+      - *hf-cache
 
       - name: Restore model cache
         id: restore-model-cache
@@ -279,11 +288,6 @@ jobs:
             torch-override: "torch==2.10.0+cu128"
 
     runs-on: ubuntu-22.04-4core-gpu
-    env:
-      TABPFN_MODEL_CACHE_DIR: ${{ github.workspace }}/model_cache
-      HF_TOKEN: ${{ secrets.HF_TOKEN }}
-      TABPFN_TOKEN: ${{ secrets.TABPFN_TOKEN }}
-
 
     steps:
       - uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231 # v4.3.1
@@ -309,6 +313,7 @@ jobs:
             --extra-index-url https://download.pytorch.org/whl/cu128 \
             --index-strategy unsafe-best-match
 
+      - *hf-cache
       - *restore-model-cache
       - *download-models
       - *save-model-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,8 @@ jobs:
           TABPFN_EXCLUDE_DEVICES: mps
         run: uv run --no-sync pytest -m "not slow" tests/
 
-      # Save even if tests failed: partial downloads still help future runs.
+        # Save even if tests failed: partial downloads avoid future runs hitting the
+        # rate limits.
       - &save-hf-cache
         name: Save HuggingFace cache
         if: always()


### PR DESCRIPTION
To avoid hitting rate limits.

This is actually only used in tabpfn-private, but making the change here to avoid conflicts.

Testing: easiest option is to wait for the merge into private and then see I think. But we have the same workflow elsewhere and it works.