### PR TITLE
Fix crash for user-specified categoricals that are all-Nan during fit

### DIFF
--- a/changelog/1002.fixed.md
+++ b/changelog/1002.fixed.md
@@ -1,0 +1,1 @@
+Fixed a `could not convert string to float` crash when a feature declared categorical via `categorical_features_indices` is all-missing during fit but has real string values at predict. Such columns are now kept categorical instead of being demoted to a constant numeric column, so they route through the ordinal encoder consistently between fit and predict.

--- a/src/tabpfn/preprocessing/modality_detection.py
+++ b/src/tabpfn/preprocessing/modality_detection.py
@@ -80,9 +80,13 @@ def _detect_feature_modality(
 ) -> FeatureModality:
     n_unique = _get_unique_with_sklearn_compatible_error(s)
 
-    if n_unique <= 1:
+    if n_unique <= 1 and not reported_categorical:
         # Either all values are missing, or all values are the same.
-        # If there's a single value but also missing ones, it's not constant
+        # If there's a single value but also missing ones, it's not constant.
+        # Columns the user explicitly declared categorical are kept categorical
+        # (handled below) even when all-missing, so they route through the ordinal
+        # encoder consistently between fit and predict instead of being treated as
+        # a constant numeric column that crashes on string values seen at predict.
         return FeatureModality.CONSTANT
 
     if _is_numeric_pandas_series(s):

--- a/tests/test_preprocessing/test_data_cleaning.py
+++ b/tests/test_preprocessing/test_data_cleaning.py
@@ -459,3 +459,40 @@ def test__classifier_fit_predict__all_missing_categorical_then_strings() -> None
 
     assert model.predict(X_test).shape == (X_test.shape[0],)
     assert model.predict_proba(X_test).shape == (X_test.shape[0], len(np.unique(y)))
+
+
+def test__classifier_fit_predict__all_missing_declared_categorical_then_strings() -> (
+    None
+):
+    """End-to-end regression for a *declared* categorical column that is all-missing."""
+    rng = np.random.RandomState(0)
+    n = 40
+    X_fit = pd.DataFrame(
+        {
+            "a": rng.rand(n),
+            "c": pd.Series([np.nan] * n, dtype="category"),  # all-missing at fit
+        }
+    )
+    y = pd.Series((rng.rand(n) > 0.5).astype(int))
+
+    X_pred = pd.DataFrame(
+        {
+            "a": rng.rand(6),
+            "c": pd.Series(
+                ["normal", "abn", "normal", "abn", "normal", "abn"], dtype="category"
+            ),
+        }
+    )
+
+    clf = TabPFNClassifier(
+        device="cpu",
+        n_estimators=1,
+        ignore_pretraining_limits=True,
+        categorical_features_indices=[1],  # "c" explicitly declared categorical
+        random_state=0,
+    )
+    clf.fit(X_fit, y)
+
+    proba = clf.predict_proba(X_pred)
+    assert proba.shape == (len(X_pred), 2)
+    assert np.isfinite(proba).all()


### PR DESCRIPTION
Fixed a `could not convert string to float` crash when a feature declared categorical via `categorical_features_indices` is all-missing during fit but has real string values at predict. Such columns are now kept categorical instead of being demoted to a constant numeric column, so they route through the ordinal encoder consistently between fit and predict.