### PR TITLE
Fix unconditional torch.mps.empty_cache() crash in OOM recovery

### DIFF
--- a/changelog/1007.fixed.md
+++ b/changelog/1007.fixed.md
@@ -1,0 +1,1 @@
+Fix a crash in the chunked-inference OOM recovery path that called `torch.mps.empty_cache()` unconditionally, raising `Cannot execute emptyCache() without MPS backend` on non-MPS devices (CUDA GPUs, CPU-only Linux) and turning a recoverable out-of-memory into a hard failure.

--- a/src/tabpfn/architectures/tabpfn_v3.py
+++ b/src/tabpfn/architectures/tabpfn_v3.py
@@ -2084,7 +2084,8 @@ class TabPFNV3(Architecture):
                     if not is_oom_error(e) or eff_col_chunk <= 1:
                         raise
                     torch.cuda.empty_cache()
-                    torch.mps.empty_cache()
+                    if torch.backends.mps.is_available():
+                        torch.mps.empty_cache()
                     eff_col_chunk //= 2
                     _logger.warning("OOM: halving col_chunk_size to %d", eff_col_chunk)
                     self.inference_col_chunk_size = eff_col_chunk

--- a/tests/test_architectures/test_tabpfn_v3.py
+++ b/tests/test_architectures/test_tabpfn_v3.py
@@ -144,6 +144,62 @@ def test__mem_eff_forward_matches_standard_forward() -> None:
         )
 
 
+@torch.no_grad()
+@pytest.mark.skipif(sys.platform == "win32", reason="float64 tests fail on Windows")
+def test__chunked_inference_recovers_from_oom(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A recoverable OOM during chunked inference must not crash the forward.
+
+    The column-chunk handler reacts to an OOM by freeing memory, halving the
+    chunk and retrying. This used to call ``torch.mps.empty_cache()``
+    unconditionally, which raises ``Cannot execute emptyCache() without MPS
+    backend`` on any non-MPS device (CUDA GPUs, CPU-only Linux), turning a
+    recoverable OOM into a hard crash on the CI runners. The recovered output
+    must also match the standard forward pass.
+    """
+    arch = _get_model()
+    # Chunkwise inference (and hence the OOM recovery path) only runs in eval mode.
+    arch.eval()
+
+    x = torch.randn(100, 2, 20, dtype=torch.float64) * 0.1
+    y = torch.randint(0, 10, [97, 2], dtype=torch.float64)
+
+    expected = arch(x, y, only_return_standard_out=False)
+
+    # Force chunking so the inducing-hidden (column) recovery path is exercised.
+    arch.inference_row_chunk_size = 50
+    arch.inference_col_chunk_size = 10
+
+    # Raise a single OOM the first time a column chunk is processed, so the
+    # handler must free memory, halve the column chunk and retry.
+    original_process_col_chunk = arch._process_col_chunk
+    calls = {"n": 0}
+
+    def _process_col_chunk_oom_once(*args: object, **kwargs: object) -> object:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("CUDA out of memory (simulated)")
+        return original_process_col_chunk(*args, **kwargs)
+
+    monkeypatch.setattr(arch, "_process_col_chunk", _process_col_chunk_oom_once)
+
+    recovered = arch(
+        x,
+        y,
+        only_return_standard_out=False,
+        performance_options=PerformanceOptions(use_chunkwise_inference=True),
+    )
+
+    assert calls["n"] > 1, "the simulated OOM never triggered a retry"
+    assert recovered.keys() == expected.keys()
+    for key in recovered:
+        assert torch.allclose(recovered[key], expected[key], atol=1e-10), (
+            f"Output '{key}' after OOM recovery differs from the standard "
+            "forward pass."
+        )
+
+
 def _get_regression_model() -> tabpfn_v3.TabPFNV3:
     config = tabpfn_v3.TabPFNV3Config(
         max_num_classes=-1,

--- a/tests/test_architectures/test_tabpfn_v3.py
+++ b/tests/test_architectures/test_tabpfn_v3.py
@@ -173,16 +173,22 @@ def test__chunked_inference_recovers_from_oom(
 
     # Raise a single OOM the first time a column chunk is processed, so the
     # handler must free memory, halve the column chunk and retry.
-    original_process_col_chunk = arch._process_col_chunk
+    # Patch on the class (not the instance) so that, should torch.compile be
+    # enabled, the bound method still exposes ``__func__`` for ``_compiled``.
+    original_process_col_chunk = tabpfn_v3.TabPFNV3._process_col_chunk
     calls = {"n": 0}
 
-    def _process_col_chunk_oom_once(*args: object, **kwargs: object) -> object:
+    def _process_col_chunk_oom_once(
+        self: tabpfn_v3.TabPFNV3, *args: object, **kwargs: object
+    ) -> object:
         calls["n"] += 1
         if calls["n"] == 1:
             raise RuntimeError("CUDA out of memory (simulated)")
-        return original_process_col_chunk(*args, **kwargs)
+        return original_process_col_chunk(self, *args, **kwargs)
 
-    monkeypatch.setattr(arch, "_process_col_chunk", _process_col_chunk_oom_once)
+    monkeypatch.setattr(
+        tabpfn_v3.TabPFNV3, "_process_col_chunk", _process_col_chunk_oom_once
+    )
 
     recovered = arch(
         x,

--- a/tests/test_architectures/test_tabpfn_v3.py
+++ b/tests/test_architectures/test_tabpfn_v3.py
@@ -195,8 +195,7 @@ def test__chunked_inference_recovers_from_oom(
     assert recovered.keys() == expected.keys()
     for key in recovered:
         assert torch.allclose(recovered[key], expected[key], atol=1e-10), (
-            f"Output '{key}' after OOM recovery differs from the standard "
-            "forward pass."
+            f"Output '{key}' after OOM recovery differs from the standard forward pass."
         )
 
 


### PR DESCRIPTION
## Problem

The column-chunk OOM recovery handler in `TabPFNV3._stages_0_to_2` (`src/tabpfn/architectures/tabpfn_v3.py:2087`) calls `torch.mps.empty_cache()` **unconditionally**:

```python
except RuntimeError as e:
    if not is_oom_error(e) or eff_col_chunk <= 1:
        raise
    torch.cuda.empty_cache()
    torch.mps.empty_cache()   # ← crashes on any non-MPS device
    eff_col_chunk //= 2
```

On any device without an MPS backend (CUDA GPUs, CPU-only Linux), `torch.mps.empty_cache()` raises `Cannot execute emptyCache() without MPS backend`. This exception is thrown from *inside* the OOM handler, so it escapes and turns a **recoverable** OOM into a hard crash. Observed in the wild on a CUDA box during inference on a large (1.2M-row) dataset:

```
An error occurred: Cannot execute emptyCache() without MPS backend.
[WARNING] Job failed.
```

The sibling row-chunk handler (`tabpfn_v3.py:2140`) already does this correctly — it only calls `torch.cuda.empty_cache()`.

The bug is invisible on Apple hardware (where MPS *is* available), which is why it slipped through local testing.

## This PR

- **Adds a regression test** (`test__chunked_inference_recovers_from_oom`) that triggers the column-chunk OOM recovery path and asserts inference completes with the correct result. It fails on non-MPS CI runners with the current code.
- The fix follows in the next commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow inference-only error-handling change with a targeted regression test; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes **chunked-inference OOM recovery** in `TabPFNV3._stages_0_to_2` so a recoverable out-of-memory no longer becomes a hard crash on CUDA or CPU-only hosts.
> 
> The column-chunk retry path still calls `torch.cuda.empty_cache()`, but **`torch.mps.empty_cache()` runs only when `torch.backends.mps.is_available()`**, avoiding `Cannot execute emptyCache() without MPS backend` on non-Apple hardware (the row-chunk handler already avoided unconditional MPS calls).
> 
> Adds **`test__chunked_inference_recovers_from_oom`**, which forces chunkwise inference, simulates one column-chunk OOM via a patched `_process_col_chunk`, and asserts retry plus outputs match the standard forward. Documents the fix in **`changelog/1007.fixed.md`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d18dc42f3cb62b6929059c9a0f62348400202e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->