### PR TITLE
Support nullable pd.dtypes and fix pipeline for dtype differences between fit and predict

### DIFF
--- a/changelog/1015.changed.md
+++ b/changelog/1015.changed.md
@@ -1,0 +1,1 @@
+At predict time, an encoded column whose dtype differs from fit is now coerced to its fit-time dtype (and warns). For a numeric-categorical column arriving as strings, numeric-looking strings (`"1.0"`) now match their fit category instead of all being treated as unseen.

--- a/changelog/1015.fixed.md
+++ b/changelog/1015.fixed.md
@@ -1,0 +1,1 @@
+Fixed two crashes from inconsistent column dtypes: `fit` raising `Cannot cast object dtype to float64` when a nullable extension dtype (`Int64`/`Float64`/`boolean`) sits next to a string categorical column, and `predict` raising a `TypeError` when a column was string/categorical at fit but arrives numeric.

--- a/src/tabpfn/preprocessing/clean.py
+++ b/src/tabpfn/preprocessing/clean.py
@@ -9,6 +9,7 @@ e.g. NaN mapping and dtype conversion.
 from __future__ import annotations
 
 import typing
+import warnings
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -20,7 +21,7 @@ from tabpfn.preprocessing.steps.preprocessing_helpers import get_ordinal_encoder
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-    from typing import Literal
+    from typing import Any, Literal
 
     from sklearn.compose import ColumnTransformer
 
@@ -63,6 +64,30 @@ def clean_data(
     )
 
     return X_numpy, ord_encoder, feature_schema
+
+
+def coerce_nullable_dtypes_to_numpy(X: pd.DataFrame) -> pd.DataFrame:
+    """Convert pandas nullable numeric/boolean extension columns to float64.
+
+    This is meant to run *before* sklearn's ``validate_data``. A nullable extension
+    dtype (``Int64``/``Float64``/``boolean``) makes sklearn's ``check_array`` perform a
+    whole-frame ``astype`` even with ``dtype=None``, which crashes when another column
+    is a string-valued category (it cannot cast e.g. ``'0e63c0f0'`` to float). Coercing
+    the nullable columns up front removes that trigger.
+
+    Only masked numeric/boolean extension columns are touched; ``category``/``string``/
+    ``object`` columns are left untouched.
+    """
+    cols = [
+        col
+        for col in X.columns
+        if pd.api.types.is_extension_array_dtype(X[col].dtype)
+        and X[col].dtype.kind in "iufb"
+    ]
+    if cols:
+        X = X.copy()
+        X[cols] = X[cols].astype("float64")
+    return X
 
 
 def fix_dtypes(  # noqa: D103, C901, PLR0912
@@ -142,6 +167,68 @@ def fix_dtypes(  # noqa: D103, C901, PLR0912
     return X
 
 
+def _column_kind(dtype: Any) -> str:
+    """Return a column's scalar dtype kind, unwrapping categorical dtypes."""
+    if isinstance(dtype, pd.CategoricalDtype):
+        return dtype.categories.dtype.kind
+    return dtype.kind
+
+
+def _align_columns_to_fitted_dtypes(
+    X: pd.DataFrame, ord_encoder: ColumnTransformer
+) -> pd.DataFrame:
+    """Coerce each encoded column to the scalar dtype it had when the encoder was fit.
+
+    Only the dtypes seen at fit are authoritative: the frozen ``OrdinalEncoder`` stored
+    its ``categories_`` (and their dtype) at fit, so an incoming column is interpreted
+    as that fit-time dtype at predict. Two mismatches are handled:
+
+    * string at fit, numeric at predict -> the column is cast to ``string``. Otherwise
+      sklearn's ``_check_unknown`` takes its numeric branch and compares float values
+      against the string ``categories_``, raising a ``TypeError``.
+    * numeric at fit, string at predict -> the column is cast to numeric via
+      ``pd.to_numeric(..., errors="coerce")``. Numeric-looking strings match their fit
+      category; non-numeric strings become ``NaN`` (treated as missing).
+
+    Either way, values that do not match a fit category map to the encoder's unknown
+    code. A dtype change between fit and predict usually signals an inconsistent feature
+    pipeline, so we warn.
+    """
+    encoder = ord_encoder.named_transformers_.get("encoder")
+    if encoder is None or not hasattr(encoder, "categories_"):
+        return X
+    selected = next(
+        (cols for name, _, cols in ord_encoder.transformers_ if name == "encoder"),
+        [],
+    )
+    to_string, to_numeric = [], []
+    for col, categories in zip(selected, encoder.categories_):
+        fit_kind = categories.dtype.kind
+        values_kind = _column_kind(X[col].dtype)
+        if fit_kind in "OUS" and values_kind in "iufcb":
+            to_string.append(col)
+        elif fit_kind in "iuf" and values_kind in "OUS":
+            to_numeric.append(col)
+
+    if not to_string and not to_numeric:
+        return X
+
+    warnings.warn(
+        f"Column(s) {to_string + to_numeric} have a dtype at predict time that differs "
+        f"from fit time; only the fit-time dtype is treated as correct, so they are "
+        f"coerced to it and values that don't match a fitted category are treated as "
+        f"unseen or missing. This usually indicates an inconsistent feature pipeline "
+        f"between fit and predict.",
+        stacklevel=2,
+    )
+    X = X.copy()
+    if to_string:
+        X[to_string] = X[to_string].astype("string")
+    for col in to_numeric:
+        X[col] = pd.to_numeric(X[col].astype("object"), errors="coerce")
+    return X
+
+
 def process_text_na_dataframe(
     X: pd.DataFrame,
     placeholder: str = NA_PLACEHOLDER,
@@ -158,6 +245,13 @@ def process_text_na_dataframe(
     """
     # TODO: Check if this step needs to be done as early as it is done here, or whether
     # it can be done later and include it in a main preprocessor object.
+
+    # When transforming with a fitted encoder, coerce columns whose dtype drifted
+    # between fit and predict back to their fit-time dtype, so the OrdinalEncoder is
+    # consistent and does not crash. This must run before `string_cols` is computed so
+    # the coerced columns get NA handling.
+    if not fit_encoder and ord_encoder is not None:
+        X = _align_columns_to_fitted_dtypes(X, ord_encoder)
 
     # Replace NAN values in X, for dtypes, which the OrdinalEncoder cannot handle
     # with placeholder NAN value. Later placeholder NAN values are transformed to np.nan

--- a/src/tabpfn/validation.py
+++ b/src/tabpfn/validation.py
@@ -20,6 +20,7 @@ from sklearn.utils.multiclass import check_classification_targets
 
 from tabpfn.errors import TabPFNValidationError
 from tabpfn.misc._sklearn_compat import check_array, validate_data
+from tabpfn.preprocessing.clean import coerce_nullable_dtypes_to_numpy
 from tabpfn.settings import settings
 
 if TYPE_CHECKING:
@@ -93,6 +94,8 @@ def ensure_compatible_predict_input_sklearn(
 
     Note that this also changes the type of X to np.ndarray.
     """
+    if isinstance(X, pd.DataFrame):
+        X = coerce_nullable_dtypes_to_numpy(X)
     try:
         result = validate_data(
             estimator,
@@ -164,6 +167,8 @@ def ensure_compatible_fit_inputs_sklearn(
         A tuple of the validated input data X, target data y, feature names,
         and number of features.
     """
+    if isinstance(X, pd.DataFrame):
+        X = coerce_nullable_dtypes_to_numpy(X)
     try:
         X, y = validate_data(
             estimator,

--- a/tests/test_preprocessing/test_data_cleaning.py
+++ b/tests/test_preprocessing/test_data_cleaning.py
@@ -12,7 +12,9 @@ import torch
 from tabpfn import TabPFNClassifier, TabPFNRegressor
 from tabpfn.errors import TabPFNValidationError
 from tabpfn.preprocessing import clean_data
+from tabpfn.preprocessing.clean import process_text_na_dataframe
 from tabpfn.preprocessing.datamodel import Feature, FeatureModality, FeatureSchema
+from tabpfn.preprocessing.steps.preprocessing_helpers import get_ordinal_encoder
 from tabpfn.validation import ensure_compatible_fit_inputs
 
 
@@ -496,3 +498,153 @@ def test__classifier_fit_predict__all_missing_declared_categorical_then_strings(
     proba = clf.predict_proba(X_pred)
     assert proba.shape == (len(X_pred), 2)
     assert np.isfinite(proba).all()
+
+
+def test__classifier_fit__string_category_plus_nullable_dtype() -> None:
+    """A string category alongside a pandas nullable dtype must not crash at fit.
+
+    Regression for a fit-time crash (seen on the `home_credit` dataset): a pandas
+    *nullable* extension dtype column (``Float64``/``Int64``/``boolean``) makes
+    sklearn's ``check_array`` perform an early whole-frame ``astype`` during
+    ``validate_data(..., dtype=None)``. That cast then tries to push a string-valued
+    category column (e.g. the hash-like ``'0e63c0f0'``) to float64 and raises
+    ``could not convert string to float``, surfaced as a ``TabPFNValidationError``.
+    A plain string-category column on its own is fine; it only breaks once a
+    nullable column forces the early conversion.
+    """
+    n = 20
+    X = pd.DataFrame(
+        {
+            # pandas *nullable* extension dtype -> triggers the early whole-frame
+            # conversion in sklearn check_array (Int64 / boolean reproduce this too).
+            "nullable_num": pd.array(np.arange(n, dtype=float), dtype="Float64"),
+            # string-valued category, like the hash-ish '0e63c0f0' in the data.
+            "str_cat": pd.Categorical(["0e63c0f0", "xx"] * (n // 2)),
+        }
+    )
+    y = np.array([0, 1] * (n // 2))
+
+    clf = TabPFNClassifier(device="cpu", n_estimators=1, random_state=0)
+    clf.fit(X, y)
+
+    proba = clf.predict_proba(X)
+    assert proba.shape == (n, 2)
+    assert np.isfinite(proba).all()
+
+
+def test__classifier_predict__numeric_against_string_fit_categories() -> None:
+    """A column that is string at fit but numeric at predict must not crash.
+
+    Regression for a predict-time crash (seen on the `anes_voting` dataset). TabPFN
+    builds an ``OrdinalEncoder`` at fit time and *freezes* the columns it applies to.
+    If a column is string-typed at fit, its ``categories_`` are stored as a
+    string/object array. When the *same* column position is numeric (float) at
+    predict, ``OrdinalEncoder._transform`` used to compare float values against string
+    categories and raise a ``TypeError`` (``'<' not supported between 'float' and
+    'str'`` / ``ufunc 'isnan' not supported``).
+
+    The fit/predict dtype drift now coerces the column to string and warns, treating its
+    values as unseen categories instead of crashing.
+    """
+    n, n_unique = 120, 60
+    y = np.array([0, 1] * (n // 2))
+
+    # Fit: 'code' is string-typed -> encoder.categories_ become strings.
+    X_fit = pd.DataFrame(
+        {
+            "num": np.arange(n, dtype="float64"),
+            "code": pd.array([f"s{i % n_unique}" for i in range(n)], dtype="string"),
+        }
+    )
+    # Predict: the *same* column is now numeric float (a later time-split fold
+    # codes the same field as numbers) -> float values vs string categories_.
+    X_pred = pd.DataFrame(
+        {
+            "num": np.arange(n, dtype="float64"),
+            "code": np.array([float(i % n_unique) for i in range(n)], dtype="float64"),
+        }
+    )
+
+    clf = TabPFNClassifier(device="cpu", n_estimators=1, random_state=0)
+    clf.fit(X_fit, y)
+
+    with pytest.warns(UserWarning, match="differs.*from fit time"):
+        proba = clf.predict_proba(X_pred)
+    assert proba.shape == (n, 2)
+    assert np.isfinite(proba).all()
+
+
+def test__process_text_na_dataframe__numeric_against_string_fit_categories() -> None:
+    """The predict-time fix isolated to ``clean.process_text_na_dataframe`` (no model).
+
+    Same root cause as
+    ``test__classifier_predict__numeric_against_string_fit_categories``, narrowed to the
+    component that owns predict-time cleaning: fit the ordinal encoder on string
+    categories, then transform a frame whose ``code`` column arrives numeric. The
+    mismatched column must be coerced to string (with a warning) and its unseen values
+    encoded as the unknown code (``-1``), instead of crashing.
+    """
+    n, n_unique = 120, 60
+    X_fit = pd.DataFrame(
+        {
+            "num": np.arange(n, dtype="float64"),
+            "code": pd.array([f"s{i % n_unique}" for i in range(n)], dtype="string"),
+        }
+    )
+    X_pred = pd.DataFrame(
+        {
+            "num": np.arange(n, dtype="float64"),
+            "code": np.array([float(i % n_unique) for i in range(n)], dtype="float64"),
+        }
+    )
+
+    encoder = get_ordinal_encoder()
+    # Fit freezes the 'code' column -> string categories_.
+    process_text_na_dataframe(X_fit.copy(), ord_encoder=encoder, fit_encoder=True)
+
+    with pytest.warns(UserWarning, match="differs.*from fit time"):
+        out = process_text_na_dataframe(X_pred.copy(), ord_encoder=encoder)
+
+    # Column order is preserved: out[:, 1] is 'code', all unseen -> unknown code -1.
+    assert out.shape == (n, 2)
+    assert (out[:, 1] == -1).all()
+
+
+def test__process_text_na_dataframe__string_against_numeric_fit_categories() -> None:
+    """Reverse direction: numeric at fit, string at predict -> coerce to fit (numeric).
+
+    A column that was numeric-categorical at fit is interpreted as that fit dtype at
+    predict: numeric-looking strings (``"1"``) now match their fit category (previously
+    they were all treated as unseen). A non-numeric string (``"abc"``) is coerced to
+    ``NaN``; for a column with no missing values at fit that encodes to the unknown
+    code, as before. A warning is emitted for the dtype change.
+    """
+    n, n_unique = 120, 4
+    X_fit = pd.DataFrame(
+        {
+            "num": np.arange(n, dtype="float64"),
+            # numeric categorical -> encoder.categories_ are numeric (int64).
+            "code": pd.Categorical([i % n_unique for i in range(n)]),
+        }
+    )
+    # Predict: same field now arrives as strings; index 0 is non-numeric.
+    codes = [str(i % n_unique) for i in range(n)]
+    codes[0] = "abc"
+    X_pred = pd.DataFrame(
+        {
+            "num": np.arange(n, dtype="float64"),
+            "code": pd.array(codes, dtype="string"),
+        }
+    )
+
+    encoder = get_ordinal_encoder()
+    process_text_na_dataframe(X_fit.copy(), ord_encoder=encoder, fit_encoder=True)
+
+    with pytest.warns(UserWarning, match="differs.*from fit time"):
+        out = process_text_na_dataframe(X_pred.copy(), ord_encoder=encoder)
+
+    assert out.shape == (n, 2)
+    # 'code' is column index 1. Numeric-looking strings now match a fit category and
+    # encode to a valid (non-negative) code; the non-numeric "abc" -> NaN -> unknown.
+    assert out[0, 1] == -1
+    assert (out[1:, 1] >= 0).all()

--- a/tests/test_preprocessing/test_data_cleaning.py
+++ b/tests/test_preprocessing/test_data_cleaning.py
@@ -574,6 +574,41 @@ def test__classifier_predict__numeric_against_string_fit_categories() -> None:
     assert np.isfinite(proba).all()
 
 
+def test__classifier_predict__numpy_array_against_string_fit_categories() -> None:
+    """Predicting with a numpy array (no column names) after a named-DataFrame fit.
+
+    ``validate_data`` converts both fit and predict inputs to numpy before
+    ``fix_dtypes`` wraps them into an integer-column DataFrame, so the frozen encoder's
+    columns are integer positions and match a numpy-array predict input. This guards
+    against a ``KeyError`` when aligning predict-time dtypes against the fit categories.
+    """
+    n, n_unique = 120, 60
+    y = np.array([0, 1] * (n // 2))
+
+    # Fit with *named* columns; 'code' is string-categorical.
+    X_fit = pd.DataFrame(
+        {
+            "num": np.arange(n, dtype="float64"),
+            "code": pd.array([f"s{i % n_unique}" for i in range(n)], dtype="string"),
+        }
+    )
+    # Predict with a bare numpy array; the 'code' position is now numeric.
+    X_pred = np.column_stack(
+        [
+            np.arange(n, dtype="float64"),
+            np.array([float(i % n_unique) for i in range(n)], dtype="float64"),
+        ]
+    )
+
+    clf = TabPFNClassifier(device="cpu", n_estimators=1, random_state=0)
+    clf.fit(X_fit, y)
+
+    with pytest.warns(UserWarning, match="differs.*from fit time"):
+        proba = clf.predict_proba(X_pred)
+    assert proba.shape == (n, 2)
+    assert np.isfinite(proba).all()
+
+
 def test__process_text_na_dataframe__numeric_against_string_fit_categories() -> None:
     """The predict-time fix isolated to ``clean.process_text_na_dataframe`` (no model).
 


### PR DESCRIPTION
- At predict time, an encoded column whose dtype differs from fit is now coerced to its fit-time dtype (and warns). For a numeric-categorical column arriving as strings, numeric-looking strings (`"1.0"`) now match their fit category instead of all being treated as unseen.

- Fixed two crashes from inconsistent column dtypes: `fit` raising `Cannot cast object dtype to float64` when a nullable extension dtype (`Int64`/`Float64`/`boolean`) sits next to a string categorical column, and `predict` raising a `TypeError` when a column was string/categorical at fit but arrives numeric.