### PR TITLE
fix(preprocessing): remove constant NaN columns

### DIFF
--- a/src/tabpfn/preprocessing/steps/remove_constant_features_step.py
+++ b/src/tabpfn/preprocessing/steps/remove_constant_features_step.py
@@ -33,9 +33,11 @@ class RemoveConstantFeaturesStep(PreprocessingStep):
         feature_schema: FeatureSchema,
     ) -> FeatureSchema:
         if isinstance(X, torch.Tensor):
-            sel_ = torch.max(X[0:1, :] != X, dim=0)[0].cpu()
+            sel_ = (torch.max(X[0:1, :] != X, dim=0)[0] & ~X.isnan().all(dim=0)).cpu()
         else:
-            sel_ = ((X[0:1, :] == X).mean(axis=0) < 1.0).tolist()
+            sel_ = np.logical_and(
+                (X[0:1, :] == X).mean(axis=0) < 1.0, ~np.all(np.isnan(X), axis=0)
+            ).tolist()
 
         if not any(sel_):
             raise TabPFNValidationError(

--- a/tests/test_preprocessing/test_remove_constant_features_step.py
+++ b/tests/test_preprocessing/test_remove_constant_features_step.py
@@ -53,6 +53,33 @@ def test__remove_constant_features_step__drops_constant_numpy() -> None:
     assert result.modality_added is None
 
 
+def test__remove_constant_features_step__drops_constant_nan_numpy() -> None:
+    """Remove constant columns for NumPy inputs."""
+    X = np.array(
+        [
+            [np.nan, 2.0, 3.0],
+            [np.nan, 5.0, 3.0],
+            [np.nan, 7.0, 4.0],
+        ]
+    )
+    schema = _numerical_metadata(num_features=3)
+
+    step = RemoveConstantFeaturesStep()
+    result = step.fit_transform(X, schema)
+
+    expected = np.array(
+        [
+            [2.0, 3.0],
+            [5.0, 3.0],
+            [7.0, 4.0],
+        ]
+    )
+    np.testing.assert_array_equal(result.X, expected)
+    assert result.feature_schema.indices_for(FeatureModality.NUMERICAL) == [0, 1]
+    assert result.X_added is None
+    assert result.modality_added is None
+
+
 def test__remove_constant_features_step__raises_when_all_constant() -> None:
     """Raise when all columns are constant."""
     X = np.ones((4, 2))
@@ -70,6 +97,34 @@ def test__remove_constant_features_step__drops_constant_torch() -> None:
             [2.0, 0.0, 5.0],
             [2.0, 1.0, 6.0],
             [2.0, 3.0, 6.0],
+        ]
+    )
+    schema = _numerical_metadata(num_features=3)
+
+    step = RemoveConstantFeaturesStep()
+    result = step.fit_transform(X, schema)  # type: ignore[arg-type]
+
+    expected = torch.tensor(
+        [
+            [0.0, 5.0],
+            [1.0, 6.0],
+            [3.0, 6.0],
+        ]
+    )
+    assert isinstance(result.X, torch.Tensor)
+    assert torch.equal(result.X, expected)
+    assert result.feature_schema.indices_for(FeatureModality.NUMERICAL) == [0, 1]
+    assert result.X_added is None
+    assert result.modality_added is None
+
+
+def test__remove_constant_features_step__drops_constant_nan_torch() -> None:
+    """Remove constant columns for torch inputs."""
+    X = torch.tensor(
+        [
+            [float("nan"), 0.0, 5.0],
+            [float("nan"), 1.0, 6.0],
+            [float("nan"), 3.0, 6.0],
         ]
     )
     schema = _numerical_metadata(num_features=3)


### PR DESCRIPTION
## Issue

Ref PRI-241.

## Motivation and Context

Fully NaN columns are not being dropped during the constant-column removal step because `nan != nan` — the constant check doesn't recognize all-NaN as constant. This means all-NaN columns remain in X and influence the feature grouping, etc causing slight differences compared to when those columns are manually dropped beforehand.

---

## Public API Changes

-   [x] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?

Using pytest:

- `test__remove_constant_features_step__drops_constant_nan_numpy`
- `test__remove_constant_features_step__drops_constant_nan_torch`

---

## Checklist

-   [x] The changes have been tested locally.
-   [x] Documentation has been updated (if the public API or usage changes).
-   [ ] A changelog entry has been added (see `changelog/README.md`), or "no changelog needed" label requested.
-   [x] The code follows the project's style guidelines.
-   [x] I have considered the impact of these changes on the public API.

---