### PR TITLE
[Fixes PRI-247] Reduce memory usage of the single file models. 

### DIFF
--- a/changelog/1019.changed.md
+++ b/changelog/1019.changed.md
@@ -1,0 +1,1 @@
+Improve peak memory of single file model implementations.

--- a/src/tabpfn/architectures/tabpfn_v2_5.py
+++ b/src/tabpfn/architectures/tabpfn_v2_5.py
@@ -464,6 +464,7 @@ class TabPFNBlock(nn.Module):
         # Call .contiguous() so that _chunk() can operate on x_BCRE in-place, when
         # memory saving is enabled.
         x_BCRE = x_BRCE.transpose(1, 2).contiguous()
+        del x_BRCE
         x_BCRE = chunked_evaluate_maybe_inplace(
             self.per_column_attention_between_cells,
             x_BCRE,
@@ -483,6 +484,7 @@ class TabPFNBlock(nn.Module):
         )
         # Again, call .contiguous() so that _chunk() can operate on x_BCRE in-place.
         x_BRCE = x_BCRE.transpose(1, 2).contiguous()
+        del x_BRCE
 
         # -- Third Block: MLP layer.
         x_BRCE = chunked_evaluate_maybe_inplace(
@@ -674,6 +676,9 @@ class TabPFNV2p5(Architecture):
 
         # Add the targets as an additional column.
         x_BRiCD = torch.cat((embedded_x_BRiGX, embedded_y_BRiX[:, :, None]), dim=2)
+        # Drop refs so the (full-size) embedded feature/target tensors are freed
+        # before the transformer blocks run.
+        del embedded_x_BRiGX, embedded_y_BRiX
         # This check results in a graph break with torch compile, so we only run it once
         # in the beginning and then disable it.
         if self._do_encoder_nan_check:

--- a/src/tabpfn/architectures/tabpfn_v2_5.py
+++ b/src/tabpfn/architectures/tabpfn_v2_5.py
@@ -482,9 +482,9 @@ class TabPFNBlock(nn.Module):
             residual=False,
             batch_dims=3,
         )
-        # Again, call .contiguous() so that _chunk() can operate on x_BCRE in-place.
+        # Again, call .contiguous() so that _chunk() can operate on x_BRCE in-place.
         x_BRCE = x_BCRE.transpose(1, 2).contiguous()
-        del x_BRCE
+        del x_BCRE
 
         # -- Third Block: MLP layer.
         x_BRCE = chunked_evaluate_maybe_inplace(

--- a/src/tabpfn/architectures/tabpfn_v2_6.py
+++ b/src/tabpfn/architectures/tabpfn_v2_6.py
@@ -493,9 +493,9 @@ class TabPFNBlock(nn.Module):
             residual=False,
             batch_dims=3,
         )
-        # Again, call .contiguous() so that _chunk() can operate on x_BCRE in-place.
+        # Again, call .contiguous() so that _chunk() can operate on x_BRCE in-place.
         x_BRCE = x_BCRE.transpose(1, 2).contiguous()
-        del x_BRCE
+        del x_BCRE
 
         # -- Third Block: MLP layer.
         x_BRCE = chunked_evaluate_maybe_inplace(

--- a/src/tabpfn/architectures/tabpfn_v2_6.py
+++ b/src/tabpfn/architectures/tabpfn_v2_6.py
@@ -475,6 +475,7 @@ class TabPFNBlock(nn.Module):
         # Call .contiguous() so that _chunk() can operate on x_BCRE in-place, when
         # memory saving is enabled.
         x_BCRE = x_BRCE.transpose(1, 2).contiguous()
+        del x_BRCE
         x_BCRE = chunked_evaluate_maybe_inplace(
             self.per_column_attention_between_cells,
             x_BCRE,
@@ -494,6 +495,7 @@ class TabPFNBlock(nn.Module):
         )
         # Again, call .contiguous() so that _chunk() can operate on x_BCRE in-place.
         x_BRCE = x_BCRE.transpose(1, 2).contiguous()
+        del x_BRCE
 
         # -- Third Block: MLP layer.
         x_BRCE = chunked_evaluate_maybe_inplace(
@@ -685,6 +687,9 @@ class TabPFNV2p6(Architecture):
 
         # Add the targets as an additional column.
         x_BRiCD = torch.cat((embedded_x_BRiGX, embedded_y_BRiX[:, :, None]), dim=2)
+        # Drop refs so the (full-size) embedded feature/target tensors are freed
+        # before the transformer blocks run.
+        del embedded_x_BRiGX, embedded_y_BRiX
         # This check results in a graph break with torch compile, so we only run it once
         # in the beginning and then disable it.
         if self._do_encoder_nan_check:

--- a/src/tabpfn/architectures/tabpfn_v2_sf.py
+++ b/src/tabpfn/architectures/tabpfn_v2_sf.py
@@ -457,6 +457,7 @@ class TabPFNBlock(nn.Module):
         # Call .contiguous() so that _chunk() can operate on x_BCRE in-place, when
         # memory saving is enabled.
         x_BCRE = x_BRCE.transpose(1, 2).contiguous()
+        del x_BRCE
         kv_entry: KVCacheEntry | None = None
         if return_kv or cached_kv is not None:
             # Build / cache paths: bypass chunking. This is consistent with the
@@ -491,6 +492,7 @@ class TabPFNBlock(nn.Module):
         )
         # Again, call .contiguous() so that _chunk() can operate on x_BCRE in-place.
         x_BRCE = x_BCRE.transpose(1, 2).contiguous()
+        del x_BCRE
 
         # -- Third Block: MLP layer.
         x_BRCE = chunked_evaluate_maybe_inplace(
@@ -961,6 +963,7 @@ class TabPFNV2(Architecture):
             )
             test_y_BRY = test_y_BY[:, None, :].expand(batch_size, num_rows, -1)
             x_BRCD = torch.cat((embedded_x_BRGX, test_y_BRY[:, :, None]), dim=2)
+            del embedded_x_BRGX
             num_train_labels = kv_cache.train_shape[1]
             block_single_eval_pos = 0
         else:
@@ -982,6 +985,9 @@ class TabPFNV2(Architecture):
 
             # Add the targets as an additional column.
             x_BRCD = torch.cat((embedded_x_BRGX, embedded_y_BRY[:, :, None]), dim=2)
+            # Drop refs so the (full-size) embedded feature/target tensors are freed
+            # before the transformer blocks run.
+            del embedded_x_BRGX, embedded_y_BRY
             # This check results in a graph break with torch compile, so we only run it
             # once in the beginning and then disable it.
             if self._do_encoder_nan_check:

--- a/tests/test_preprocessing/test_power_transformer.py
+++ b/tests/test_preprocessing/test_power_transformer.py
@@ -88,6 +88,7 @@ def test__safe_power_transformer__inverse_transform_float32__no_overflow_warning
     transformer = SafePowerTransformer(method="yeo-johnson", standardize=False)
     transformer.lambdas_ = np.array([lmbda])
     transformer._scaler = None
+    transformer.n_features_in_ = 1
 
     # Forward-transform a large value so the inverse must reconstruct it
     x_large = np.array([[1e30]], dtype=np.float32)


### PR DESCRIPTION
Now they're below the original implementation and faster.

Base model peak memory: 2.2088 GB, time: 197 ms
TabPFN model peak memory: 2.0242 GB, time: 182 ms