### PR TITLE
Add n_features_in_ to SafePowerTransformer for scikit-learn 1.9.

### DIFF
--- a/tests/test_preprocessing/test_power_transformer.py
+++ b/tests/test_preprocessing/test_power_transformer.py
@@ -86,8 +86,10 @@ def test__safe_power_transformer__inverse_transform_float32__no_overflow_warning
     # "RuntimeWarning: overflow encountered in cast".
     lmbda = 0.01
     transformer = SafePowerTransformer(method="yeo-johnson", standardize=False)
+    # Mock the state of SafePowerTransformer after a .fit() call.
     transformer.lambdas_ = np.array([lmbda])
     transformer._scaler = None
+    transformer.n_features_in_ = 1
 
     # Forward-transform a large value so the inverse must reconstruct it
     x_large = np.array([[1e30]], dtype=np.float32)


### PR DESCRIPTION
This is causing tests to fail on main after the scikit-learn update.

In this test we set some attributes on SafePowerTransformer to pretend it's been fit. scikit-learn 1.9 requires a new attribute. It has no effect outside of the tests, where we actually call .fit() which sets the attribute correctly.