### PR TITLE
Drop Python 3.9 support, bump minimum to 3.10, add Python 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,7 +318,6 @@ jobs:
         include:
           - python-version: "3.10"
             dependency-set: lowest-direct
-            torch-override: ""
           - python-version: "3.14"
             dependency-set: highest
 
@@ -343,13 +342,6 @@ jobs:
 
       - name: Install dependencies
         run: uv sync --group ci --resolution ${{ matrix.dependency-set }}
-
-      - name: Override torch for GPU compatibility
-        if: ${{ matrix.torch-override != '' }}
-        run: |
-          uv pip install "${{ matrix.torch-override }}" \
-            --extra-index-url https://download.pytorch.org/whl/cu128 \
-            --index-strategy unsafe-best-match
 
       - *restore-hf-cache
       - *restore-model-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,12 +321,6 @@ jobs:
             torch-override: ""
           - python-version: "3.14"
             dependency-set: highest
-            # Pin torch to 2.10.0 for now, otherwise the runner raises a
-            # `The NVIDIA driver on your system is too old` error.
-            # TODO: Update the runner
-            # We install torch separately (post-sync) so the cu128 GPU wheel can
-            # be forced without re-resolving the rest of the locked dependencies.
-            torch-override: "torch==2.10.0+cu128"
 
     runs-on: ubuntu-22.04-4core-gpu
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,16 +42,16 @@ jobs:
         # it, which requires a separate workflow.
         include:
           - os: ubuntu-latest
-            python-version: "3.9"
+            python-version: "3.10"
             dependency-set: lowest-direct
           # Note that new pytorch versions >= 2.5 don't support x86 on mac anymore,
-          # but python 3.9 only works on x86, so we disable this runner.
+          # and macos-latest (ARM) is python >= 3.11 only, so we disable this runner.
           # https://github.com/actions/setup-python/issues/855
           # - os: macos-15-intel # We need x86 as ARM is python>= 3.11 only.
-          #  python-version: "3.9"
+          #  python-version: "3.10"
           #  dependency-set: lowest-direct
           - os: windows-latest
-            python-version: "3.9"
+            python-version: "3.10"
             dependency-set: lowest-direct
           - os: macos-latest
             python-version: "3.14"
@@ -316,7 +316,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: "3.9"
+          - python-version: "3.10"
             dependency-set: lowest-direct
             torch-override: ""
           - python-version: "3.14"
@@ -324,9 +324,8 @@ jobs:
             # Pin torch to 2.10.0 for now, otherwise the runner raises a
             # `The NVIDIA driver on your system is too old` error.
             # TODO: Update the runner
-            # We install torch separately (post-sync) to avoid uv trying to
-            # re-resolve the lock for all requires-python versions (>=3.9),
-            # which fails because torch>=2.10.0 only supports Python>=3.10.
+            # We install torch separately (post-sync) so the cu128 GPU wheel can
+            # be forced without re-resolving the rest of the locked dependencies.
             torch-override: "torch==2.10.0+cu128"
 
     runs-on: ubuntu-22.04-4core-gpu

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Discord](https://img.shields.io/discord/1285598202732482621?color=7289da&label=Discord&logo=discord&logoColor=ffffff)](https://discord.gg/BHnX2Ptf4j)
 [![Documentation](https://img.shields.io/badge/docs-priorlabs.ai-blue)](https://priorlabs.ai/docs)
 [![colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/PriorLabs/TabPFN/blob/main/examples/notebooks/TabPFN_Demo_Local.ipynb)
-[![Python Versions](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://pypi.org/project/tabpfn/)
+[![Python Versions](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/tabpfn/)
 
 <img src="https://github.com/PriorLabs/tabpfn-extensions/blob/main/tabpfn_summary.webp" width="80%" alt="TabPFN Summary">
 
@@ -200,7 +200,7 @@ Recommended row and feature limits vary by checkpoint — see the [Models page](
 <details>
 <summary><b>Q: Why can't I use TabPFN with Python 3.9?</b></summary>
 
-TabPFN requires **Python 3.10+** due to newer language features. Compatible versions: **3.10, 3.11, 3.12, 3.13**.
+TabPFN requires **Python 3.10+** due to newer language features. Compatible versions: **3.10, 3.11, 3.12, 3.13, 3.14**.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Discord](https://img.shields.io/discord/1285598202732482621?color=7289da&label=Discord&logo=discord&logoColor=ffffff)](https://discord.gg/BHnX2Ptf4j)
 [![Documentation](https://img.shields.io/badge/docs-priorlabs.ai-blue)](https://priorlabs.ai/docs)
 [![colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/PriorLabs/TabPFN/blob/main/examples/notebooks/TabPFN_Demo_Local.ipynb)
-[![Python Versions](https://img.shields.io/badge/python-3.9%20%7C%203.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://pypi.org/project/tabpfn/)
+[![Python Versions](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://pypi.org/project/tabpfn/)
 
 <img src="https://github.com/PriorLabs/tabpfn-extensions/blob/main/tabpfn_summary.webp" width="80%" alt="TabPFN Summary">
 
@@ -198,9 +198,9 @@ Recommended row and feature limits vary by checkpoint — see the [Models page](
 </details>
 
 <details>
-<summary><b>Q: Why can't I use TabPFN with Python 3.8?</b></summary>
+<summary><b>Q: Why can't I use TabPFN with Python 3.9?</b></summary>
 
-TabPFN requires **Python 3.9+** due to newer language features. Compatible versions: **3.9, 3.10, 3.11, 3.12, 3.13**.
+TabPFN requires **Python 3.10+** due to newer language features. Compatible versions: **3.10, 3.11, 3.12, 3.13**.
 
 </details>
 

--- a/changelog/1038.added.md
+++ b/changelog/1038.added.md
@@ -1,0 +1,1 @@
+Added official support for Python 3.14 (already exercised by the CI test matrix).

--- a/changelog/1038.breaking.md
+++ b/changelog/1038.breaking.md
@@ -1,0 +1,1 @@
+Dropped support for Python 3.9; the minimum required version is now Python 3.10. The `eval-type-backport` dependency (only needed on 3.9) has been removed.

--- a/examples/plot_regression_distribution.py
+++ b/examples/plot_regression_distribution.py
@@ -39,7 +39,7 @@ def main(
     fig, axes = plt.subplots(1, 3, figsize=(16, 4.5))
     fig.suptitle("TabPFN predicted distributions — diabetes dataset", fontsize=13)
 
-    for i, (ax, idx, title) in enumerate(zip(axes, selected, titles, strict=False)):
+    for i, (ax, idx, title) in enumerate(zip(axes, selected, titles, strict=True)):
         plot_regression_distribution(out, sample_idx=i, ax=ax)
         true_val = y_test[idx]
         true_line = ax.axvline(

--- a/examples/plot_regression_distribution.py
+++ b/examples/plot_regression_distribution.py
@@ -39,7 +39,7 @@ def main(
     fig, axes = plt.subplots(1, 3, figsize=(16, 4.5))
     fig.suptitle("TabPFN predicted distributions — diabetes dataset", fontsize=13)
 
-    for i, (ax, idx, title) in enumerate(zip(axes, selected, titles)):
+    for i, (ax, idx, title) in enumerate(zip(axes, selected, titles, strict=False)):
         plot_regression_distribution(out, sample_idx=i, ax=ax)
         true_val = y_test[idx]
         true_line = ax.axvline(

--- a/examples/sagemaker.py
+++ b/examples/sagemaker.py
@@ -35,7 +35,7 @@ usage, import `invoke_tabpfn` and pass your own NumPy arrays.
 
 import json
 import os
-from typing import Any, Literal, Optional
+from typing import Any, Literal
 
 import boto3
 import numpy as np
@@ -167,8 +167,8 @@ def invoke_tabpfn(
     y_train: np.ndarray,
     x_test: np.ndarray,
     task: Literal["classification", "regression"],
-    model_params: Optional[dict[str, Any]] = None,
-    predict_params: Optional[dict[str, Any]] = None,
+    model_params: dict[str, Any] | None = None,
+    predict_params: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Invoke the TabPFN SageMaker endpoint with tabular data.
 

--- a/examples/tabpfn_for_regression.py
+++ b/examples/tabpfn_for_regression.py
@@ -37,7 +37,7 @@ quantile_predictions = reg.predict(
     output_type="quantiles",
     quantiles=quantiles,
 )
-for q, q_pred in zip(quantiles, quantile_predictions, strict=False):
+for q, q_pred in zip(quantiles, quantile_predictions, strict=True):
     print(f"Quantile {q} MAE:", mean_absolute_error(y_test, q_pred))
 # Predict with mode
 mode_predictions = reg.predict(X_test, output_type="mode")

--- a/examples/tabpfn_for_regression.py
+++ b/examples/tabpfn_for_regression.py
@@ -37,7 +37,7 @@ quantile_predictions = reg.predict(
     output_type="quantiles",
     quantiles=quantiles,
 )
-for q, q_pred in zip(quantiles, quantile_predictions):
+for q, q_pred in zip(quantiles, quantile_predictions, strict=False):
     print(f"Quantile {q} MAE:", mean_absolute_error(y_test, q_pred))
 # Predict with mode
 mode_predictions = reg.predict(X_test, output_type="mode")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ classifiers = [
   'Programming Language :: Python :: 3.11',
   'Programming Language :: Python :: 3.12',
   'Programming Language :: Python :: 3.13',
+  'Programming Language :: Python :: 3.14',
 ]
 license = { file = "LICENSE" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,6 @@ dependencies = [
   "huggingface-hub>=0.23.0",
   "pydantic>=2.8.0",
   "pydantic-settings>=2.10.1",
-  # eval-type-backport is required on Python 3.9 to enable support for "X | Y" notation
-  # for union types in Pydantic.
-  # Once Python 3.10 is the minimum version, this can be removed.
-  "eval-type-backport>=0.2.2",
   "joblib>=1.2.0",
   "tqdm>=4.66.0",
   "tabpfn-common-utils[telemetry-interactive]>=0.2.13",
@@ -28,7 +24,7 @@ dependencies = [
   "lightgbm>=3.0",
   "mlx>=0.29.3; sys_platform == 'darwin' and platform_machine == 'arm64'",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [{ name = "Prior Labs", email = "opensource@priorlabs.ai" }]
 
 readme = "README.md"
@@ -43,7 +39,6 @@ classifiers = [
   'Operating System :: Unix',
   'Operating System :: MacOS',
   'Programming Language :: Python :: 3',
-  'Programming Language :: Python :: 3.9',
   'Programming Language :: Python :: 3.10',
   'Programming Language :: Python :: 3.11',
   'Programming Language :: Python :: 3.12',
@@ -115,7 +110,7 @@ markers = [
 
 # https://github.com/charliermarsh/ruff
 [tool.ruff]
-target-version = "py39"
+target-version = "py310"
 line-length = 88
 output-format = "full"
 src = ["src", "tests", "examples"]
@@ -323,7 +318,7 @@ ignore-decorators = ["typing.override", "typing_extensions.override", "typing.ov
 max-args = 10 # Changed from default of 5
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 packages = ["src/tabpfn", "tests"]
 
 show_error_codes = true
@@ -379,7 +374,7 @@ ignore_missing_imports = true
 [tool.pyright]
 include = ["src", "tests"]
 
-pythonVersion = "3.9"
+pythonVersion = "3.10"
 typeCheckingMode = "strict"
 
 strictListInference = true

--- a/src/tabpfn/architectures/base/attention/full_attention.py
+++ b/src/tabpfn/architectures/base/attention/full_attention.py
@@ -114,7 +114,9 @@ class MultiHeadAttention(Attention):
             actual_shape = tensor.size()
             err = f"Tensor {actual_shape=} does not match {expected_shape=}."
             assert len(actual_shape) == len(expected_shape), err
-            for actual_dim, expected_dim in zip(actual_shape, expected_shape):
+            for actual_dim, expected_dim in zip(
+                actual_shape, expected_shape, strict=False
+            ):
                 if expected_dim is not None:
                     assert actual_dim == expected_dim, err
 

--- a/src/tabpfn/architectures/base/attention/full_attention.py
+++ b/src/tabpfn/architectures/base/attention/full_attention.py
@@ -115,7 +115,7 @@ class MultiHeadAttention(Attention):
             err = f"Tensor {actual_shape=} does not match {expected_shape=}."
             assert len(actual_shape) == len(expected_shape), err
             for actual_dim, expected_dim in zip(
-                actual_shape, expected_shape, strict=False
+                actual_shape, expected_shape, strict=True
             ):
                 if expected_dim is not None:
                     assert actual_dim == expected_dim, err

--- a/src/tabpfn/architectures/base/bar_distribution.py
+++ b/src/tabpfn/architectures/base/bar_distribution.py
@@ -139,7 +139,9 @@ class BarDistribution(nn.Module):
         probs = torch.stack(
             [
                 bar_dist.get_probs_for_different_borders(logits, self.borders)
-                for bar_dist, logits in zip(list_of_bar_distributions, list_of_logits)
+                for bar_dist, logits in zip(
+                    list_of_bar_distributions, list_of_logits, strict=False
+                )
             ],
             dim=0,
         )

--- a/src/tabpfn/architectures/base/bar_distribution.py
+++ b/src/tabpfn/architectures/base/bar_distribution.py
@@ -140,7 +140,7 @@ class BarDistribution(nn.Module):
             [
                 bar_dist.get_probs_for_different_borders(logits, self.borders)
                 for bar_dist, logits in zip(
-                    list_of_bar_distributions, list_of_logits, strict=False
+                    list_of_bar_distributions, list_of_logits, strict=True
                 )
             ],
             dim=0,

--- a/src/tabpfn/architectures/base/config.py
+++ b/src/tabpfn/architectures/base/config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from copy import deepcopy
-from typing import Any, Literal, Optional
+from typing import Any, Literal
 from typing_extensions import Self
 
 import pydantic
@@ -15,9 +15,9 @@ from tabpfn.architectures.interface import ArchitectureConfig
 
 logger = logging.getLogger(__name__)
 
-FeaturePositionalEmbedding = Optional[
-    Literal["normal_rand_vec", "uni_rand_vec", "learned", "subspace"]
-]
+FeaturePositionalEmbedding = (
+    Literal["normal_rand_vec", "uni_rand_vec", "learned", "subspace"] | None
+)
 
 
 @dataclass

--- a/src/tabpfn/architectures/base/layer.py
+++ b/src/tabpfn/architectures/base/layer.py
@@ -407,7 +407,7 @@ class PerFeatureEncoderLayer(Module):
                 ),
             )
 
-        for sublayer, layer_norm in zip(sublayers, self.layer_norms, strict=False):
+        for sublayer, layer_norm in zip(sublayers, self.layer_norms, strict=True):
             if self.pre_norm:
                 raise AssertionError(
                     "Pre-norm implementation is wrong, as the residual should never"

--- a/src/tabpfn/architectures/base/layer.py
+++ b/src/tabpfn/architectures/base/layer.py
@@ -407,7 +407,7 @@ class PerFeatureEncoderLayer(Module):
                 ),
             )
 
-        for sublayer, layer_norm in zip(sublayers, self.layer_norms):
+        for sublayer, layer_norm in zip(sublayers, self.layer_norms, strict=False):
             if self.pre_norm:
                 raise AssertionError(
                     "Pre-norm implementation is wrong, as the residual should never"

--- a/src/tabpfn/architectures/base/memory.py
+++ b/src/tabpfn/architectures/base/memory.py
@@ -65,6 +65,9 @@ def support_save_peak_mem_factor(method: MethodType) -> Callable:
             assert save_peak_mem_factor > 1
             split_size = (x.size(0) + save_peak_mem_factor - 1) // save_peak_mem_factor
 
+            # strict=False: torch.split can yield fewer than save_peak_mem_factor
+            # chunks for small tensors, which wouldn't match the
+            # `[arg] * save_peak_mem_factor` replication for non-tensor args.
             split_args = zip(
                 *[
                     torch.split(arg, split_size)
@@ -72,7 +75,7 @@ def support_save_peak_mem_factor(method: MethodType) -> Callable:
                     else [arg] * save_peak_mem_factor
                     for arg in (x, *args)
                 ],
-                strict=True,
+                strict=False,
             )
 
             for x_, *args_ in split_args:

--- a/src/tabpfn/architectures/base/memory.py
+++ b/src/tabpfn/architectures/base/memory.py
@@ -72,7 +72,7 @@ def support_save_peak_mem_factor(method: MethodType) -> Callable:
                     else [arg] * save_peak_mem_factor
                     for arg in (x, *args)
                 ],
-                strict=False,
+                strict=True,
             )
 
             for x_, *args_ in split_args:

--- a/src/tabpfn/architectures/base/memory.py
+++ b/src/tabpfn/architectures/base/memory.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 from collections.abc import Callable, Sequence
 from types import MethodType
-from typing import Any, Literal, Union
+from typing import Any, Literal
 
 import torch
 
@@ -72,6 +72,7 @@ def support_save_peak_mem_factor(method: MethodType) -> Callable:
                     else [arg] * save_peak_mem_factor
                     for arg in (x, *args)
                 ],
+                strict=False,
             )
 
             for x_, *args_ in split_args:
@@ -89,7 +90,7 @@ def support_save_peak_mem_factor(method: MethodType) -> Callable:
     return method_
 
 
-MemorySavingMode = Union[bool, Literal["auto"], float, int]
+MemorySavingMode = bool | Literal["auto"] | float | int
 
 
 def should_save_peak_mem(

--- a/src/tabpfn/architectures/base/transformer.py
+++ b/src/tabpfn/architectures/base/transformer.py
@@ -810,5 +810,5 @@ def _add_pos_emb(
         pe *= sign
 
         # TODO(old) Double check the ordering is right
-        for n, pe_ in zip(graph.nodes(), pe):
+        for n, pe_ in zip(graph.nodes(), pe, strict=False):
             graph.nodes[n]["positional_encoding"] = pe_

--- a/src/tabpfn/architectures/base/transformer.py
+++ b/src/tabpfn/architectures/base/transformer.py
@@ -810,5 +810,5 @@ def _add_pos_emb(
         pe *= sign
 
         # TODO(old) Double check the ordering is right
-        for n, pe_ in zip(graph.nodes(), pe, strict=False):
+        for n, pe_ in zip(graph.nodes(), pe, strict=True):
             graph.nodes[n]["positional_encoding"] = pe_

--- a/src/tabpfn/architectures/encoders/steps/multiclass_classification_target_encoder_step.py
+++ b/src/tabpfn/architectures/encoders/steps/multiclass_classification_target_encoder_step.py
@@ -4,7 +4,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 from typing_extensions import override
 
 import torch

--- a/src/tabpfn/architectures/shared/chunked_evaluate.py
+++ b/src/tabpfn/architectures/shared/chunked_evaluate.py
@@ -7,8 +7,9 @@ This reduces the memory required for inference.
 
 from __future__ import annotations
 
-from typing import Callable
-from typing_extensions import Concatenate, ParamSpec
+from collections.abc import Callable
+from typing import Concatenate
+from typing_extensions import ParamSpec
 
 import torch
 

--- a/src/tabpfn/architectures/shared/chunked_evaluate.py
+++ b/src/tabpfn/architectures/shared/chunked_evaluate.py
@@ -8,8 +8,7 @@ This reduces the memory required for inference.
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Concatenate
-from typing_extensions import ParamSpec
+from typing import Concatenate, ParamSpec
 
 import torch
 

--- a/src/tabpfn/architectures/shared/compile_utils.py
+++ b/src/tabpfn/architectures/shared/compile_utils.py
@@ -16,7 +16,8 @@ only *applying* it does, so ``import torch`` at module scope here is safe.
 from __future__ import annotations
 
 import functools
-from typing import Any, Callable, TypeVar
+from collections.abc import Callable
+from typing import Any, TypeVar
 
 import torch
 

--- a/src/tabpfn/architectures/shared/fa3_backend.py
+++ b/src/tabpfn/architectures/shared/fa3_backend.py
@@ -12,7 +12,7 @@ fp16/bf16 inputs.
 from __future__ import annotations
 
 import functools
-from typing import Callable
+from collections.abc import Callable
 
 import torch
 

--- a/src/tabpfn/base.py
+++ b/src/tabpfn/base.py
@@ -8,7 +8,7 @@ import pathlib
 import typing
 from collections.abc import Sequence
 from inspect import signature
-from typing import TYPE_CHECKING, Literal, Union
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 import torch
@@ -88,7 +88,7 @@ class RegressorModelSpecs(BaseModelSpecs):
         self.norm_criterion = norm_criterion
 
 
-ModelSpecs = Union[RegressorModelSpecs, ClassifierModelSpecs]
+ModelSpecs = RegressorModelSpecs | ClassifierModelSpecs
 
 
 def initialize_tabpfn_model(

--- a/src/tabpfn/constants.py
+++ b/src/tabpfn/constants.py
@@ -9,8 +9,7 @@ from __future__ import annotations
 
 import pathlib
 from enum import Enum
-from typing import Any, Literal, Union
-from typing_extensions import TypeAlias
+from typing import Any, Literal, TypeAlias
 
 import joblib
 import numpy as np
@@ -22,7 +21,7 @@ TaskTypeValues: tuple[TaskType, ...] = ("multiclass", "regression")
 XType: TypeAlias = Any
 YType: TypeAlias = Any
 
-ModelPath: TypeAlias = Union[str, pathlib.Path]
+ModelPath: TypeAlias = str | pathlib.Path
 
 
 class ModelVersion(str, Enum):

--- a/src/tabpfn/finetuning/data_util.py
+++ b/src/tabpfn/finetuning/data_util.py
@@ -773,7 +773,7 @@ def get_preprocessed_dataset_chunks(  # noqa: PLR0913
         calling_instance._initialize_model_variables()
 
     X_split, y_split = [], []
-    for X_item, y_item in zip(X_raw, y_raw, strict=False):
+    for X_item, y_item in zip(X_raw, y_raw, strict=True):
         if max_data_size is not None:
             Xparts, yparts = shuffle_and_chunk_data(
                 X_item,
@@ -792,7 +792,7 @@ def get_preprocessed_dataset_chunks(  # noqa: PLR0913
     dataset_config_collection: list[
         RegressorDatasetConfig | ClassifierDatasetConfig
     ] = []
-    for X_item, y_item in zip(X_split, y_split, strict=False):
+    for X_item, y_item in zip(X_split, y_split, strict=True):
         if model_type == "classifier":
             ensemble_configs, X_mod, y_mod = (
                 calling_instance._initialize_dataset_preprocessing(

--- a/src/tabpfn/finetuning/data_util.py
+++ b/src/tabpfn/finetuning/data_util.py
@@ -5,9 +5,9 @@
 from __future__ import annotations
 
 import warnings
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Callable, Literal
+from typing import TYPE_CHECKING, Any, Literal
 from typing_extensions import override
 
 import numpy as np
@@ -773,7 +773,7 @@ def get_preprocessed_dataset_chunks(  # noqa: PLR0913
         calling_instance._initialize_model_variables()
 
     X_split, y_split = [], []
-    for X_item, y_item in zip(X_raw, y_raw):
+    for X_item, y_item in zip(X_raw, y_raw, strict=False):
         if max_data_size is not None:
             Xparts, yparts = shuffle_and_chunk_data(
                 X_item,
@@ -792,7 +792,7 @@ def get_preprocessed_dataset_chunks(  # noqa: PLR0913
     dataset_config_collection: list[
         RegressorDatasetConfig | ClassifierDatasetConfig
     ] = []
-    for X_item, y_item in zip(X_split, y_split):
+    for X_item, y_item in zip(X_split, y_split, strict=False):
         if model_type == "classifier":
             ensemble_configs, X_mod, y_mod = (
                 calling_instance._initialize_dataset_preprocessing(

--- a/src/tabpfn/finetuning/train_util.py
+++ b/src/tabpfn/finetuning/train_util.py
@@ -8,8 +8,9 @@ import copy
 import logging
 import math
 import warnings
+from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 import torch
 from torch.optim import AdamW

--- a/src/tabpfn/inference.py
+++ b/src/tabpfn/inference.py
@@ -424,7 +424,9 @@ class InferenceEngineOnDemand(MultiDeviceInferenceEngine):
             )
         )
 
-        for config, output in zip(self.ensemble_preprocessor.configs, timed_outputs):
+        for config, output in zip(
+            self.ensemble_preprocessor.configs, timed_outputs, strict=False
+        ):
             yield _move_and_squeeze_output(output, devices[0]), config
 
         self._speed_metrics["predict_model_forward_seconds"] = (
@@ -733,7 +735,9 @@ class InferenceEngineCachePreprocessing(MultiDeviceInferenceEngine):
             )
         )
 
-        for output, ensemble_member in zip(timed_outputs, self.ensemble_members):
+        for output, ensemble_member in zip(
+            timed_outputs, self.ensemble_members, strict=False
+        ):
             yield _move_and_squeeze_output(output, devices[0]), ensemble_member.config
 
         self._speed_metrics["predict_model_forward_seconds"] = (
@@ -939,7 +943,9 @@ class InferenceEngineCacheKV(SingleDeviceInferenceEngine):
     ) -> Iterator[tuple[torch.Tensor | dict, EnsembleConfig]]:
         preprocess_time = 0.0
         forward_time = 0.0
-        for ensemble_member, model in zip(self.ensemble_members, self.models):
+        for ensemble_member, model in zip(
+            self.ensemble_members, self.models, strict=False
+        ):
             preprocess_start = time.perf_counter()
             model.to(self.device)
             X_test = ensemble_member.transform_X_test(X)
@@ -1243,7 +1249,9 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
             )
         )
 
-        for output, ensemble_member in zip(timed_outputs, self.ensemble_members):
+        for output, ensemble_member in zip(
+            timed_outputs, self.ensemble_members, strict=False
+        ):
             yield _move_and_squeeze_output(output, devices[0]), ensemble_member.config
 
         self._speed_metrics["predict_model_forward_seconds"] = (

--- a/src/tabpfn/inference.py
+++ b/src/tabpfn/inference.py
@@ -425,7 +425,7 @@ class InferenceEngineOnDemand(MultiDeviceInferenceEngine):
         )
 
         for config, output in zip(
-            self.ensemble_preprocessor.configs, timed_outputs, strict=False
+            self.ensemble_preprocessor.configs, timed_outputs, strict=True
         ):
             yield _move_and_squeeze_output(output, devices[0]), config
 
@@ -736,7 +736,7 @@ class InferenceEngineCachePreprocessing(MultiDeviceInferenceEngine):
         )
 
         for output, ensemble_member in zip(
-            timed_outputs, self.ensemble_members, strict=False
+            timed_outputs, self.ensemble_members, strict=True
         ):
             yield _move_and_squeeze_output(output, devices[0]), ensemble_member.config
 
@@ -944,7 +944,7 @@ class InferenceEngineCacheKV(SingleDeviceInferenceEngine):
         preprocess_time = 0.0
         forward_time = 0.0
         for ensemble_member, model in zip(
-            self.ensemble_members, self.models, strict=False
+            self.ensemble_members, self.models, strict=True
         ):
             preprocess_start = time.perf_counter()
             model.to(self.device)
@@ -1250,7 +1250,7 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
         )
 
         for output, ensemble_member in zip(
-            timed_outputs, self.ensemble_members, strict=False
+            timed_outputs, self.ensemble_members, strict=True
         ):
             yield _move_and_squeeze_output(output, devices[0]), ensemble_member.config
 

--- a/src/tabpfn/inference_tuning.py
+++ b/src/tabpfn/inference_tuning.py
@@ -6,8 +6,9 @@ from __future__ import annotations
 
 import dataclasses
 import warnings
+from collections.abc import Callable
 from enum import Enum
-from typing import TYPE_CHECKING, Callable, Literal
+from typing import TYPE_CHECKING, Literal
 from typing_extensions import Self
 
 import numpy as np

--- a/src/tabpfn/model_loading.py
+++ b/src/tabpfn/model_loading.py
@@ -1085,7 +1085,7 @@ def save_tabpfn_model(
         models,
         configs,
         save_paths,
-        strict=False,
+        strict=True,
     ):
         model_state = ens_model.state_dict()
 

--- a/src/tabpfn/model_loading.py
+++ b/src/tabpfn/model_loading.py
@@ -21,7 +21,7 @@ from dataclasses import asdict, dataclass
 from enum import Enum
 from importlib import import_module
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, TypeVar, Union, cast, overload
+from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast, overload
 from urllib.error import URLError
 
 import joblib
@@ -557,7 +557,7 @@ def _download_model(
     return errors
 
 
-P = TypeVar("P", bound=Union[str, list[str]])
+P = TypeVar("P", bound=str | list[str])
 
 
 def prepend_cache_path(model_path: P) -> P:
@@ -1085,6 +1085,7 @@ def save_tabpfn_model(
         models,
         configs,
         save_paths,
+        strict=False,
     ):
         model_state = ens_model.state_dict()
 

--- a/src/tabpfn/parallel_execute.py
+++ b/src/tabpfn/parallel_execute.py
@@ -6,9 +6,9 @@ from __future__ import annotations
 
 import queue
 import threading
-from collections.abc import Generator, Iterable, Sequence
+from collections.abc import Callable, Generator, Iterable, Sequence
 from multiprocessing.pool import ThreadPool
-from typing import Callable, Generic, Protocol, TypeVar
+from typing import Generic, Protocol, TypeVar
 
 import torch
 

--- a/src/tabpfn/preprocessing/clean.py
+++ b/src/tabpfn/preprocessing/clean.py
@@ -202,7 +202,7 @@ def _align_columns_to_fitted_dtypes(
         [],
     )
     to_string, to_numeric = [], []
-    for col, categories in zip(selected, encoder.categories_):
+    for col, categories in zip(selected, encoder.categories_, strict=False):
         fit_kind = categories.dtype.kind
         values_kind = _column_kind(X[col].dtype)
         if fit_kind in "OUS" and values_kind in "iufcb":

--- a/src/tabpfn/preprocessing/clean.py
+++ b/src/tabpfn/preprocessing/clean.py
@@ -202,7 +202,7 @@ def _align_columns_to_fitted_dtypes(
         [],
     )
     to_string, to_numeric = [], []
-    for col, categories in zip(selected, encoder.categories_, strict=False):
+    for col, categories in zip(selected, encoder.categories_, strict=True):
         fit_kind = categories.dtype.kind
         values_kind = _column_kind(X[col].dtype)
         if fit_kind in "OUS" and values_kind in "iufcb":

--- a/src/tabpfn/preprocessing/ensemble.py
+++ b/src/tabpfn/preprocessing/ensemble.py
@@ -165,7 +165,7 @@ class TabPFNEnsemblePreprocessor:
                 random_state=int(seed),
                 enable_gpu_preprocessing=enable_gpu_preprocessing,
             )
-            for config, seed in zip(self.configs, self.pipeline_seeds)
+            for config, seed in zip(self.configs, self.pipeline_seeds, strict=False)
         ]
 
         n_total_features = feature_schema.num_columns
@@ -676,7 +676,7 @@ def _get_subsample_feature_indices(
     # For one-hot encoding, num_added_features returns 0 as an approximation
     # because the true count depends on data cardinality (see warning below).
     subsample_sizes = []
-    for pipeline, max_feats in zip(pipelines, max_features_per_estimator):
+    for pipeline, max_feats in zip(pipelines, max_features_per_estimator, strict=False):
         subsample_sizes.append(
             _find_max_input_features(
                 pipeline=pipeline,
@@ -1083,6 +1083,7 @@ def generate_classification_ensemble_configs(
             configs_,
             class_permutations,
             model_indices,
+            strict=False,
         )
     ]
 
@@ -1150,6 +1151,7 @@ def generate_regression_ensemble_configs(
             featshifts,
             configs_,
             model_indices,
+            strict=False,
         )
     ]
 

--- a/src/tabpfn/preprocessing/ensemble.py
+++ b/src/tabpfn/preprocessing/ensemble.py
@@ -165,7 +165,7 @@ class TabPFNEnsemblePreprocessor:
                 random_state=int(seed),
                 enable_gpu_preprocessing=enable_gpu_preprocessing,
             )
-            for config, seed in zip(self.configs, self.pipeline_seeds, strict=False)
+            for config, seed in zip(self.configs, self.pipeline_seeds, strict=True)
         ]
 
         n_total_features = feature_schema.num_columns
@@ -676,7 +676,7 @@ def _get_subsample_feature_indices(
     # For one-hot encoding, num_added_features returns 0 as an approximation
     # because the true count depends on data cardinality (see warning below).
     subsample_sizes = []
-    for pipeline, max_feats in zip(pipelines, max_features_per_estimator, strict=False):
+    for pipeline, max_feats in zip(pipelines, max_features_per_estimator, strict=True):
         subsample_sizes.append(
             _find_max_input_features(
                 pipeline=pipeline,
@@ -1083,7 +1083,7 @@ def generate_classification_ensemble_configs(
             configs_,
             class_permutations,
             model_indices,
-            strict=False,
+            strict=True,
         )
     ]
 
@@ -1151,7 +1151,7 @@ def generate_regression_ensemble_configs(
             featshifts,
             configs_,
             model_indices,
-            strict=False,
+            strict=True,
         )
     ]
 

--- a/src/tabpfn/preprocessing/pipeline_interface.py
+++ b/src/tabpfn/preprocessing/pipeline_interface.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import dataclasses
 import time
 from abc import abstractmethod
-from typing_extensions import TypeAlias
+from typing import TypeAlias
 
 import numpy as np
 import torch

--- a/src/tabpfn/preprocessing/transform.py
+++ b/src/tabpfn/preprocessing/transform.py
@@ -217,6 +217,7 @@ def fit_preprocessing(
                 pipelines,
                 subsample_feature_indices,
                 subsample_row_indices,
+                strict=False,
             )  # type: ignore[arg-type]
         )
     )

--- a/src/tabpfn/preprocessing/transform.py
+++ b/src/tabpfn/preprocessing/transform.py
@@ -217,7 +217,7 @@ def fit_preprocessing(
                 pipelines,
                 subsample_feature_indices,
                 subsample_row_indices,
-                strict=False,
+                strict=True,
             )  # type: ignore[arg-type]
         )
     )

--- a/src/tabpfn/regressor.py
+++ b/src/tabpfn/regressor.py
@@ -24,8 +24,8 @@ import warnings
 from collections.abc import Iterator, Sequence
 from functools import partial
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Any, Literal
-from typing_extensions import Self, TypedDict, deprecated, overload
+from typing import TYPE_CHECKING, Annotated, Any, Literal, overload
+from typing_extensions import Self, TypedDict, deprecated
 
 import numpy as np
 import torch

--- a/src/tabpfn/regressor.py
+++ b/src/tabpfn/regressor.py
@@ -24,7 +24,7 @@ import warnings
 from collections.abc import Iterator, Sequence
 from functools import partial
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Any, Literal, Union
+from typing import TYPE_CHECKING, Annotated, Any, Literal
 from typing_extensions import Self, TypedDict, deprecated, overload
 
 import numpy as np
@@ -145,9 +145,7 @@ class FullOutputDict(MainOutputDict):
     logits: torch.Tensor
 
 
-RegressionResultType = Union[
-    np.ndarray, list[np.ndarray], MainOutputDict, FullOutputDict
-]
+RegressionResultType = np.ndarray | list[np.ndarray] | MainOutputDict | FullOutputDict
 """The type hint for the return value of the `predict` method."""
 
 

--- a/src/tabpfn/utils.py
+++ b/src/tabpfn/utils.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import contextlib
 import os
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Literal, Union
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 import numpy.typing as npt
@@ -105,9 +105,9 @@ def _cancel_nan_borders(
     return borders, logit_cancel_mask
 
 
-DevicesSpecification = Union[
-    torch.device, str, Sequence[Union[torch.device, str]], Literal["auto"]
-]
+DevicesSpecification = (
+    torch.device | str | Sequence[torch.device | str] | Literal["auto"]
+)
 
 
 def infer_devices(devices: DevicesSpecification) -> tuple[torch.device, ...]:

--- a/tests/README.md
+++ b/tests/README.md
@@ -42,7 +42,7 @@ For this reason:
 
 We test against specific CI platform configurations:
 - Linux, Windows, and macOS
-- Python 3.9 and 3.13
+- Python 3.10 and 3.14
 
 To ensure reliable CI testing:
 1. Reference values should be generated on a CI-compatible platform

--- a/tests/test_classifier_interface.py
+++ b/tests/test_classifier_interface.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import io
 import itertools
 import os
+from collections.abc import Callable
 from itertools import product
-from typing import Any, Callable, Literal
+from typing import Any, Literal
 
 import numpy as np
 import pandas as pd

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -19,9 +19,10 @@ import json
 import logging
 import pathlib
 import platform
+from collections.abc import Callable
 from dataclasses import dataclass
 from functools import partial
-from typing import Callable, Union
+from typing import TypeAlias
 
 import numpy as np
 import pytest
@@ -96,7 +97,7 @@ def _add_extra_devices(
     return model
 
 
-TensorOrArray = Union[np.ndarray, torch.Tensor]
+TensorOrArray: TypeAlias = np.ndarray | torch.Tensor
 
 
 @dataclass(frozen=True)

--- a/tests/test_finetuning_classifier.py
+++ b/tests/test_finetuning_classifier.py
@@ -312,7 +312,7 @@ def variable_synthetic_dataset_collection() -> list[tuple[np.ndarray, np.ndarray
     dataset_sizes = [10, 20, 30]
     class_counts = [2, 4, 6]
     n_features = 3
-    for size, n_classes in zip(dataset_sizes, class_counts, strict=False):
+    for size, n_classes in zip(dataset_sizes, class_counts, strict=True):
         X = rng.normal(size=(size, n_features)).astype(np.float32)
         y = rng.integers(0, n_classes, size=size)
         datasets.append((X, y))

--- a/tests/test_finetuning_classifier.py
+++ b/tests/test_finetuning_classifier.py
@@ -312,7 +312,7 @@ def variable_synthetic_dataset_collection() -> list[tuple[np.ndarray, np.ndarray
     dataset_sizes = [10, 20, 30]
     class_counts = [2, 4, 6]
     n_features = 3
-    for size, n_classes in zip(dataset_sizes, class_counts):
+    for size, n_classes in zip(dataset_sizes, class_counts, strict=False):
         X = rng.normal(size=(size, n_features)).astype(np.float32)
         y = rng.integers(0, n_classes, size=size)
         datasets.append((X, y))

--- a/tests/test_ft_utils.py
+++ b/tests/test_ft_utils.py
@@ -55,7 +55,7 @@ def test_chunk_data():
     assert len(y_chunks) == expected_num_chunks, "Incorrect y chunk count"
 
     # Check that each chunk size is <= max_chunk
-    for x_chunk, y_chunk in zip(x_chunks, y_chunks):
+    for x_chunk, y_chunk in zip(x_chunks, y_chunks, strict=False):
         assert len(x_chunk) <= max_chunk, "X chunk size exceeds max"
         assert len(y_chunk) <= max_chunk, "y chunk size exceeds max"
         assert len(x_chunk) == len(y_chunk), "X/y chunk length mismatch"

--- a/tests/test_ft_utils.py
+++ b/tests/test_ft_utils.py
@@ -55,7 +55,7 @@ def test_chunk_data():
     assert len(y_chunks) == expected_num_chunks, "Incorrect y chunk count"
 
     # Check that each chunk size is <= max_chunk
-    for x_chunk, y_chunk in zip(x_chunks, y_chunks, strict=False):
+    for x_chunk, y_chunk in zip(x_chunks, y_chunks, strict=True):
         assert len(x_chunk) <= max_chunk, "X chunk size exceeds max"
         assert len(y_chunk) <= max_chunk, "y chunk size exceeds max"
         assert len(x_chunk) == len(y_chunk), "X/y chunk length mismatch"

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -317,7 +317,7 @@ def test__cache_preprocessing__with_outlier_removal() -> None:
 
     assert len(outputs_outlier_removed) == len(outputs_outlier_not_removed)
     for outlier_removed_output, outlier_not_removed_output in zip(
-        outputs_outlier_removed, outputs_outlier_not_removed, strict=False
+        outputs_outlier_removed, outputs_outlier_not_removed, strict=True
     ):
         assert isinstance(outlier_removed_output[0], Tensor)
         assert isinstance(outlier_not_removed_output[0], Tensor)

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -317,7 +317,7 @@ def test__cache_preprocessing__with_outlier_removal() -> None:
 
     assert len(outputs_outlier_removed) == len(outputs_outlier_not_removed)
     for outlier_removed_output, outlier_not_removed_output in zip(
-        outputs_outlier_removed, outputs_outlier_not_removed
+        outputs_outlier_removed, outputs_outlier_not_removed, strict=False
     ):
         assert isinstance(outlier_removed_output[0], Tensor)
         assert isinstance(outlier_not_removed_output[0], Tensor)

--- a/tests/test_model/test_bar_distribution.py
+++ b/tests/test_model/test_bar_distribution.py
@@ -72,8 +72,6 @@ def test_average_bar_distributions_into_different_one():
     ).item() == pytest.approx(1.0)
     pos = torch.tensor([new_small_d.borders[-2]])
     assert new_small_d.cdf(new_small_logits, pos).item() == pytest.approx(
-        sum(
-            bd.cdf(lo, pos)[0].item() for bd, lo in zip(bar_dists, logits, strict=False)
-        )
+        sum(bd.cdf(lo, pos)[0].item() for bd, lo in zip(bar_dists, logits, strict=True))
         / 4
     )

--- a/tests/test_model/test_bar_distribution.py
+++ b/tests/test_model/test_bar_distribution.py
@@ -72,5 +72,8 @@ def test_average_bar_distributions_into_different_one():
     ).item() == pytest.approx(1.0)
     pos = torch.tensor([new_small_d.borders[-2]])
     assert new_small_d.cdf(new_small_logits, pos).item() == pytest.approx(
-        sum(bd.cdf(lo, pos)[0].item() for bd, lo in zip(bar_dists, logits)) / 4
+        sum(
+            bd.cdf(lo, pos)[0].item() for bd, lo in zip(bar_dists, logits, strict=False)
+        )
+        / 4
     )

--- a/tests/test_preprocessing/test_ensemble.py
+++ b/tests/test_preprocessing/test_ensemble.py
@@ -66,7 +66,7 @@ def test__get_subsample_indices_for_estimators():
     )
     assert len(subsample_indices) == 3
     for subsample_index, expected_subsample_index in zip(
-        subsample_indices, expected_subsample_indices, strict=False
+        subsample_indices, expected_subsample_indices, strict=True
     ):
         assert subsample_index is not None
         assert (subsample_index == expected_subsample_index).all()
@@ -466,14 +466,14 @@ def test__get_subsample_feature_indices__balanced_reproducibility():
     # Same seed -> identical output.
     result_a = _get_subsample_feature_indices(rng=np.random.default_rng(42), **kwargs)
     result_b = _get_subsample_feature_indices(rng=np.random.default_rng(42), **kwargs)
-    for a, b in zip(result_a, result_b, strict=False):
+    for a, b in zip(result_a, result_b, strict=True):
         np.testing.assert_array_equal(a, b)
 
     # Different seed -> different output.
     result_c = _get_subsample_feature_indices(rng=np.random.default_rng(99), **kwargs)
     any_different = any(
         not np.array_equal(a, c)
-        for a, c in zip(result_a, result_c, strict=False)
+        for a, c in zip(result_a, result_c, strict=True)
         if a is not None and c is not None
     )
     assert any_different, "Different seeds should produce different distributions"

--- a/tests/test_preprocessing/test_ensemble.py
+++ b/tests/test_preprocessing/test_ensemble.py
@@ -66,7 +66,7 @@ def test__get_subsample_indices_for_estimators():
     )
     assert len(subsample_indices) == 3
     for subsample_index, expected_subsample_index in zip(
-        subsample_indices, expected_subsample_indices
+        subsample_indices, expected_subsample_indices, strict=False
     ):
         assert subsample_index is not None
         assert (subsample_index == expected_subsample_index).all()
@@ -466,14 +466,14 @@ def test__get_subsample_feature_indices__balanced_reproducibility():
     # Same seed -> identical output.
     result_a = _get_subsample_feature_indices(rng=np.random.default_rng(42), **kwargs)
     result_b = _get_subsample_feature_indices(rng=np.random.default_rng(42), **kwargs)
-    for a, b in zip(result_a, result_b):
+    for a, b in zip(result_a, result_b, strict=False):
         np.testing.assert_array_equal(a, b)
 
     # Different seed -> different output.
     result_c = _get_subsample_feature_indices(rng=np.random.default_rng(99), **kwargs)
     any_different = any(
         not np.array_equal(a, c)
-        for a, c in zip(result_a, result_c)
+        for a, c in zip(result_a, result_c, strict=False)
         if a is not None and c is not None
     )
     assert any_different, "Different seeds should produce different distributions"

--- a/tests/test_preprocessing/test_pipeline_consistency.py
+++ b/tests/test_preprocessing/test_pipeline_consistency.py
@@ -19,9 +19,10 @@ import json
 import logging
 import pathlib
 import platform
+from collections.abc import Callable
 from dataclasses import dataclass
 from functools import partial
-from typing import Callable, Literal
+from typing import Literal
 
 import numpy as np
 import pytest

--- a/tests/test_regressor_interface.py
+++ b/tests/test_regressor_interface.py
@@ -6,7 +6,8 @@ import io
 import itertools
 import os
 import typing
-from typing import Any, Callable, Literal
+from collections.abc import Callable
+from typing import Any, Literal
 from unittest import mock
 
 import numpy as np
@@ -550,7 +551,7 @@ def test_dict_vs_object_preprocessor_config(X_y: tuple[np.ndarray, np.ndarray]) 
     quant_dict = model_dict.predict(X, output_type="quantiles", quantiles=quantiles)
     quant_obj = model_obj.predict(X, output_type="quantiles", quantiles=quantiles)
 
-    for q_dict, q_obj in zip(quant_dict, quant_obj):
+    for q_dict, q_obj in zip(quant_dict, quant_obj, strict=False):
         np.testing.assert_array_almost_equal(
             q_dict,
             q_obj,

--- a/tests/test_regressor_interface.py
+++ b/tests/test_regressor_interface.py
@@ -551,7 +551,7 @@ def test_dict_vs_object_preprocessor_config(X_y: tuple[np.ndarray, np.ndarray]) 
     quant_dict = model_dict.predict(X, output_type="quantiles", quantiles=quantiles)
     quant_obj = model_obj.predict(X, output_type="quantiles", quantiles=quantiles)
 
-    for q_dict, q_obj in zip(quant_dict, quant_obj, strict=False):
+    for q_dict, q_obj in zip(quant_dict, quant_obj, strict=True):
         np.testing.assert_array_almost_equal(
             q_dict,
             q_obj,


### PR DESCRIPTION
Note that I had to add some changes like removing `Union` as ruff rules change with the bumped python version.
I've also opted to use strict=True since this is typically safer bug-wise but might introduce crashes - let me know if 
you prefer strict=False :)


Note2: I've updated the branch protection rule as well to gate on the 3.10 tests, not 3.9.

Claude stuff below:



## Summary

Removes support for Python 3.9 (minimum is now **3.10**) and adds official support for Python **3.14**.


### Dropping 3.9 / minimum 3.10

**`pyproject.toml`**
- `requires-python = ">=3.9"` → `">=3.10"`
- Removed the `eval-type-backport>=0.2.2` dependency — it was only needed on Python 3.9 to enable `X | Y` union notation in Pydantic models (native since 3.10).
- Removed the `Programming Language :: Python :: 3.9` classifier.
- Bumped tooling targets: ruff `target-version = "py310"`, mypy `python_version = "3.10"`, pyright `pythonVersion = "3.10"`.

**`.github/workflows/ci.yml`**
- Bumped the `lowest-direct` test matrices (compatibility + GPU) from `3.9` → `3.10`.
- Updated stale comments that referenced the `>=3.9` constraint / 3.9-on-x86 limitation.

### Adding 3.14
- Added the `Programming Language :: Python :: 3.14` classifier.
- 3.14 is already exercised by the CI matrix (`highest` dependency set on Ubuntu/macOS/Windows + GPU), so no workflow changes were needed.

### Docs
- Updated the README Python-versions badge and FAQ (now `3.10`–`3.14`).
- Updated `tests/README.md` CI version note.

### Notes
- The only remaining `sys.version_info < (3, 10)` branch lives in `src/tabpfn/misc/_sklearn_compat.py`, which is vendored verbatim from scikit-learn (ruff-ignored `ALL`). Left untouched to stay faithful to upstream; it is harmless on 3.10+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)