### PR TITLE
`.predict_proba_batched()` interface for batched classifier predicts

### DIFF
--- a/changelog/1045.added.md
+++ b/changelog/1045.added.md
@@ -1,0 +1,1 @@
+Add `TabPFNClassifier.predict_proba_batched(X_list, y_list, X_test_list)` to score several independent datasets in a single fused forward per estimator (stacking them on the model's batch dimension), equivalent to fitting and predicting each dataset separately but much faster when launching many small predicts.

--- a/src/tabpfn/classifier.py
+++ b/src/tabpfn/classifier.py
@@ -29,7 +29,7 @@ from typing_extensions import Self, deprecated
 import numpy as np
 import torch
 from sklearn import config_context
-from sklearn.base import BaseEstimator, ClassifierMixin, check_is_fitted
+from sklearn.base import BaseEstimator, ClassifierMixin, check_is_fitted, clone
 from tqdm.auto import tqdm
 
 from tabpfn.base import (
@@ -52,6 +52,7 @@ from tabpfn.inference import (
     InferenceEngine,
     InferenceEngineBatchedNoPreprocessing,
     InferenceEngineCachePreprocessing,
+    _maybe_run_gpu_preprocessing,
 )
 from tabpfn.inference_tuning import (
     ClassifierEvalMetrics,
@@ -908,6 +909,13 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
                 self.inference_precision, self.devices_
             )
 
+        # Preprocessed labels are integer-encoded [0, ..., n-1]. Needed so batched
+        # *inference* postprocessing can shape outputs; harmless for fine-tuning,
+        # where the wrapper sets these. Only set if not already provided.
+        if not hasattr(self, "n_classes_"):
+            self.n_classes_ = max(int(t.max().item()) for t in y_preprocessed) + 1
+            self.classes_ = torch.arange(self.n_classes_)
+
         feature_schema = convert_batch_of_cat_ix_to_schema(
             batch_of_cat_indices=cat_ix,
             num_features=X_preprocessed[0].shape[1],
@@ -929,6 +937,198 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
         )
 
         return self
+
+    def predict_proba_batched(
+        self,
+        X_train_list: list[XType],
+        y_train_list: list[YType],
+        X_test_list: list[XType],
+    ) -> np.ndarray:
+        """Predict probabilities for several independent datasets in one pass.
+
+        Each ``(X_train, y_train, X_test)`` triple is preprocessed exactly as in
+        ``fit()`` + ``predict_proba()`` (input validation, CPU and GPU
+        preprocessing, same ensemble configs), then all datasets are stacked along
+        the model's batch dimension and scored with a *single fused forward per
+        estimator*. For the supported cases below this is equivalent to calling
+        ``fit`` + ``predict_proba`` on each dataset independently.
+
+        All datasets must share the same set of classes (they are scored together
+        with a single ``n_classes_``) and the same array shapes: the fused forward
+        stacks them on the batch dimension, and ragged batches are rejected rather
+        than padded (padding would feed the model fake context/query rows and
+        silently corrupt results). Group datasets by shape upstream if needed.
+
+        This method does not modify the estimator: the per-dataset fits run on an
+        internal clone, so ``self`` is unchanged on return (any prior ``fit`` is
+        preserved).
+
+        Args:
+            X_train_list: Training features, one array per dataset (all same shape).
+            y_train_list: Training labels, one array per dataset.
+            X_test_list: Test features, one array per dataset (all same shape).
+
+        Returns:
+            Probabilities of shape ``(n_datasets, n_test, n_classes)``.
+
+        Raises:
+            ValueError: If the input lists have unequal or zero length, the
+                datasets do not all share the same set of classes, or the training
+                (or test) arrays do not all share one shape.
+            NotImplementedError: If ``balance_probabilities`` or ``tuning_config``
+                is configured on the estimator — their state is per-dataset and
+                cannot be applied correctly across a shared batch. Score those
+                datasets individually with ``predict_proba``.
+        """
+        # Both imported here rather than at module scope to avoid circular imports:
+        # architectures.interface imported at runtime from classifier is circular
+        # (the rest of the module only needs PerformanceOptions for type-checking),
+        # and the `finetuning` package imports TabPFNClassifier.
+        from tabpfn.architectures.interface import (  # noqa: PLC0415
+            PerformanceOptions,
+        )
+        from tabpfn.finetuning.data_util import (  # noqa: PLC0415
+            ClassifierBatch,
+            meta_dataset_collator,
+        )
+
+        if not len(X_train_list) == len(y_train_list) == len(X_test_list):
+            raise ValueError(
+                "X_train_list, y_train_list and X_test_list must have equal length."
+            )
+        if len(X_train_list) == 0:
+            raise ValueError("Nothing to predict: empty dataset list.")
+
+        # These per-prediction post-processing steps are configured globally on the
+        # estimator but their fitted state (thresholds, class counts, calibrated
+        # temperature) is per-dataset; applying the last dataset's state across the
+        # whole batch would be wrong, so they are not supported here.
+        if self.balance_probabilities:
+            raise NotImplementedError(
+                "predict_proba_batched does not support balance_probabilities=True; "
+                "score datasets individually with predict_proba."
+            )
+        if self.tuning_config is not None:
+            raise NotImplementedError(
+                "predict_proba_batched does not support tuning_config (tuned "
+                "decision thresholds / temperature calibration); score datasets "
+                "individually with predict_proba."
+            )
+
+        # All datasets are scored with a single, shared n_classes_ (one fused
+        # forward over the batch), so they must share the same set of classes.
+        class_sets = [
+            tuple(sorted(np.unique(np.asarray(y)).tolist())) for y in y_train_list
+        ]
+        if len(set(class_sets)) > 1:
+            raise ValueError(
+                "predict_proba_batched requires all datasets to share the same "
+                "set of classes (they are scored together with one n_classes_); "
+                f"got differing class sets across datasets: {sorted(set(class_sets))}"
+            )
+
+        # The fused forward stacks datasets on the model's batch dimension, which
+        # requires identical shapes. Padding ragged datasets would feed the model
+        # fake (zero) context/query rows and leave padded query rows untrimmed in
+        # the output, silently corrupting results — so reject ragged batches.
+        train_shapes = {
+            tuple(X.shape) if hasattr(X, "shape") else np.asarray(X).shape
+            for X in X_train_list
+        }
+        test_shapes = {
+            tuple(X.shape) if hasattr(X, "shape") else np.asarray(X).shape
+            for X in X_test_list
+        }
+        if len(train_shapes) > 1 or len(test_shapes) > 1:
+            raise ValueError(
+                "predict_proba_batched requires all training arrays to share one "
+                "shape and all test arrays to share one shape (ragged batches are "
+                f"not supported); got train shapes {sorted(train_shapes)} and test "
+                f"shapes {sorted(test_shapes)}. Group datasets by shape and call "
+                "once per group."
+            )
+
+        # Run the per-dataset fits on an internal clone so this prediction method
+        # does not mutate the estimator: ``self`` is left unchanged on return (any
+        # prior fit is preserved), and the batched executor is dropped with the
+        # clone rather than pinning every dataset's tensors on ``self``. The clone
+        # shares the same model via the ``model_path`` param, so there is no reload.
+        worker = clone(self)
+        # Fit each dataset in "fit_preprocessors" mode so the fitted ensemble
+        # members are cached on the executor and reused directly (no redundant
+        # preprocessing).
+        worker.fit_mode = "fit_preprocessors"
+        items = []
+        for X, y, X_test in zip(X_train_list, y_train_list, X_test_list, strict=True):
+            # Standard fit on the clone: builds the ensemble preprocessor + configs,
+            # caches the fitted members on the executor, and sets classes_/n_classes_
+            # exactly as a normal predict would.
+            worker.fit(X, y)
+            # Validate/clean X_test exactly as the standard predict path does
+            # (_raw_predict) before the per-member preprocessors run, so non-numeric
+            # inputs (DataFrames, categoricals, NaNs) are handled identically.
+            X_test = ensure_compatible_predict_input_sklearn(X_test, worker)  # noqa: PLW2901
+            X_test = fix_dtypes(  # noqa: PLW2901
+                X_test,
+                cat_indices=worker.inferred_feature_schema_.indices_for(
+                    FeatureModality.CATEGORICAL
+                ),
+            )
+            X_test = process_text_na_dataframe(  # noqa: PLW2901
+                X=X_test,
+                ord_encoder=getattr(worker, "ordinal_encoder_", None),
+            )
+            members = worker.executor_.ensemble_members
+            x_context, x_query, cat_indices = [], [], []
+            y_context = [
+                torch.as_tensor(np.asarray(m.y_train), dtype=torch.float32)
+                for m in members
+            ]
+            device = worker.devices_[0]
+            for member in members:
+                x_tr = torch.as_tensor(np.asarray(member.X_train), dtype=torch.float32)
+                x_te = torch.as_tensor(
+                    np.asarray(member.transform_X_test(X_test)), dtype=torch.float32
+                )
+                full, schema = _maybe_run_gpu_preprocessing(
+                    torch.cat([x_tr, x_te], dim=0).to(device),
+                    member.gpu_preprocessor,
+                    member.feature_schema,
+                    num_train_rows=x_tr.shape[0],
+                )
+                n = x_tr.shape[0]
+                x_context.append(full[:n])
+                x_query.append(full[n:])
+                cat_indices.append(
+                    schema.indices_for(FeatureModality.CATEGORICAL) or []
+                )
+            n_test = x_query[0].shape[0]
+            items.append(
+                ClassifierBatch(
+                    X_context=x_context,
+                    X_query=x_query,
+                    y_context=y_context,
+                    y_query=torch.zeros(n_test),
+                    cat_indices=cat_indices,
+                    configs=worker.ensemble_configs_,
+                )
+            )
+
+        batch = meta_dataset_collator(items)
+        # The clone now drives the batched executor; set the mode so
+        # fit_from_preprocessed does not warn about switching out of fine-tuning mode.
+        worker.fit_mode = "batched"
+        worker.fit_from_preprocessed(
+            batch.X_context,
+            batch.y_context,
+            batch.cat_indices,
+            batch.configs,
+            performance_options=PerformanceOptions(),
+        )
+        # (n_test, n_datasets, n_classes)
+        out = worker.forward(batch.X_query, use_inference_mode=True)
+        out = out.detach().float().cpu().numpy()
+        return np.transpose(out, (1, 0, 2))  # -> (n_datasets, n_test, n_classes)
 
     def fit_with_differentiable_input(self, X: torch.Tensor, y: torch.Tensor) -> Self:
         """Fit the model with differentiable input.
@@ -1471,12 +1671,23 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
             and (not X or isinstance(X[0], torch.Tensor))
         )
 
-        assert is_standard_inference or is_batched_for_grads, (
+        # Scenario 3: Batched *inference* — score several independent datasets in
+        # one fused forward per estimator (no gradients). Output keeps the dataset
+        # batch dimension.
+        is_batched_inference = (
+            use_inference_mode
+            and isinstance(self.executor_, InferenceEngineBatchedNoPreprocessing)
+            and isinstance(X, list)
+            and (not X or isinstance(X[0], torch.Tensor))
+        )
+
+        assert is_standard_inference or is_batched_for_grads or is_batched_inference, (
             f"Invalid forward pass: Bad combination of inference mode "
             f"({use_inference_mode=}), input X, "
             f"or executor type ({type(self.executor_)}). Ensure call is from standard "
-            f"predict ({is_standard_inference=}) or a batched fine-tuning context."
-            f"({is_batched_for_grads=})."
+            f"predict ({is_standard_inference=}), batched fine-tuning "
+            f"({is_batched_for_grads=}), or batched inference "
+            f"({is_batched_inference=})."
         )
 
         # Specific check for float64 incompatibility if the batched engine is being
@@ -1558,7 +1769,9 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
             output = self.logits_to_probabilities(stacked_outputs)
 
         # --- Final output shaping ---
-        if output.ndim > 2 and use_inference_mode:
+        # Standard inference squeezes the singleton batch dim; batched inference
+        # keeps it so the output is always (n_query, batch_size, n_classes).
+        if output.ndim > 2 and use_inference_mode and not is_batched_inference:
             output = output.squeeze(1) if not return_raw_logits else output.squeeze(2)
 
         if not use_inference_mode:

--- a/src/tabpfn/finetuning/data_util.py
+++ b/src/tabpfn/finetuning/data_util.py
@@ -619,12 +619,20 @@ def meta_dataset_collator(
         A collated ClassifierBatch or RegressorBatch with stacked/padded data.
 
     Note:
-        Currently only implemented and tested for `batch_size = 1`,
-        as enforced by an internal assertion.
+        ``batch_size > 1`` stacks several datasets along the model's batch
+        dimension (used by batched inference). Tensors are padded to a common
+        shape, so callers that need exact, per-dataset-equivalent results must
+        pass same-shaped datasets (padded context/query rows are not masked).
+        For ``RegressorBatch`` the bar distributions are taken from the first
+        item only; batched regressor decoding applies each dataset's own bar
+        distribution downstream, after the fused forward.
     """
-    batch_sz = len(batch)
-    assert batch_sz == 1, "Only Implemented and tested for batch size of 1"
-
+    # batch_size > 1 stacks multiple independent datasets along the model's batch
+    # dimension, enabling a single fused forward over all of them (the transformer
+    # batch dim is independent). Tensors are padded to a common shape; when the
+    # datasets share a shape (the common case) no padding occurs and results are
+    # exact. Ragged datasets are padded with ``padding_val`` (see pad_tensors);
+    # masking of padded context positions is left to the model/preprocessing.
     first_item = batch[0]
     num_estimators = len(first_item.X_context)
 

--- a/src/tabpfn/inference.py
+++ b/src/tabpfn/inference.py
@@ -524,11 +524,15 @@ class InferenceEngineBatchedNoPreprocessing(SingleDeviceInferenceEngine):
             performance_options: Performance and memory options forwarded to
                 the model on each forward call.
         """
+        # Each entry of ``ensemble_configs`` is one estimator slot holding one
+        # config per dataset in the batch (length == batch size). A single fused
+        # forward is run per estimator over the whole dataset batch, so all
+        # datasets in a batch must use the same underlying model.
         for ensemble_config in ensemble_configs:
-            if len(ensemble_config) > 1:
+            if len({cfg._model_index for cfg in ensemble_config}) > 1:
                 raise ValueError(
-                    "Batched inference does not support multiple ensemble"
-                    " configurations because no preprocessing is applied."
+                    "Batched inference requires all datasets in a batch to use the"
+                    " same model; got multiple model indices in one estimator slot."
                 )
 
         super().__init__(

--- a/tests/test_classifier_interface.py
+++ b/tests/test_classifier_interface.py
@@ -1382,3 +1382,194 @@ def test__create_default_for_version__passes_through_overrides() -> None:
 
     assert estimator.n_estimators == 16
     assert estimator.softmax_temperature == 0.9
+
+
+# =============================================================================
+# predict_proba_batched: batched multi-dataset inference (public API)
+# =============================================================================
+
+
+@pytest.mark.parametrize("device", devices)
+def test__predict_proba_batched__matches_per_dataset(device: str) -> None:
+    """The public predict_proba_batched API matches per-dataset fit+predict_proba.
+
+    Each dataset is preprocessed exactly as in standard inference, then all are
+    scored in one fused forward per estimator. Output is (n_datasets, n_test,
+    n_classes) and equals running each dataset alone to within float tolerance.
+    """
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA device requested but not available.")
+
+    def mkds(seed: int, n: int = 60, f: int = 5) -> tuple[np.ndarray, np.ndarray]:
+        r = np.random.RandomState(seed)
+        X = r.randn(n, f).astype(np.float32)
+        y = (X[:, 0] + 0.3 * r.randn(n) > 0).astype(int)
+        return X, y
+
+    data = [mkds(s) for s in range(3)]
+    X_tests = [d[0][:5] for d in data]
+
+    clf = TabPFNClassifier(
+        n_estimators=2,
+        device=device,
+        random_state=42,
+        inference_precision=torch.float32,
+    )
+    proba = clf.predict_proba_batched(
+        [d[0] for d in data], [d[1] for d in data], X_tests
+    )
+    assert proba.shape == (3, 5, 2)
+    assert np.allclose(proba.sum(-1), 1.0, atol=1e-4)
+
+    atol = 1e-4
+    for i, (X, y) in enumerate(data):
+        ref_clf = TabPFNClassifier(
+            n_estimators=2,
+            device=device,
+            random_state=42,
+            inference_precision=torch.float32,
+        )
+        ref_clf.fit(X, y)
+        ref = ref_clf.predict_proba(X_tests[i])
+        np.testing.assert_allclose(proba[i], ref, atol=atol)
+
+
+def test__predict_proba_batched__rejects_mismatched_classes() -> None:
+    """predict_proba_batched raises if datasets do not share the same classes."""
+    r = np.random.RandomState(0)
+    X_bin = r.randn(40, 4).astype(np.float32)
+    y_bin = (X_bin[:, 0] > 0).astype(int)  # classes {0, 1}
+    X_multi = r.randn(40, 4).astype(np.float32)
+    y_multi = (X_multi[:, 0] * 2).astype(int) % 3  # classes {0, 1, 2}
+
+    clf = TabPFNClassifier(n_estimators=2, device="cpu", random_state=42)
+    with pytest.raises(ValueError, match=r"same.*set of classes"):
+        clf.predict_proba_batched(
+            [X_bin, X_multi], [y_bin, y_multi], [X_bin[:3], X_multi[:3]]
+        )
+
+
+@pytest.mark.parametrize("device", devices)
+def test__predict_proba_batched__matches_per_dataset_dataframe(device: str) -> None:
+    """Batched prediction matches per-dataset on non-numeric DataFrame inputs.
+
+    The standard predict path runs fix_dtypes / process_text_na_dataframe /
+    ordinal encoding on X_test before the member preprocessors; predict_proba_batched
+    must apply the same validation or non-numeric inputs would diverge from (or
+    crash relative to) predict_proba. To actually exercise those paths the frames
+    here mix dtypes that need conversion: a categorical-dtype column, an
+    object/string column, and NaNs in both a numeric and the object column. The
+    NaNs land within the first 5 rows so X_test (the first 5 rows) exercises NaN
+    handling too, not just the training side.
+    """
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA device requested but not available.")
+
+    def mkdf(seed: int, n: int = 60) -> tuple[pd.DataFrame, np.ndarray]:
+        r = np.random.RandomState(seed)
+        num = r.randn(n, 3).astype(np.float32)
+        cat = r.choice(["a", "b", "c"], size=n)
+        txt = r.choice(["red", "green", "blue"], size=n).astype(object)
+        df = pd.DataFrame(
+            {
+                "f0": num[:, 0],
+                "f1": num[:, 1],
+                "f2": num[:, 2],
+                "cat": pd.Categorical(cat),  # categorical dtype
+                "txt": txt,  # object / string dtype
+            }
+        )
+        # Inject NaNs in a numeric and the object column within the first 5 rows
+        # (so X_test sees them) plus some beyond. f0 stays clean for the label.
+        df.loc[[1, 4, 17], "f1"] = np.nan
+        df.loc[[2, 4, 23], "txt"] = None
+        # Median split on the clean numeric column guarantees both classes are
+        # present in every dataset.
+        y = (num[:, 0] > np.median(num[:, 0])).astype(int)
+        return df, y
+
+    data = [mkdf(s) for s in range(3)]
+    X_tests = [d[0].iloc[:5] for d in data]
+
+    clf = TabPFNClassifier(
+        n_estimators=2,
+        device=device,
+        random_state=42,
+        inference_precision=torch.float32,
+    )
+    proba = clf.predict_proba_batched(
+        [d[0] for d in data], [d[1] for d in data], X_tests
+    )
+    assert proba.shape == (3, 5, 2)
+
+    atol = 1e-4
+    for i, (X, y) in enumerate(data):
+        ref = TabPFNClassifier(
+            n_estimators=2,
+            device=device,
+            random_state=42,
+            inference_precision=torch.float32,
+        )
+        ref.fit(X, y)
+        np.testing.assert_allclose(proba[i], ref.predict_proba(X_tests[i]), atol=atol)
+
+
+def test__predict_proba_batched__rejects_ragged() -> None:
+    """Ragged batches are rejected (padding would corrupt the fused forward)."""
+    r = np.random.RandomState(0)
+    X_a = r.randn(40, 4).astype(np.float32)
+    y_a = (X_a[:, 0] > 0).astype(int)
+    X_b = r.randn(30, 4).astype(np.float32)  # different number of training rows
+    y_b = (X_b[:, 0] > 0).astype(int)
+
+    clf = TabPFNClassifier(n_estimators=2, device="cpu", random_state=42)
+    with pytest.raises(ValueError, match=r"ragged"):
+        clf.predict_proba_batched([X_a, X_b], [y_a, y_b], [X_a[:3], X_b[:3]])
+
+
+def test__predict_proba_batched__rejects_balance_probabilities() -> None:
+    """balance_probabilities uses per-dataset class counts → unsupported, raises."""
+    r = np.random.RandomState(0)
+    X = r.randn(40, 4).astype(np.float32)
+    y = (X[:, 0] > 0).astype(int)
+
+    clf = TabPFNClassifier(
+        n_estimators=2, device="cpu", random_state=42, balance_probabilities=True
+    )
+    with pytest.raises(NotImplementedError, match=r"balance_probabilities"):
+        clf.predict_proba_batched([X, X], [y, y], [X[:3], X[:3]])
+
+
+def test__predict_proba_batched__does_not_mutate_estimator() -> None:
+    """predict_proba_batched runs on an internal clone, leaving self untouched."""
+
+    def mk(seed: int, n: int = 60, f: int = 5) -> tuple[np.ndarray, np.ndarray]:
+        r = np.random.RandomState(seed)
+        X = r.randn(n, f).astype(np.float32)
+        y = (X[:, 0] > 0).astype(int)
+        return X, y
+
+    data = [mk(s) for s in range(3)]
+    X_list = [d[0] for d in data]
+    y_list = [d[1] for d in data]
+    X_tests = [d[0][:3] for d in data]
+
+    # An unfitted estimator stays unfitted (no executor_/classes_ left behind).
+    clf = TabPFNClassifier(n_estimators=2, device="cpu", random_state=42)
+    clf.predict_proba_batched(X_list, y_list, X_tests)
+    assert not hasattr(clf, "executor_")
+    assert not hasattr(clf, "classes_")
+
+    # A prior fit is preserved exactly across a batched call.
+    a_x, a_y = mk(99, n=80)
+    fitted = TabPFNClassifier(
+        n_estimators=2,
+        device="cpu",
+        random_state=42,
+        inference_precision=torch.float32,
+    )
+    fitted.fit(a_x, a_y)
+    before = fitted.predict_proba(a_x[:5])
+    fitted.predict_proba_batched(X_list, y_list, X_tests)
+    after = fitted.predict_proba(a_x[:5])
+    np.testing.assert_array_equal(before, after)

--- a/tests/test_finetuning_classifier.py
+++ b/tests/test_finetuning_classifier.py
@@ -1301,3 +1301,82 @@ def test__finetuned_tabpfn_classifier__use_fixed_preprocessing_seed(
             "Column order is not different for any batch! Fixed preprocessing seed is "
             "not working."
         )
+
+
+@pytest.mark.parametrize("device", devices)
+def test__batched_inference__matches_single_dataset(device: str) -> None:
+    """Batched inference scores several independent datasets in a single fused
+    forward per estimator and matches per-dataset inference exactly.
+
+    The transformer batch dimension is independent, so stacking datasets along it
+    yields independent in-context predictions in one forward. This verifies both
+    the output contract ((n_query, batch_size, n_classes)) and numerical
+    equivalence with running each dataset alone from the same preprocessed inputs.
+    """
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA device requested but not available.")
+
+    def mkds(seed: int, n: int = 60, f: int = 5) -> tuple[np.ndarray, np.ndarray]:
+        r = np.random.RandomState(seed)
+        X = r.randn(n, f).astype(np.float32)
+        y = (X[:, 0] + 0.3 * r.randn(n) > 0).astype(int)
+        return X, y
+
+    data = [mkds(s) for s in range(3)]
+
+    def make_clf() -> TabPFNClassifier:
+        return TabPFNClassifier(
+            n_estimators=2,
+            device=device,
+            random_state=42,
+            fit_mode="batched",
+            inference_precision=torch.float32,
+            differentiable_input=False,
+        )
+
+    clf = make_clf()
+    collection = get_preprocessed_dataset_chunks(
+        clf,
+        [d[0] for d in data],
+        [d[1] for d in data],
+        train_test_split,
+        100,
+        model_type="classifier",
+        equal_split_size=True,
+        data_shuffle_seed=42,
+        preprocessing_random_state=42,
+    )
+    batch = next(
+        iter(DataLoader(collection, batch_size=3, collate_fn=meta_dataset_collator))
+    )
+    perf = PerformanceOptions()
+
+    clf.fit_from_preprocessed(
+        batch.X_context,
+        batch.y_context,
+        batch.cat_indices,
+        batch.configs,
+        performance_options=perf,
+    )
+    fused = clf.forward(batch.X_query, use_inference_mode=True).detach()
+
+    # Output keeps the dataset batch dim: (n_query, n_datasets, n_classes).
+    assert fused.ndim == 3
+    assert fused.shape[1] == 3
+    assert torch.allclose(fused.sum(-1), torch.ones_like(fused.sum(-1)), atol=1e-4)
+
+    # Each dataset, run alone from the same preprocessed inputs, matches the slice.
+    for i in range(3):
+        single_clf = make_clf()
+        single_clf.fit_from_preprocessed(
+            [t[i : i + 1] for t in batch.X_context],
+            [t[i : i + 1] for t in batch.y_context],
+            [batch.cat_indices[i]],
+            [[cfg[i]] for cfg in batch.configs],
+            performance_options=perf,
+        )
+        single = single_clf.forward(
+            [t[i : i + 1] for t in batch.X_query], use_inference_mode=True
+        ).detach()
+        assert single.shape[1] == 1
+        assert torch.allclose(fused[:, i, :], single[:, 0, :], atol=1e-4)


### PR DESCRIPTION
## Issue

* We have a use-case where we have many small independent datasets to process
* This doesn't use the GPU very well, in fact CPU inference is faster
* Hence the proposal of this batched API for inference (previously this was only used for finetuning), that allows utilizing the GPU better for this use-case

---

## Public API Changes

-   [x] Yes, Public API changes (Details below)

Adding `.predict_proba_batched(..)` to classifier

Note: Adding this to the regressor interface would also be possible but not as nicely as for classifier as we can't easily reuse `.forward(..)` with the batch dimension, so I've left this out for now, but let me know if I should add regressor also for completeness.


---
