### PR TITLE
Fix fitted model archive path handling

### DIFF
--- a/changelog/1048.fixed.md
+++ b/changelog/1048.fixed.md
@@ -1,0 +1,1 @@
+Fix fitted model saving for paths whose parent directories contain `.tabpfn_fit`.

--- a/src/tabpfn/model_loading.py
+++ b/src/tabpfn/model_loading.py
@@ -1088,8 +1088,10 @@ def save_fitted_tabpfn_model(estimator: BaseEstimator, path: Path | str) -> None
         )
 
         # 4. Create the final zip archive
-        shutil.make_archive(str(path).replace(".tabpfn_fit", ""), "zip", tmp)
-        shutil.move(str(path).replace(".tabpfn_fit", "") + ".zip", path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        archive_base = path.with_suffix("")
+        archive_path = shutil.make_archive(str(archive_base), "zip", tmp)
+        shutil.move(archive_path, path)
 
 
 def _extract_archive(path: Path, tmp: Path) -> None:

--- a/src/tabpfn/model_loading.py
+++ b/src/tabpfn/model_loading.py
@@ -1089,9 +1089,10 @@ def save_fitted_tabpfn_model(estimator: BaseEstimator, path: Path | str) -> None
 
         # 4. Create the final zip archive
         path.parent.mkdir(parents=True, exist_ok=True)
-        archive_base = path.with_suffix("")
-        archive_path = shutil.make_archive(str(archive_base), "zip", tmp)
-        shutil.move(archive_path, path)
+        with tempfile.TemporaryDirectory() as archive_tmpdir:
+            archive_base = Path(archive_tmpdir) / "archive"
+            archive_path = shutil.make_archive(str(archive_base), "zip", tmp)
+            shutil.move(archive_path, path)
 
 
 def _extract_archive(path: Path, tmp: Path) -> None:

--- a/tests/test_save_load_fitted_model.py
+++ b/tests/test_save_load_fitted_model.py
@@ -18,7 +18,7 @@ from tabpfn import TabPFNClassifier, TabPFNRegressor
 from tabpfn.architectures.interface import ArchitectureConfig
 from tabpfn.base import RegressorModelSpecs, initialize_tabpfn_model
 from tabpfn.inference_tuning import ClassifierEvalMetrics
-from tabpfn.model_loading import save_fitted_tabpfn_model, save_tabpfn_model
+from tabpfn.model_loading import save_tabpfn_model
 
 from .utils import get_pytest_devices, get_pytest_devices_with_mps_marked_slow
 
@@ -35,21 +35,6 @@ def _make_classification_data_with_categoricals() -> tuple[np.ndarray, np.ndarra
     X_cat = X.astype(object)
     X_cat[:, 2] = np.random.choice(["A", "B", "C"], size=X.shape[0])  # noqa: NPY002
     return X_cat, y
-
-
-class _DummyExecutor:
-    def save_state_except_model_weights(self, path: Path) -> None:
-        path.write_text("executor state")
-
-
-class _DummyEstimator:
-    fitted_marker_ = "fitted"
-
-    def __init__(self) -> None:
-        self.executor_ = _DummyExecutor()
-
-    def get_params(self, *, deep: bool = False) -> dict[str, object]:
-        return {"deep": deep}
 
 
 # Exclude pairs where where "mps" is exatly one device type. MPS yields different
@@ -137,9 +122,12 @@ def test__save_fit_state__does_not_move_live_estimator_to_cpu(
 
 
 def test__save_fit_state__keeps_tabpfn_fit_parent_name(tmp_path: Path) -> None:
+    X, y = _make_regression_data()
+    model = TabPFNRegressor(device="cpu", n_estimators=1)
+    model.fit(X, y)
     path = tmp_path / "project.tabpfn_fit" / "model.tabpfn_fit"
 
-    save_fitted_tabpfn_model(_DummyEstimator(), path)
+    model.save_fit_state(path)
 
     assert path.exists()
     assert not (tmp_path / "project").exists()

--- a/tests/test_save_load_fitted_model.py
+++ b/tests/test_save_load_fitted_model.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import zipfile
 from copy import deepcopy
 from itertools import product
 from pathlib import Path
@@ -17,7 +18,7 @@ from tabpfn import TabPFNClassifier, TabPFNRegressor
 from tabpfn.architectures.interface import ArchitectureConfig
 from tabpfn.base import RegressorModelSpecs, initialize_tabpfn_model
 from tabpfn.inference_tuning import ClassifierEvalMetrics
-from tabpfn.model_loading import save_tabpfn_model
+from tabpfn.model_loading import save_fitted_tabpfn_model, save_tabpfn_model
 
 from .utils import get_pytest_devices, get_pytest_devices_with_mps_marked_slow
 
@@ -34,6 +35,21 @@ def _make_classification_data_with_categoricals() -> tuple[np.ndarray, np.ndarra
     X_cat = X.astype(object)
     X_cat[:, 2] = np.random.choice(["A", "B", "C"], size=X.shape[0])  # noqa: NPY002
     return X_cat, y
+
+
+class _DummyExecutor:
+    def save_state_except_model_weights(self, path: Path) -> None:
+        path.write_text("executor state")
+
+
+class _DummyEstimator:
+    fitted_marker_ = "fitted"
+
+    def __init__(self) -> None:
+        self.executor_ = _DummyExecutor()
+
+    def get_params(self, *, deep: bool = False) -> dict[str, object]:
+        return {"deep": deep}
 
 
 # Exclude pairs where where "mps" is exatly one device type. MPS yields different
@@ -118,6 +134,22 @@ def test__save_fit_state__does_not_move_live_estimator_to_cpu(
     # These output types rely on the bar distributions living on the model device.
     model.predict(X, output_type="median")
     model.predict(X, output_type="quantiles")
+
+
+def test__save_fit_state__keeps_tabpfn_fit_parent_name(tmp_path: Path) -> None:
+    path = tmp_path / "project.tabpfn_fit" / "model.tabpfn_fit"
+
+    save_fitted_tabpfn_model(_DummyEstimator(), path)
+
+    assert path.exists()
+    assert not (tmp_path / "project").exists()
+
+    with zipfile.ZipFile(path) as archive:
+        assert sorted(archive.namelist()) == [
+            "executor_state.joblib",
+            "fitted_attrs.joblib",
+            "init_params.json",
+        ]
 
 
 # --- Error Handling Tests ---


### PR DESCRIPTION
## Summary
- Derive the `.tabpfn_fit` archive base from the file suffix instead of using a global string replacement.
- Explicitly create the destination parent directory before moving the generated archive.
- Add regression coverage for save paths whose parent directory also contains `.tabpfn_fit`.

## Why
The previous string replacement could strip `.tabpfn_fit` from parent directory names while building the temporary zip path. That could create or touch a sibling directory unrelated to the requested save path before moving the final archive.

## Tests
- `uv run --no-project --with ruff==0.15.12 ruff check src/tabpfn/model_loading.py tests/test_save_load_fitted_model.py`
- `uv run --no-project --with ruff==0.15.12 ruff format --check src/tabpfn/model_loading.py tests/test_save_load_fitted_model.py`
- `uv run pytest tests/test_save_load_fitted_model.py::test__save_fit_state__keeps_tabpfn_fit_parent_name`
