### PR TITLE
Temporarily disable new PR assigning workflow and revert to CODEOWNERS.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,5 @@
+* @PriorLabs/opensource-review-team
+
 # Release automation – only release maintainers can modify these workflows
 .github/workflows/release-create-pr.yml  @PriorLabs/release-maintainers
 .github/workflows/release-tag-on-merge.yml       @PriorLabs/release-maintainers

--- a/.github/workflows/assign-pr-reviewer.yml
+++ b/.github/workflows/assign-pr-reviewer.yml
@@ -16,8 +16,10 @@ on:
   # This is safe, as we do not check out any code. See
   # https://docs.github.com/en/enterprise-cloud@latest/actions/reference/security/secure-use#mitigating-the-risks-of-untrusted-code-checkout
   # DO NOT ADD ACTIONS/CHECKOUT TO THIS WORKFLOW.
-  pull_request_target:
-    types: [opened, reopened, ready_for_review]
+  # pull_request_target:
+  #   types: [opened, reopened, ready_for_review]
+  # Disable the workflow while we fix it.
+  workflow_dispatch:
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
The new workflow fails because it doesn't have permission to access the team:
https://github.com/PriorLabs/TabPFN/actions/runs/27471342437/job/81202694148

I want to discuss whether we can fix this without adding more permissions to the workflow, as it also uses pull_request_target. In the meantime, switch back to how things were before
https://github.com/PriorLabs/TabPFN/pull/1042