### PR TITLE
[Automated PR (update-readme)]: Fix save_tabpfn_model usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ reg_cpu = load_fitted_tabpfn_model("my_reg.tabpfn_fit", device="cpu")
 ```
 
 To store just the foundation model weights (without a fitted estimator) use
-``save_tabpfn_model(reg, "my_tabpfn.ckpt")``. This merely saves a
+``save_tabpfn_model(reg, "my_tabpfn.ckpt")`` (imported from ``tabpfn.model_loading``). This merely saves a
 checkpoint of the pre-trained weights so you can later create and fit a fresh
 estimator. Reload the checkpoint with ``load_model_criterion_config``.
 

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ reg_cpu = load_fitted_tabpfn_model("my_reg.tabpfn_fit", device="cpu")
 ```
 
 To store just the foundation model weights (without a fitted estimator) use
-``save_tabpfn_model(reg.model_, "my_tabpfn.ckpt")``. This merely saves a
+``save_tabpfn_model(reg, "my_tabpfn.ckpt")``. This merely saves a
 checkpoint of the pre-trained weights so you can later create and fit a fresh
 estimator. Reload the checkpoint with ``load_model_criterion_config``.
 

--- a/changelog/1053.fixed.md
+++ b/changelog/1053.fixed.md
@@ -1,0 +1,1 @@
+Fix the README's save/load example to call `save_tabpfn_model(reg, ...)` with the estimator instead of `reg.model_`, which would have raised at runtime.


### PR DESCRIPTION
⚠️ This PR was based on the routine defined in update-readme.
As the automatically chosen reviewer, you are responsible for this PR.
Feel free to close or edit the PR, and either merge when ready or assign another reviewer if needed.
If the PR is not satisfactory, please edit the prompt in update-readme in the [misc/claude-routines directory](https://github.com/PriorLabs/misc/tree/main/claude-routines), or contact the routine owner Philipp Singer.

## What

Fixes an incorrect code snippet in the README's "How do I save and load a trained TabPFN model?" FAQ.

The README documents:
```python
save_tabpfn_model(reg.model_, "my_tabpfn.ckpt")
```

But `save_tabpfn_model` expects the **estimator** itself, not `reg.model_`:

```python
def save_tabpfn_model(
    model: TabPFNRegressor | TabPFNClassifier,
    save_path: Path | str | list[Path | str],
    ...
) -> None:
```

Its body reads `model.models_`, `model.configs_`, and `model.inference_config_` — attributes of the fitted estimator. `reg.model_` is a property that returns a single internal `Architecture` (a `torch.nn.Module`), which does not have those attributes, so the documented call would raise at runtime.

This matches how the function is actually invoked across the codebase (e.g. `tests/test_save_load_fitted_model.py`, `tests/test_model_loading.py`, `src/tabpfn/finetuning/train_util.py`), where the estimator is passed directly.

## Change

```diff
-``save_tabpfn_model(reg.model_, "my_tabpfn.ckpt")``
+``save_tabpfn_model(reg, "my_tabpfn.ckpt")``
```

## Verification

Reviewed the rest of the README against the codebase (public API names, `ModelVersion` values, `create_default_for_version`, environment variables, the offline download script, HuggingFace checkpoint filenames, supported Python versions, and example file paths) — all other claims are accurate. This was the only discrepancy found.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rx2Tv5rt5LRHzDzjFHkL41)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only correction with no runtime or API changes.
> 
> **Overview**
> Corrects the FAQ snippet for saving foundation weights only: **`save_tabpfn_model`** must receive the fitted **`TabPFNRegressor`** / **`TabPFNClassifier`**, not **`reg.model_`**. The old example would fail at runtime because the internal module lacks **`models_`**, **`configs_`**, and **`inference_config_`**.
> 
> Adds a short **changelog** entry for the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b3d553a164021906b275c95e3d5c3faa2b825e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->