### PR TITLE
Add link and citation for the v3 report

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,12 +134,22 @@ We're building the future of tabular machine learning and would love your involv
 
 ## Citation
 
-You can read our paper explaining TabPFNv2 [here](https://doi.org/10.1038/s41586-024-08328-6), and the model report of TabPFN-2.5 [here](https://arxiv.org/abs/2511.08667).
+You can read our paper explaining TabPFNv2 [here](https://doi.org/10.1038/s41586-024-08328-6), and model reports for [TabPFN-2.5](https://arxiv.org/abs/2511.08667) and [TabPFN-3](https://arxiv.org/abs/2605.13986).
 
 <details>
 <summary><b>BibTeX</b></summary>
 
 ```bibtex
+@misc{grinsztajn2026tabpfn3technicalreport,
+      title={TabPFN-3: Technical Report}, 
+      author={Léo Grinsztajn and Klemens Flöge and Oscar Key and Felix Birkel and Philipp Jund and Brendan Roof and Mihir Manium and Shi Bin Hoo and Magnus Bühler and Anurag Garg and Dominik Safaric and Jake Robertson and Benjamin Jäger and Simone Alessi and Adrian Hayler and Vladyslav Moroshan and Lennart Purucker and Philipp Singer and Alan Arazi and Julien Siems and Jan Hendrik Metzen and Georg Grab and Nick Erickson and Siyuan Guo and Eliott Kalfon and Simon Bing and David Salinas and Clara Cornu and Lilly Charlotte Wehrhahn and Diana Kriuchkova and Kursat Kaya and Lydia Sidhoum and Marie Salmon and Jerry Chen and Madelon Hulsebos and Yann LeCun and Samuel Müller and Bernhard Schölkopf and Sauraj Gambhir and Noah Hollmann and Frank Hutter},
+      year={2026},
+      eprint={2605.13986},
+      archivePrefix={arXiv},
+      primaryClass={cs.LG},
+      url={https://arxiv.org/abs/2605.13986}, 
+}
+
 @misc{grinsztajn2025tabpfn,
   title={TabPFN-2.5: Advancing the State of the Art in Tabular Foundation Models},
   author={Léo Grinsztajn and Klemens Flöge and Oscar Key and Felix Birkel and Philipp Jund and Brendan Roof and


### PR DESCRIPTION
## Issue
Please link the corresponding GitHub issue. If an issue does not already exist,
please open one to describe the bug or feature request before creating a pull request.

This allows us to discuss the proposal and helps avoid unnecessary work.

## Motivation and Context

---

## Public API Changes

-   [ ] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?

---

## Checklist

-   [ ] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [ ] A changelog entry has been added (see `changelog/README.md`), or "no changelog needed" label requested.
-   [ ] The code follows the project's style guidelines.
-   [ ] I have considered the impact of these changes on the public API.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only README edits with no runtime or API impact.
> 
> **Overview**
> Updates the **Citation** section so readers can find the TabPFN-3 technical report alongside the existing TabPFNv2 and TabPFN-2.5 references.
> 
> The prose link now points to [TabPFN-3 on arXiv](https://arxiv.org/abs/2605.13986), and a new **`@misc{grinsztajn2026tabpfn3technicalreport}`** BibTeX entry is added at the top of the collapsible block (before the TabPFN-2.5 entry). No code or API behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 105194678bb237a16ba8cd020ac106dbc063035a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->