### PR TITLE
fix(preprocessing): remove constant NaN columns

### DIFF
--- a/changelog/1061.fixed.md
+++ b/changelog/1061.fixed.md
@@ -1,0 +1,1 @@
+Remove all-NaN columns as constant features so they no longer leak NaNs into downstream preprocessing.

--- a/src/tabpfn/preprocessing/steps/remove_constant_features_step.py
+++ b/src/tabpfn/preprocessing/steps/remove_constant_features_step.py
@@ -33,9 +33,11 @@ class RemoveConstantFeaturesStep(PreprocessingStep):
         feature_schema: FeatureSchema,
     ) -> FeatureSchema:
         if isinstance(X, torch.Tensor):
-            sel_ = torch.max(X[0:1, :] != X, dim=0)[0].cpu()
+            sel_ = (torch.max(X[0:1, :] != X, dim=0)[0] & ~X.isnan().all(dim=0)).cpu()
         else:
-            sel_ = ((X[0:1, :] == X).mean(axis=0) < 1.0).tolist()
+            sel_ = np.logical_and(
+                (X[0:1, :] == X).mean(axis=0) < 1.0, ~np.all(np.isnan(X), axis=0)
+            ).tolist()
 
         if not any(sel_):
             raise TabPFNValidationError(

--- a/tests/test_preprocessing/test_remove_constant_features_step.py
+++ b/tests/test_preprocessing/test_remove_constant_features_step.py
@@ -53,6 +53,33 @@ def test__remove_constant_features_step__drops_constant_numpy() -> None:
     assert result.modality_added is None
 
 
+def test__remove_constant_features_step__drops_constant_nan_numpy() -> None:
+    """Remove constant columns for NumPy inputs."""
+    X = np.array(
+        [
+            [np.nan, 2.0, 3.0],
+            [np.nan, 5.0, 3.0],
+            [np.nan, 7.0, 4.0],
+        ]
+    )
+    schema = _numerical_metadata(num_features=3)
+
+    step = RemoveConstantFeaturesStep()
+    result = step.fit_transform(X, schema)
+
+    expected = np.array(
+        [
+            [2.0, 3.0],
+            [5.0, 3.0],
+            [7.0, 4.0],
+        ]
+    )
+    np.testing.assert_array_equal(result.X, expected)
+    assert result.feature_schema.indices_for(FeatureModality.NUMERICAL) == [0, 1]
+    assert result.X_added is None
+    assert result.modality_added is None
+
+
 def test__remove_constant_features_step__raises_when_all_constant() -> None:
     """Raise when all columns are constant."""
     X = np.ones((4, 2))
@@ -70,6 +97,34 @@ def test__remove_constant_features_step__drops_constant_torch() -> None:
             [2.0, 0.0, 5.0],
             [2.0, 1.0, 6.0],
             [2.0, 3.0, 6.0],
+        ]
+    )
+    schema = _numerical_metadata(num_features=3)
+
+    step = RemoveConstantFeaturesStep()
+    result = step.fit_transform(X, schema)  # type: ignore[arg-type]
+
+    expected = torch.tensor(
+        [
+            [0.0, 5.0],
+            [1.0, 6.0],
+            [3.0, 6.0],
+        ]
+    )
+    assert isinstance(result.X, torch.Tensor)
+    assert torch.equal(result.X, expected)
+    assert result.feature_schema.indices_for(FeatureModality.NUMERICAL) == [0, 1]
+    assert result.X_added is None
+    assert result.modality_added is None
+
+
+def test__remove_constant_features_step__drops_constant_nan_torch() -> None:
+    """Remove constant columns for torch inputs."""
+    X = torch.tensor(
+        [
+            [float("nan"), 0.0, 5.0],
+            [float("nan"), 1.0, 6.0],
+            [float("nan"), 3.0, 6.0],
         ]
     )
     schema = _numerical_metadata(num_features=3)


### PR DESCRIPTION
## Issue

Closes [PRI-241](https://linear.app/priorlabs/issue/PRI-241/all-nan-columns-not-removed-as-constant-columns-affecting-predictions) — all-NaN columns were not being removed as constant columns, affecting downstream preprocessing.

## Motivation and Context

`RemoveConstantFeaturesStep` decides which columns to keep using an equality comparison (`X[0:1, :] == X`). For an all-NaN column every comparison is `False` (`NaN != NaN`), so the column was treated as **non-constant** and kept, even though it carries no information. These columns then propagate NaNs into later preprocessing steps.

This adds an explicit guard so a column that is entirely NaN is also treated as constant and dropped:

* NumPy path: `~np.all(np.isnan(X), axis=0)` is AND-ed into the keep mask.
* Torch path: `& ~X.isnan().all(dim=0)`.

At this point in the pipeline `X` is always a numeric float array (categoricals/strings are ordinally encoded and cast to `float64` by `clean_data` upstream), so `np.isnan` / `Tensor.isnan` are safe.

---

## Public API Changes

- [X] No Public API changes
- [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?

- [X] Added [unit tests](<tests/test_preprocessing/test_remove_constant_features_step.py>) covering all-NaN column removal for both NumPy and torch inputs, and ran the step's full test suite locally.
- [X] Evaluated the actual performance trade-off

---

## Checklist

- [X] The changes have been tested locally.
- [X] Documentation has been updated (if the public API or usage changes). — N/A, no API change
- [X] A changelog entry has been added (see `changelog/README.md`), or "no changelog needed" label requested.
- [X] The code follows the project's style guidelines.
- [X] I have considered the impact of these changes on the public API.