### PR TITLE
[Automated PR (update-readme)]: Fix README rendering and document MPS memory env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ TabPFN uses Pydantic settings for configuration, supporting environment variable
 **Model Configuration:**
 - `TABPFN_MODEL_CACHE_DIR`: Custom directory for caching downloaded TabPFN models (default: platform-specific user cache directory)
 - `TABPFN_ALLOW_CPU_LARGE_DATASET`: Allow running TabPFN on CPU with large datasets (>1000 samples). Set to `true` to override the CPU limitation. Note: This will be very slow!
+- `TABPFN_MPS_MEMORY_FRACTION`: Fraction of recommended max MPS memory to allow on Apple Silicon (default: `0.7`). Used to prevent macOS system crashes; set before importing TabPFN. Values above `1.0` are not recommended.
 
 **PyTorch Settings:**
 - `PYTORCH_CUDA_ALLOC_CONF`: PyTorch CUDA memory allocation configuration to optimize GPU memory usage (default: `max_split_size_mb:512`). See [PyTorch CUDA documentation](https://docs.pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-cuda-alloc-conf) for more information.
@@ -298,9 +299,9 @@ Or simply set them in your `.env`
 <details>
 <summary><b>Q: How do I save and load a trained TabPFN model?</b></summary>
 
-Use :func:`save_fitted_tabpfn_model` to persist a fitted estimator and reload
-it later with :func:`load_fitted_tabpfn_model` (or the corresponding
-``load_from_fit_state`` class methods).
+Use `save_fitted_tabpfn_model` to persist a fitted estimator and reload
+it later with `load_fitted_tabpfn_model` (or the corresponding
+`load_from_fit_state` class methods).
 
 ```python
 from tabpfn import TabPFNRegressor

--- a/changelog/1065.fixed.md
+++ b/changelog/1065.fixed.md
@@ -1,0 +1,1 @@
+Fix the README save/load FAQ to render correctly on GitHub (replace Sphinx `:func:` roles with code spans) and document the `TABPFN_MPS_MEMORY_FRACTION` environment variable.


### PR DESCRIPTION
⚠️ This PR was based on the routine defined in update-readme.
As the automatically chosen reviewer, you are responsible for this PR.
Feel free to close or edit the PR, and either merge when ready or assign another reviewer if needed.
If the PR is not satisfactory, please edit the prompt in update-readme in the [misc/claude-routines directory](https://github.com/PriorLabs/misc/tree/main/claude-routines), or contact the routine owner Philipp Singer.

---

While checking the README against the codebase I found two discrepancies and fixed them. (Scope kept minimal — no new sections added.)

### 1. Sphinx `:func:` roles don't render on GitHub
The "How do I save and load a trained TabPFN model?" FAQ used reStructuredText cross-reference roles (`` :func:`save_fitted_tabpfn_model` ``), which render literally as `:func:` on GitHub-flavored Markdown. Replaced them with plain code spans.

### 2. `TABPFN_MPS_MEMORY_FRACTION` was undocumented
The "What environment variables can I use to configure TabPFN?" FAQ enumerates the configurable env vars but omitted `TABPFN_MPS_MEMORY_FRACTION`, which is a real user-facing setting in `src/tabpfn/settings.py` (its docstring explicitly instructs users to set it before importing TabPFN to prevent macOS crashes on Apple Silicon). Added it alongside the other model/memory settings.

Note: the nearby `save_tabpfn_model(reg, ...)` argument fix is handled separately in #1053, so it is intentionally not touched here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HezpyZgbdtr2bmoiYx7ZLT)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and changelog only; no runtime or API behavior changes.
> 
> **Overview**
> **README-only fixes** so the FAQ matches how GitHub renders Markdown and reflects real configuration in `settings.py`.
> 
> The **environment variables** FAQ now lists **`TABPFN_MPS_MEMORY_FRACTION`** (default `0.7`, set before import on Apple Silicon to cap MPS memory and reduce crash risk).
> 
> The **save/load** FAQ no longer uses Sphinx **`:func:`** cross-references (they showed up as literal text on GitHub); those API names are plain **code spans** instead.
> 
> A **changelog** entry records both fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0980942181dd4c6ce153cbe771484794b94a6d9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->