### PR TITLE
feat: enable fit with cache for v2.6

### DIFF
--- a/src/tabpfn/classifier.py
+++ b/src/tabpfn/classifier.py
@@ -819,9 +819,6 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
                 "batched",
             ] = "fit_preprocessors"
 
-        if self.fit_mode == "fit_with_cache" and "v2.6" in str(self.model_path):
-            raise ValueError("fit_with_cache is not supported for TabPFN v2.6 yet.")
-
         static_seed, _ = infer_random_state(self.random_state)
         byte_size = self._initialize_model_variables()
         ensemble_configs, X, y = self._initialize_dataset_preprocessing(

--- a/src/tabpfn/regressor.py
+++ b/src/tabpfn/regressor.py
@@ -834,9 +834,6 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
             )
             self.fit_mode = "fit_preprocessors"
 
-        if self.fit_mode == "fit_with_cache" and "v2.6" in str(self.model_path):
-            raise ValueError("fit_with_cache is not supported for TabPFN v2.6 yet.")
-
         static_seed, _ = infer_random_state(self.random_state)
         byte_size = self._initialize_model_variables()
         ensemble_configs, X, y, znorm_space_bardist = (

--- a/tests/test_classifier_interface.py
+++ b/tests/test_classifier_interface.py
@@ -530,7 +530,8 @@ def test_balance_probabilities_alters_proba_output() -> None:
 
 
 @pytest.mark.parametrize(
-    "model_version", [ModelVersion.V2, ModelVersion.V2_5, ModelVersion.V3]
+    "model_version",
+    [ModelVersion.V2, ModelVersion.V2_5, ModelVersion.V2_6, ModelVersion.V3],
 )
 # Disable MPS as it doesn't support float64.
 @pytest.mark.parametrize("device", [d for d in get_pytest_devices() if d != "mps"])

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -93,36 +93,6 @@ def test__to__between_fits__outputs_equal(
 
 
 @pytest.mark.parametrize("estimator_class", [TabPFNRegressor, TabPFNClassifier])
-def test__fit_with_cache__matches_fit_preprocessors_for_v2_6(
-    estimator_class: type[TabPFNClassifier] | type[TabPFNRegressor],
-) -> None:
-    """``fit_with_cache`` is an inference optimisation, not a different model.
-
-    For v2.6 (whose KV cache was added later than the rest of the architecture) the
-    cached engine must produce the same predictions as ``fit_preprocessors``.
-    """
-    base = estimator_class.create_default_for_version(
-        ModelVersion.V2_6, fit_mode="fit_preprocessors", n_estimators=2, random_state=0
-    )
-    cached = estimator_class.create_default_for_version(
-        ModelVersion.V2_6, fit_mode="fit_with_cache", n_estimators=2, random_state=0
-    )
-    X_train, X_test, y_train = _get_tiny_dataset(base)
-    base.fit(X_train, y_train)
-    cached.fit(X_train, y_train)
-
-    if isinstance(base, TabPFNClassifier):
-        out_base = base.predict_proba(X_test)
-        out_cached = cached.predict_proba(X_test)
-    else:
-        out_base = base.predict(X_test)
-        out_cached = cached.predict(X_test)
-
-    assert np.isfinite(out_cached).all()
-    np.testing.assert_allclose(out_base, out_cached, atol=1e-4)
-
-
-@pytest.mark.parametrize("estimator_class", [TabPFNRegressor, TabPFNClassifier])
 @pytest.mark.parametrize("fit_mode", ["fit_preprocessors", "low_memory"])
 def test__to__after_fit__no_tensors_left_on_old_device(
     estimator_class: type[TabPFNClassifier] | type[TabPFNRegressor],

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -93,18 +93,33 @@ def test__to__between_fits__outputs_equal(
 
 
 @pytest.mark.parametrize("estimator_class", [TabPFNRegressor, TabPFNClassifier])
-def test__fit_with_cache__raises_error_for_v2_6(
+def test__fit_with_cache__matches_fit_preprocessors_for_v2_6(
     estimator_class: type[TabPFNClassifier] | type[TabPFNRegressor],
 ) -> None:
-    estimator = estimator_class.create_default_for_version(
-        ModelVersion.V2_6, fit_mode="fit_with_cache", n_estimators=2
-    )
-    X_train, _, y_train = _get_tiny_dataset(estimator)
+    """``fit_with_cache`` is an inference optimisation, not a different model.
 
-    with pytest.raises(
-        ValueError, match="fit_with_cache is not supported for TabPFN v2"
-    ):
-        estimator.fit(X_train, y_train)
+    For v2.6 (whose KV cache was added later than the rest of the architecture) the
+    cached engine must produce the same predictions as ``fit_preprocessors``.
+    """
+    base = estimator_class.create_default_for_version(
+        ModelVersion.V2_6, fit_mode="fit_preprocessors", n_estimators=2, random_state=0
+    )
+    cached = estimator_class.create_default_for_version(
+        ModelVersion.V2_6, fit_mode="fit_with_cache", n_estimators=2, random_state=0
+    )
+    X_train, X_test, y_train = _get_tiny_dataset(base)
+    base.fit(X_train, y_train)
+    cached.fit(X_train, y_train)
+
+    if isinstance(base, TabPFNClassifier):
+        out_base = base.predict_proba(X_test)
+        out_cached = cached.predict_proba(X_test)
+    else:
+        out_base = base.predict(X_test)
+        out_cached = cached.predict(X_test)
+
+    assert np.isfinite(out_cached).all()
+    np.testing.assert_allclose(out_base, out_cached, atol=1e-4)
 
 
 @pytest.mark.parametrize("estimator_class", [TabPFNRegressor, TabPFNClassifier])

--- a/tests/test_preprocessing/test_inf_handling.py
+++ b/tests/test_preprocessing/test_inf_handling.py
@@ -616,10 +616,6 @@ def test__regressor_fit_predict__handles_infinities_per_passthrough_flag(
             model.fit(X, y)
 
 
-# All v2.x architectures (download weights on first use). v2.6 has no
-# fit_with_cache support yet -- it's only a guard (regressor.py / classifier.py:
-# "fit_with_cache is not supported for TabPFN v2.6 yet."). strict xfail makes the
-# day that guard is lifted fail loudly, prompting this marker's removal.
 _FIT_WITH_CACHE_VERSIONS = [
     ModelVersion.V2,
     ModelVersion.V2_5,

--- a/tests/test_preprocessing/test_inf_handling.py
+++ b/tests/test_preprocessing/test_inf_handling.py
@@ -623,12 +623,7 @@ def test__regressor_fit_predict__handles_infinities_per_passthrough_flag(
 _FIT_WITH_CACHE_VERSIONS = [
     ModelVersion.V2,
     ModelVersion.V2_5,
-    pytest.param(
-        ModelVersion.V2_6,
-        marks=pytest.mark.xfail(
-            raises=ValueError, strict=True, reason="fit_with_cache guard for v2.6"
-        ),
-    ),
+    ModelVersion.V2_6,
     ModelVersion.V3,
 ]
 

--- a/tests/test_regressor_interface.py
+++ b/tests/test_regressor_interface.py
@@ -286,7 +286,8 @@ def test__fit_predict__specify_inference_config__outputs_correct_shape(
 
 
 @pytest.mark.parametrize(
-    "model_version", [ModelVersion.V2, ModelVersion.V2_5, ModelVersion.V3]
+    "model_version",
+    [ModelVersion.V2, ModelVersion.V2_5, ModelVersion.V2_6, ModelVersion.V3],
 )
 # Disable MPS as it doesn't support float64.
 @pytest.mark.parametrize("device", [d for d in get_pytest_devices() if d != "mps"])


### PR DESCRIPTION
## Motivation and Context

Removes a guardrail kept by #1052 preventing from using KV Cache with TabPFN v2.6.

---

## Public API Changes

-   [x] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?

See 46de9302cbc4d842303fe7bf255aac31ffe6cedd.

---

## Checklist

-   [x] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [x] A changelog entry has been added (see `changelog/README.md`), or "no changelog needed" label requested.
-   [x] The code follows the project's style guidelines.
-   [x] I have considered the impact of these changes on the public API.

---
