### PR TITLE
CI: parallelise CPU test runs with pytest-xdist (~2.3x faster)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,13 +63,6 @@ jobs:
     env:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
       TABPFN_TOKEN: ${{ secrets.TABPFN_TOKEN }}
-      # The test runs use pytest-xdist (`-n auto`), so each worker gets one core.
-      # Pin BLAS/torch to a single thread per process; otherwise each worker spawns
-      # its own multi-threaded torch and they oversubscribe the cores, which is
-      # dramatically *slower* than serial.
-      OMP_NUM_THREADS: 1
-      MKL_NUM_THREADS: 1
-      OPENBLAS_NUM_THREADS: 1
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4.3.1
@@ -137,57 +130,51 @@ jobs:
         if: ${{ matrix.dependency-set != 'lowest-direct' && github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
         shell: bash
         run: |
-          set -e
-          if [ "$RUNNER_OS" != "macOS" ]; then
-            uv run --no-sync pytest tests/ -n auto --dist worksteal
-            exit 0
+          # macOS runs the MPS device tests; under pytest-xdist each worker opens
+          # its own MPS context and they exhaust the shared GPU memory. Keep macOS
+          # serial; parallelise on the CPU-only runners with one thread per worker
+          # (without the thread pinning the workers oversubscribe the cores and the
+          # run is slower than serial).
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            uv run --no-sync pytest tests/
+          else
+            OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 \
+              uv run --no-sync pytest tests/ -n auto --dist worksteal
           fi
-          # The CI macOS runner's MPS device is virtualised with a tiny memory budget
-          # and can't host concurrent contexts, so the MPS tests can't run under
-          # pytest-xdist. Run the CPU tests in parallel with MPS excluded (so
-          # device="auto" resolves to CPU), then run the MPS tests serially. The
-          # mlx-backend tests gate on torch.backends.mps.is_available() directly
-          # (ignoring TABPFN_EXCLUDE_DEVICES), so they go in the serial pass too.
-          # `|| [ $? -eq 5 ]` tolerates a pass that collected no tests.
-          mlx=tests/test_architectures/test_mlx_backend.py
-          TABPFN_EXCLUDE_DEVICES=mps \
-            uv run --no-sync pytest tests/ --ignore="$mlx" -n auto --dist worksteal
-          uv run --no-sync pytest tests/ -k mps --ignore="$mlx" || [ $? -eq 5 ]
-          uv run --no-sync pytest "$mlx" || [ $? -eq 5 ]
 
       - name: Run Tests (PR tests only)
         if: ${{ matrix.dependency-set != 'lowest-direct' && (github.event_name == 'pull_request' || github.event_name == 'merge_group') }}
         shell: bash
         run: |
-          set -e
-          if [ "$RUNNER_OS" != "macOS" ]; then
-            uv run --no-sync pytest -m "not slow" tests/ -n auto --dist worksteal
-            exit 0
+          # See "Run Tests (all tests)": macOS stays serial (MPS), CPU runners parallelise.
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            uv run --no-sync pytest -m "not slow" tests/
+          else
+            OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 \
+              uv run --no-sync pytest -m "not slow" tests/ -n auto --dist worksteal
           fi
-          # See "Run Tests (all tests)": on macOS the MPS device can't be shared by
-          # xdist workers, so run CPU tests in parallel (MPS excluded) then MPS
-          # tests serially. `|| [ $? -eq 5 ]` tolerates a pass with no tests.
-          mlx=tests/test_architectures/test_mlx_backend.py
-          TABPFN_EXCLUDE_DEVICES=mps \
-            uv run --no-sync pytest -m "not slow" tests/ --ignore="$mlx" -n auto --dist worksteal
-          uv run --no-sync pytest -m "not slow" tests/ -k mps --ignore="$mlx" || [ $? -eq 5 ]
-          uv run --no-sync pytest -m "not slow" "$mlx" || [ $? -eq 5 ]
 
       # We don't support MPS below PyTorch 2.5 (see tabpfn.utils.infer_devices()), thus
       # disable MPS for the lowest-direct dependency set.
 
       # The lowest-direct matrix entries are CPU-only (Linux/Windows, MPS excluded),
-      # so we always parallelise (thread pinning is set at the job level).
+      # so we always parallelise. One thread per worker avoids core oversubscription.
       - name: Run Tests (all tests, MPS disabled)
         if: ${{ matrix.dependency-set == 'lowest-direct' && github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
         env:
           TABPFN_EXCLUDE_DEVICES: mps
+          OMP_NUM_THREADS: 1
+          MKL_NUM_THREADS: 1
+          OPENBLAS_NUM_THREADS: 1
         run: uv run --no-sync pytest tests/ -n auto --dist worksteal
 
       - name: Run Tests (PR tests only, MPS disabled)
         if: ${{ matrix.dependency-set == 'lowest-direct' && (github.event_name == 'pull_request' || github.event_name == 'merge_group') }}
         env:
           TABPFN_EXCLUDE_DEVICES: mps
+          OMP_NUM_THREADS: 1
+          MKL_NUM_THREADS: 1
+          OPENBLAS_NUM_THREADS: 1
         run: uv run --no-sync pytest -m "not slow" tests/ -n auto --dist worksteal
 
         # Save even if tests failed: partial downloads avoid future runs hitting the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,19 @@ jobs:
     env:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
       TABPFN_TOKEN: ${{ secrets.TABPFN_TOKEN }}
+      # The test steps run under pytest-xdist (`-n auto`), so each worker gets one
+      # core. Pin BLAS/torch to a single thread per process; otherwise each worker
+      # spawns its own multi-threaded torch and they oversubscribe the cores, which
+      # is dramatically *slower* than serial.
+      OMP_NUM_THREADS: 1
+      MKL_NUM_THREADS: 1
+      OPENBLAS_NUM_THREADS: 1
+      # On the macOS runner the MPS device tests run in parallel too. The CI GPU is
+      # virtualised with a tiny memory budget, so several worker processes each
+      # opening an MPS context blow past the default high-watermark and OOM.
+      # Disabling the watermark (as PyTorch's own OOM message suggests) lets the
+      # tiny test models allocate freely; harmless on Linux/Windows (no MPS).
+      PYTORCH_MPS_HIGH_WATERMARK_RATIO: 0.0
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4.3.1
@@ -128,53 +141,25 @@ jobs:
 
       - name: Run Tests (all tests)
         if: ${{ matrix.dependency-set != 'lowest-direct' && github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
-        shell: bash
-        run: |
-          # macOS runs the MPS device tests; under pytest-xdist each worker opens
-          # its own MPS context and they exhaust the shared GPU memory. Keep macOS
-          # serial; parallelise on the CPU-only runners with one thread per worker
-          # (without the thread pinning the workers oversubscribe the cores and the
-          # run is slower than serial).
-          if [ "$RUNNER_OS" = "macOS" ]; then
-            uv run --no-sync pytest tests/
-          else
-            OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 \
-              uv run --no-sync pytest tests/ -n auto --dist worksteal
-          fi
+        run: uv run --no-sync pytest tests/ -n auto --dist worksteal
 
       - name: Run Tests (PR tests only)
         if: ${{ matrix.dependency-set != 'lowest-direct' && (github.event_name == 'pull_request' || github.event_name == 'merge_group') }}
-        shell: bash
-        run: |
-          # See "Run Tests (all tests)": macOS stays serial (MPS), CPU runners parallelise.
-          if [ "$RUNNER_OS" = "macOS" ]; then
-            uv run --no-sync pytest -m "not slow" tests/
-          else
-            OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 \
-              uv run --no-sync pytest -m "not slow" tests/ -n auto --dist worksteal
-          fi
+        run: uv run --no-sync pytest -m "not slow" tests/ -n auto --dist worksteal
 
       # We don't support MPS below PyTorch 2.5 (see tabpfn.utils.infer_devices()), thus
       # disable MPS for the lowest-direct dependency set.
 
-      # The lowest-direct matrix entries are CPU-only (Linux/Windows, MPS excluded),
-      # so we always parallelise. One thread per worker avoids core oversubscription.
       - name: Run Tests (all tests, MPS disabled)
         if: ${{ matrix.dependency-set == 'lowest-direct' && github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
         env:
           TABPFN_EXCLUDE_DEVICES: mps
-          OMP_NUM_THREADS: 1
-          MKL_NUM_THREADS: 1
-          OPENBLAS_NUM_THREADS: 1
         run: uv run --no-sync pytest tests/ -n auto --dist worksteal
 
       - name: Run Tests (PR tests only, MPS disabled)
         if: ${{ matrix.dependency-set == 'lowest-direct' && (github.event_name == 'pull_request' || github.event_name == 'merge_group') }}
         env:
           TABPFN_EXCLUDE_DEVICES: mps
-          OMP_NUM_THREADS: 1
-          MKL_NUM_THREADS: 1
-          OPENBLAS_NUM_THREADS: 1
         run: uv run --no-sync pytest -m "not slow" tests/ -n auto --dist worksteal
 
         # Save even if tests failed: partial downloads avoid future runs hitting the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,13 @@ jobs:
     env:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
       TABPFN_TOKEN: ${{ secrets.TABPFN_TOKEN }}
+      # The test runs use pytest-xdist (`-n auto`), so each worker gets one core.
+      # Pin BLAS/torch to a single thread per process; otherwise each worker spawns
+      # its own multi-threaded torch and they oversubscribe the cores, which is
+      # dramatically *slower* than serial.
+      OMP_NUM_THREADS: 1
+      MKL_NUM_THREADS: 1
+      OPENBLAS_NUM_THREADS: 1
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4.3.1
@@ -130,51 +137,57 @@ jobs:
         if: ${{ matrix.dependency-set != 'lowest-direct' && github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
         shell: bash
         run: |
-          # macOS runs the MPS device tests; under pytest-xdist each worker opens
-          # its own MPS context and they exhaust the shared GPU memory. Keep macOS
-          # serial; parallelise on the CPU-only runners with one thread per worker
-          # (without the thread pinning the workers oversubscribe the cores and the
-          # run is slower than serial).
-          if [ "$RUNNER_OS" = "macOS" ]; then
-            uv run --no-sync pytest tests/
-          else
-            OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 \
-              uv run --no-sync pytest tests/ -n auto --dist worksteal
+          set -e
+          if [ "$RUNNER_OS" != "macOS" ]; then
+            uv run --no-sync pytest tests/ -n auto --dist worksteal
+            exit 0
           fi
+          # The CI macOS runner's MPS device is virtualised with a tiny memory budget
+          # and can't host concurrent contexts, so the MPS tests can't run under
+          # pytest-xdist. Run the CPU tests in parallel with MPS excluded (so
+          # device="auto" resolves to CPU), then run the MPS tests serially. The
+          # mlx-backend tests gate on torch.backends.mps.is_available() directly
+          # (ignoring TABPFN_EXCLUDE_DEVICES), so they go in the serial pass too.
+          # `|| [ $? -eq 5 ]` tolerates a pass that collected no tests.
+          mlx=tests/test_architectures/test_mlx_backend.py
+          TABPFN_EXCLUDE_DEVICES=mps \
+            uv run --no-sync pytest tests/ --ignore="$mlx" -n auto --dist worksteal
+          uv run --no-sync pytest tests/ -k mps --ignore="$mlx" || [ $? -eq 5 ]
+          uv run --no-sync pytest "$mlx" || [ $? -eq 5 ]
 
       - name: Run Tests (PR tests only)
         if: ${{ matrix.dependency-set != 'lowest-direct' && (github.event_name == 'pull_request' || github.event_name == 'merge_group') }}
         shell: bash
         run: |
-          # See "Run Tests (all tests)": macOS stays serial (MPS), CPU runners parallelise.
-          if [ "$RUNNER_OS" = "macOS" ]; then
-            uv run --no-sync pytest -m "not slow" tests/
-          else
-            OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 \
-              uv run --no-sync pytest -m "not slow" tests/ -n auto --dist worksteal
+          set -e
+          if [ "$RUNNER_OS" != "macOS" ]; then
+            uv run --no-sync pytest -m "not slow" tests/ -n auto --dist worksteal
+            exit 0
           fi
+          # See "Run Tests (all tests)": on macOS the MPS device can't be shared by
+          # xdist workers, so run CPU tests in parallel (MPS excluded) then MPS
+          # tests serially. `|| [ $? -eq 5 ]` tolerates a pass with no tests.
+          mlx=tests/test_architectures/test_mlx_backend.py
+          TABPFN_EXCLUDE_DEVICES=mps \
+            uv run --no-sync pytest -m "not slow" tests/ --ignore="$mlx" -n auto --dist worksteal
+          uv run --no-sync pytest -m "not slow" tests/ -k mps --ignore="$mlx" || [ $? -eq 5 ]
+          uv run --no-sync pytest -m "not slow" "$mlx" || [ $? -eq 5 ]
 
       # We don't support MPS below PyTorch 2.5 (see tabpfn.utils.infer_devices()), thus
       # disable MPS for the lowest-direct dependency set.
 
       # The lowest-direct matrix entries are CPU-only (Linux/Windows, MPS excluded),
-      # so we always parallelise. One thread per worker avoids core oversubscription.
+      # so we always parallelise (thread pinning is set at the job level).
       - name: Run Tests (all tests, MPS disabled)
         if: ${{ matrix.dependency-set == 'lowest-direct' && github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
         env:
           TABPFN_EXCLUDE_DEVICES: mps
-          OMP_NUM_THREADS: 1
-          MKL_NUM_THREADS: 1
-          OPENBLAS_NUM_THREADS: 1
         run: uv run --no-sync pytest tests/ -n auto --dist worksteal
 
       - name: Run Tests (PR tests only, MPS disabled)
         if: ${{ matrix.dependency-set == 'lowest-direct' && (github.event_name == 'pull_request' || github.event_name == 'merge_group') }}
         env:
           TABPFN_EXCLUDE_DEVICES: mps
-          OMP_NUM_THREADS: 1
-          MKL_NUM_THREADS: 1
-          OPENBLAS_NUM_THREADS: 1
         run: uv run --no-sync pytest -m "not slow" tests/ -n auto --dist worksteal
 
         # Save even if tests failed: partial downloads avoid future runs hitting the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,13 +63,6 @@ jobs:
     env:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
       TABPFN_TOKEN: ${{ secrets.TABPFN_TOKEN }}
-      # The test steps run under pytest-xdist (`-n auto`), so each worker gets one
-      # core. Pin BLAS/torch to a single thread per process; otherwise each worker
-      # spawns its own multi-threaded torch and the workers oversubscribe the
-      # cores, which is dramatically *slower* than running serially.
-      OMP_NUM_THREADS: 1
-      MKL_NUM_THREADS: 1
-      OPENBLAS_NUM_THREADS: 1
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4.3.1
@@ -135,25 +128,53 @@ jobs:
 
       - name: Run Tests (all tests)
         if: ${{ matrix.dependency-set != 'lowest-direct' && github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
-        run: uv run --no-sync pytest tests/ -n auto --dist worksteal
+        shell: bash
+        run: |
+          # macOS runs the MPS device tests; under pytest-xdist each worker opens
+          # its own MPS context and they exhaust the shared GPU memory. Keep macOS
+          # serial; parallelise on the CPU-only runners with one thread per worker
+          # (without the thread pinning the workers oversubscribe the cores and the
+          # run is slower than serial).
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            uv run --no-sync pytest tests/
+          else
+            OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 \
+              uv run --no-sync pytest tests/ -n auto --dist worksteal
+          fi
 
       - name: Run Tests (PR tests only)
         if: ${{ matrix.dependency-set != 'lowest-direct' && (github.event_name == 'pull_request' || github.event_name == 'merge_group') }}
-        run: uv run --no-sync pytest -m "not slow" tests/ -n auto --dist worksteal
+        shell: bash
+        run: |
+          # See "Run Tests (all tests)": macOS stays serial (MPS), CPU runners parallelise.
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            uv run --no-sync pytest -m "not slow" tests/
+          else
+            OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 \
+              uv run --no-sync pytest -m "not slow" tests/ -n auto --dist worksteal
+          fi
 
       # We don't support MPS below PyTorch 2.5 (see tabpfn.utils.infer_devices()), thus
       # disable MPS for the lowest-direct dependency set.
 
+      # The lowest-direct matrix entries are CPU-only (Linux/Windows, MPS excluded),
+      # so we always parallelise. One thread per worker avoids core oversubscription.
       - name: Run Tests (all tests, MPS disabled)
         if: ${{ matrix.dependency-set == 'lowest-direct' && github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
         env:
           TABPFN_EXCLUDE_DEVICES: mps
+          OMP_NUM_THREADS: 1
+          MKL_NUM_THREADS: 1
+          OPENBLAS_NUM_THREADS: 1
         run: uv run --no-sync pytest tests/ -n auto --dist worksteal
 
       - name: Run Tests (PR tests only, MPS disabled)
         if: ${{ matrix.dependency-set == 'lowest-direct' && (github.event_name == 'pull_request' || github.event_name == 'merge_group') }}
         env:
           TABPFN_EXCLUDE_DEVICES: mps
+          OMP_NUM_THREADS: 1
+          MKL_NUM_THREADS: 1
+          OPENBLAS_NUM_THREADS: 1
         run: uv run --no-sync pytest -m "not slow" tests/ -n auto --dist worksteal
 
         # Save even if tests failed: partial downloads avoid future runs hitting the
@@ -178,8 +199,9 @@ jobs:
     env:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
       TABPFN_TOKEN: ${{ secrets.TABPFN_TOKEN }}
-      # See test_compatibility: pin threads so the xdist workers (`-n auto`) don't
-      # oversubscribe the cores.
+      # This job is Linux/CPU-only, so the test step always runs under pytest-xdist
+      # (`-n auto`). Pin threads to one per worker so they don't oversubscribe the
+      # cores (which is slower than serial).
       OMP_NUM_THREADS: 1
       MKL_NUM_THREADS: 1
       OPENBLAS_NUM_THREADS: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,13 @@ jobs:
     env:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
       TABPFN_TOKEN: ${{ secrets.TABPFN_TOKEN }}
+      # The test steps run under pytest-xdist (`-n auto`), so each worker gets one
+      # core. Pin BLAS/torch to a single thread per process; otherwise each worker
+      # spawns its own multi-threaded torch and the workers oversubscribe the
+      # cores, which is dramatically *slower* than running serially.
+      OMP_NUM_THREADS: 1
+      MKL_NUM_THREADS: 1
+      OPENBLAS_NUM_THREADS: 1
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4.3.1
@@ -128,11 +135,11 @@ jobs:
 
       - name: Run Tests (all tests)
         if: ${{ matrix.dependency-set != 'lowest-direct' && github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
-        run: uv run --no-sync pytest tests/
+        run: uv run --no-sync pytest tests/ -n auto --dist worksteal
 
       - name: Run Tests (PR tests only)
         if: ${{ matrix.dependency-set != 'lowest-direct' && (github.event_name == 'pull_request' || github.event_name == 'merge_group') }}
-        run: uv run --no-sync pytest -m "not slow" tests/
+        run: uv run --no-sync pytest -m "not slow" tests/ -n auto --dist worksteal
 
       # We don't support MPS below PyTorch 2.5 (see tabpfn.utils.infer_devices()), thus
       # disable MPS for the lowest-direct dependency set.
@@ -141,13 +148,13 @@ jobs:
         if: ${{ matrix.dependency-set == 'lowest-direct' && github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
         env:
           TABPFN_EXCLUDE_DEVICES: mps
-        run: uv run --no-sync pytest tests/
+        run: uv run --no-sync pytest tests/ -n auto --dist worksteal
 
       - name: Run Tests (PR tests only, MPS disabled)
         if: ${{ matrix.dependency-set == 'lowest-direct' && (github.event_name == 'pull_request' || github.event_name == 'merge_group') }}
         env:
           TABPFN_EXCLUDE_DEVICES: mps
-        run: uv run --no-sync pytest -m "not slow" tests/
+        run: uv run --no-sync pytest -m "not slow" tests/ -n auto --dist worksteal
 
         # Save even if tests failed: partial downloads avoid future runs hitting the
         # rate limits.
@@ -171,6 +178,11 @@ jobs:
     env:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
       TABPFN_TOKEN: ${{ secrets.TABPFN_TOKEN }}
+      # See test_compatibility: pin threads so the xdist workers (`-n auto`) don't
+      # oversubscribe the cores.
+      OMP_NUM_THREADS: 1
+      MKL_NUM_THREADS: 1
+      OPENBLAS_NUM_THREADS: 1
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4.3.1
@@ -204,7 +216,7 @@ jobs:
       - *save-model-cache
 
       - name: Run Tests
-        run: uv run --no-sync pytest tests/
+        run: uv run --no-sync pytest tests/ -n auto --dist worksteal
 
       - *save-hf-cache
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,19 +63,6 @@ jobs:
     env:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
       TABPFN_TOKEN: ${{ secrets.TABPFN_TOKEN }}
-      # The test steps run under pytest-xdist (`-n auto`), so each worker gets one
-      # core. Pin BLAS/torch to a single thread per process; otherwise each worker
-      # spawns its own multi-threaded torch and they oversubscribe the cores, which
-      # is dramatically *slower* than serial.
-      OMP_NUM_THREADS: 1
-      MKL_NUM_THREADS: 1
-      OPENBLAS_NUM_THREADS: 1
-      # On the macOS runner the MPS device tests run in parallel too. The CI GPU is
-      # virtualised with a tiny memory budget, so several worker processes each
-      # opening an MPS context blow past the default high-watermark and OOM.
-      # Disabling the watermark (as PyTorch's own OOM message suggests) lets the
-      # tiny test models allocate freely; harmless on Linux/Windows (no MPS).
-      PYTORCH_MPS_HIGH_WATERMARK_RATIO: 0.0
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4.3.1
@@ -141,25 +128,53 @@ jobs:
 
       - name: Run Tests (all tests)
         if: ${{ matrix.dependency-set != 'lowest-direct' && github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
-        run: uv run --no-sync pytest tests/ -n auto --dist worksteal
+        shell: bash
+        run: |
+          # macOS runs the MPS device tests; under pytest-xdist each worker opens
+          # its own MPS context and they exhaust the shared GPU memory. Keep macOS
+          # serial; parallelise on the CPU-only runners with one thread per worker
+          # (without the thread pinning the workers oversubscribe the cores and the
+          # run is slower than serial).
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            uv run --no-sync pytest tests/
+          else
+            OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 \
+              uv run --no-sync pytest tests/ -n auto --dist worksteal
+          fi
 
       - name: Run Tests (PR tests only)
         if: ${{ matrix.dependency-set != 'lowest-direct' && (github.event_name == 'pull_request' || github.event_name == 'merge_group') }}
-        run: uv run --no-sync pytest -m "not slow" tests/ -n auto --dist worksteal
+        shell: bash
+        run: |
+          # See "Run Tests (all tests)": macOS stays serial (MPS), CPU runners parallelise.
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            uv run --no-sync pytest -m "not slow" tests/
+          else
+            OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 \
+              uv run --no-sync pytest -m "not slow" tests/ -n auto --dist worksteal
+          fi
 
       # We don't support MPS below PyTorch 2.5 (see tabpfn.utils.infer_devices()), thus
       # disable MPS for the lowest-direct dependency set.
 
+      # The lowest-direct matrix entries are CPU-only (Linux/Windows, MPS excluded),
+      # so we always parallelise. One thread per worker avoids core oversubscription.
       - name: Run Tests (all tests, MPS disabled)
         if: ${{ matrix.dependency-set == 'lowest-direct' && github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
         env:
           TABPFN_EXCLUDE_DEVICES: mps
+          OMP_NUM_THREADS: 1
+          MKL_NUM_THREADS: 1
+          OPENBLAS_NUM_THREADS: 1
         run: uv run --no-sync pytest tests/ -n auto --dist worksteal
 
       - name: Run Tests (PR tests only, MPS disabled)
         if: ${{ matrix.dependency-set == 'lowest-direct' && (github.event_name == 'pull_request' || github.event_name == 'merge_group') }}
         env:
           TABPFN_EXCLUDE_DEVICES: mps
+          OMP_NUM_THREADS: 1
+          MKL_NUM_THREADS: 1
+          OPENBLAS_NUM_THREADS: 1
         run: uv run --no-sync pytest -m "not slow" tests/ -n auto --dist worksteal
 
         # Save even if tests failed: partial downloads avoid future runs hitting the

--- a/changelog/1072.changed.md
+++ b/changelog/1072.changed.md
@@ -1,0 +1,1 @@
+Run the CPU test suites in CI in parallel with pytest-xdist, speeding up the test jobs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,8 +62,6 @@ dev = [
   # This version must be the same as in [tool.ruff] below and in .pre-commit-config.yaml
   "ruff==0.15.12",
   "mypy==2.1.0", # This version must be the same as in .pre-commit-config.yaml
-  # Test
-  "pytest-xdist>=3.8.0",
   # Changelog
   "towncrier>=24.8.0",
   # Docs
@@ -87,6 +85,7 @@ ci = [
   "onnx>=1.19.0",  # We run onnx export in the tests, but not in the production package.
   "pytest-mock>=3.14.1",
   "pytest>=8.4.2",
+  "pytest-xdist>=3.8.0",  # Parallelises the test run in CI (`pytest -n auto`).
 ]
 
 [tool.uv]


### PR DESCRIPTION
## What

Run the CPU test jobs under `pytest-xdist` instead of serially.

- Add `-n auto --dist worksteal` to the pytest steps in `test_compatibility` and `test_ubuntu_latest_314`.
- Pin `OMP_NUM_THREADS=MKL_NUM_THREADS=OPENBLAS_NUM_THREADS=1` in those two jobs.
- Move `pytest-xdist` from the `dev` group into the `ci` group (CI installs `--group ci`).

The GPU job (`test_gpu`) and the first-party-packages job are intentionally left as-is.

## Why

The suite is ~1100+ independent tests and currently runs serially. It parallelises cleanly.

Measured on a 4-core node matched to the CI runner (threads pinned, model cache on local disk), on the `-m "not slow"` suite, same node back-to-back:

| Config | time | speedup |
|---|---|---|
| serial | 408s | 1.0x |
| `-n2 --dist worksteal` (OMP=2) | 198s | 2.1x |
| **`-n auto`=`-n4 --dist worksteal` (OMP=1)** | **180s** | **2.3x** |

All **1178 tests pass** in every configuration (0 failures under xdist).

## Why thread pinning is mandatory

Without `*_NUM_THREADS=1`, each xdist worker spawns its own multi-threaded torch; on a 4-core runner the 4 workers then fight over the cores and the run is *slower* than serial. One thread per worker + one worker per core is the fast configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI workflow and dev/ci dependency grouping; application runtime and GPU jobs are untouched.
> 
> **Overview**
> Speeds up CPU CI by running pytest under **pytest-xdist** (`-n auto --dist worksteal`) instead of a single serial process.
> 
> In `test_compatibility`, Linux/Windows (and lowest-direct MPS-disabled matrix legs) use xdist with `OMP_NUM_THREADS`, `MKL_NUM_THREADS`, and `OPENBLAS_NUM_THREADS` set to **1** so each worker does not oversubscribe cores. **macOS stays serial** because parallel MPS workers exhaust shared GPU memory. The `test_ubuntu_latest_314` job always parallelises with the same thread env at job level. **GPU** and **first-party** test jobs are unchanged.
> 
> `pytest-xdist` moves from the `dev` dependency group into **`ci`** so `uv sync --group ci` installs it. A towncrier **changed** note documents faster parallel CPU test suites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6467f9c3d112e69f4faacb867c531ba7aead4ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->