### PR TITLE
Pin macos-15 runner, as tests fail on macos-26.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,16 +44,17 @@ jobs:
           - os: ubuntu-latest
             python-version: "3.10"
             dependency-set: lowest-direct
-          # Note that new pytorch versions >= 2.5 don't support x86 on mac anymore,
-          # and macos-latest (ARM) is python >= 3.11 only, so we disable this runner.
-          # https://github.com/actions/setup-python/issues/855
-          # - os: macos-15-intel # We need x86 as ARM is python>= 3.11 only.
-          #  python-version: "3.10"
-          #  dependency-set: lowest-direct
+          # The MacOS tests are failing on macos-26, so pin to 15 for now. See
+          # https://linear.app/priorlabs/issue/PRI-331/ci-failing-when-runner-is-macos-26
+          - os: macos-15
+            python-version: "3.10"
+            dependency-set: lowest-direct
           - os: windows-latest
             python-version: "3.10"
             dependency-set: lowest-direct
-          - os: macos-latest
+          # The MacOS tests are failing on macos-26, so pin to 15 for now. See
+          # https://linear.app/priorlabs/issue/PRI-331/ci-failing-when-runner-is-macos-26
+          - os: macos-15
             python-version: "3.14"
             dependency-set: highest
           - os: windows-latest
@@ -71,7 +72,6 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
-          architecture: x64
 
       - name: Install uv
         uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
@@ -179,7 +179,6 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.14"
-          architecture: x64
 
       - name: Install uv
         uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
@@ -333,7 +332,6 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
-          architecture: x64
 
       - name: Install uv
         uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,12 @@ jobs:
           - os: ubuntu-latest
             python-version: "3.10"
             dependency-set: lowest-direct
-          # The MacOS tests are failing on macos-26, so pin to 15 for now. See
-          # https://linear.app/priorlabs/issue/PRI-331/ci-failing-when-runner-is-macos-26
-          - os: macos-15
-            python-version: "3.10"
-            dependency-set: lowest-direct
+          # Note that new pytorch versions >= 2.5 don't support x86 on mac anymore,
+          # and macos-latest (ARM) is python >= 3.11 only, so we disable this runner.
+          # https://github.com/actions/setup-python/issues/855
+          # - os: macos-15-intel # We need x86 as ARM is python>= 3.11 only.
+          #  python-version: "3.10"
+          #  dependency-set: lowest-direct
           - os: windows-latest
             python-version: "3.10"
             dependency-set: lowest-direct


### PR DESCRIPTION
GitHub is gradually switching macos-latest to macos-26, which makes the tests flake. Just pin to macos-15 for now, while we investigate.

Also: Don't request x64 Python, as we want to test on arm without Rosetta (this is what most people will have). It also doesn't seem to be having any affect in recent runs anyway, e.g. see "Install uv" here: https://github.com/PriorLabs/TabPFN/actions/runs/28105021796/job/83216827365

Part of PRI-331