### PR TITLE
Fix incorrect model output due to MPS nn.Linear bug.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,9 +53,7 @@ jobs:
           - os: windows-latest
             python-version: "3.10"
             dependency-set: lowest-direct
-          # The MacOS tests are failing on macos-26, so pin to 15 for now. See
-          # https://linear.app/priorlabs/issue/PRI-331/ci-failing-when-runner-is-macos-26
-          - os: macos-15
+          - os: macos-latest
             python-version: "3.14"
             dependency-set: highest
           - os: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,9 @@ jobs:
           - os: windows-latest
             python-version: "3.10"
             dependency-set: lowest-direct
-          - os: macos-latest
+          # TEMPORARY: forced to macos-26 to test the MPS Linear workaround on the
+          # affected runner. Revert to macos-latest before merging.
+          - os: macos-26
             python-version: "3.14"
             dependency-set: highest
           - os: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,9 +53,7 @@ jobs:
           - os: windows-latest
             python-version: "3.10"
             dependency-set: lowest-direct
-          # TEMPORARY: forced to macos-26 to test the MPS Linear workaround on the
-          # affected runner. Revert to macos-latest before merging.
-          - os: macos-26
+          - os: macos-latest
             python-version: "3.14"
             dependency-set: highest
           - os: windows-latest

--- a/changelog/1077.fixed.md
+++ b/changelog/1077.fixed.md
@@ -1,0 +1,1 @@
+Fix incorrect model output on MacOS 26 on M1 when using the MPS device.

--- a/src/tabpfn/architectures/shared/workaround_mps_linear_bug.py
+++ b/src/tabpfn/architectures/shared/workaround_mps_linear_bug.py
@@ -30,14 +30,14 @@ def _mps_linear_bias_is_buggy() -> bool:
     if not torch.backends.mps.is_available():
         return False
     with torch.no_grad():
-        torch.manual_seed(0)
-        cpu = nn.Linear(2, 192, bias=True)
-        mps = nn.Linear(2, 192, bias=True).to("mps")
-        mps.load_state_dict(cpu.state_dict())
-        x = torch.randn(80, 1, 2)
-        rel = (
-            (cpu(x) - mps(x.to("mps")).cpu()).abs().max() / cpu(x).abs().max()
-        ).item()
+        # Use a local generator so we don't disturb the global RNG state.
+        gen = torch.Generator().manual_seed(0)
+        weight = torch.randn(192, 2, generator=gen)
+        bias = torch.randn(192, generator=gen)
+        x = torch.randn(80, 1, 2, generator=gen)
+        cpu = F.linear(x, weight, bias)
+        mps = F.linear(x.to("mps"), weight.to("mps"), bias.to("mps")).cpu()
+        rel = ((cpu - mps).abs().max() / cpu.abs().max()).item()
     return rel > 1e-3
 
 

--- a/src/tabpfn/architectures/shared/workaround_mps_linear_bug.py
+++ b/src/tabpfn/architectures/shared/workaround_mps_linear_bug.py
@@ -1,0 +1,71 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+"""Workaround for a silent-correctness bug in PyTorch's MPS Linear layer.
+
+
+On macOS 26 + Apple M1, nn.Linear with bias=True returns silently wrong results when the
+input is more than 2D with a unary (size-1) dimension. The workaround for this,
+mirroring what PyTorch did upstream, is to decompose the nn.Linear(bias=True) into
+F.linear() without bias followed by adding on the bias.
+
+See https://github.com/pytorch/pytorch/issues/188438.
+
+This workaround can be removed once
+https://github.com/pytorch/pytorch/commit/6394b2e9723f87bc6a85d12e52a725abd5240471
+is included in the minimum PyTorch version (torch>=2.13 should have it), or M1 is no
+longer supported.
+"""
+
+from __future__ import annotations
+
+import functools
+
+import torch
+from torch import nn
+from torch.nn import functional as F  # noqa: N812
+
+
+@functools.cache
+def _mps_linear_bias_is_buggy() -> bool:
+    """Return True if this machine suffers from the nn.Linear MPS bug."""
+    if not torch.backends.mps.is_available():
+        return False
+    with torch.no_grad():
+        torch.manual_seed(0)
+        cpu = nn.Linear(2, 192, bias=True)
+        mps = nn.Linear(2, 192, bias=True).to("mps")
+        mps.load_state_dict(cpu.state_dict())
+        x = torch.randn(80, 1, 2)
+        rel = (
+            (cpu(x) - mps(x.to("mps")).cpu()).abs().max() / cpu(x).abs().max()
+        ).item()
+    return rel > 1e-3
+
+
+class MpsSafeLinear(nn.Linear):
+    """A Linear layer that decomposes the bias add on MPS, else identical.
+
+    Only changes forward(), so it can load the nn.Linear() state dict.
+    """
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Apply the linear layer, decomposing the bias add on MPS."""
+        if input.is_mps and self.bias is not None:
+            return F.linear(input, self.weight, None) + self.bias
+        return super().forward(input)
+
+
+def maybe_replace_linears_on_mps(model: nn.Module) -> nn.Module:
+    """Retype bias-enabled Linear layers in-place if MPS is buggy on this machine.
+
+    No-op unless the MPS self-test finds the bug. Only vanilla bias-enabled
+    nn.Linear modules are affected; bias=False layers are left untouched (they are
+    not affected by the bug). Mutates and returns model.
+    """
+    if not _mps_linear_bias_is_buggy():
+        return model
+    for module in model.modules():
+        if type(module) is nn.Linear and module.bias is not None:
+            # Same memory layout and parameters, so re-typing in place is safe and
+            # preserves weights, buffers, hooks, and state_dict compatibility.
+            module.__class__ = MpsSafeLinear
+    return model

--- a/src/tabpfn/architectures/shared/workaround_mps_linear_bug.py
+++ b/src/tabpfn/architectures/shared/workaround_mps_linear_bug.py
@@ -18,10 +18,14 @@ longer supported.
 from __future__ import annotations
 
 import functools
+import logging
+from collections.abc import Sequence
 
 import torch
 from torch import nn
 from torch.nn import functional as F  # noqa: N812
+
+logger = logging.getLogger(__name__)
 
 
 @functools.cache
@@ -54,15 +58,19 @@ class MpsSafeLinear(nn.Linear):
         return super().forward(input)
 
 
-def maybe_replace_linears_on_mps(model: nn.Module) -> nn.Module:
+def maybe_replace_linears_on_mps(
+    model: nn.Module, devices: Sequence[torch.device]
+) -> nn.Module:
     """Retype bias-enabled Linear layers in-place if MPS is buggy on this machine.
 
-    No-op unless the MPS self-test finds the bug. Only vanilla bias-enabled
-    nn.Linear modules are affected; bias=False layers are left untouched (they are
-    not affected by the bug). Mutates and returns model.
+    If devices does not contain an MPS device, does nothing. Otherwise, checks if this
+    device suffers from the MPS bug (see module docstring), and applies the workaround.
     """
+    if not any(device.type == "mps" for device in devices):
+        return model
     if not _mps_linear_bias_is_buggy():
         return model
+    logger.debug("Detected MPS nn.Linear bug. Applying workaround")
     for module in model.modules():
         if type(module) is nn.Linear and module.bias is not None:
             # Same memory layout and parameters, so re-typing in place is safe and

--- a/src/tabpfn/inference.py
+++ b/src/tabpfn/inference.py
@@ -18,6 +18,9 @@ from typing_extensions import override
 import joblib
 import torch
 
+from tabpfn.architectures.shared.workaround_mps_linear_bug import (
+    maybe_replace_linears_on_mps,
+)
 from tabpfn.constants import DEFAULT_SAVE_PEAK_MEMORY_FACTOR, MemorySavingMode
 from tabpfn.memory import should_save_peak_mem
 from tabpfn.parallel_execute import parallel_execute
@@ -594,6 +597,8 @@ class InferenceEngineBatchedNoPreprocessing(SingleDeviceInferenceEngine):
         # As this inference engine only supports one device, just take the first.
         device = devices[0]
         for model in self.models:
+            # Apply a workaround for a nn.Linear bug on MPS. No-op if MPS not selected.
+            maybe_replace_linears_on_mps(model, [device])
             model.to(device)
 
 
@@ -1226,6 +1231,10 @@ class _PerDeviceModelCache:
         any references to models previously obtained with .get_model() after calling
         this function.
         """
+        # Apply a workaround for a nn.Linear bug on MPS. No-op if MPS not selected.
+        for model in self._models.values():
+            maybe_replace_linears_on_mps(model, devices)
+
         spare_models = [
             model for device, model in self._models.items() if device not in devices
         ]

--- a/src/tabpfn/model_loading.py
+++ b/src/tabpfn/model_loading.py
@@ -31,6 +31,9 @@ from torch import nn
 
 from tabpfn.architectures import ARCHITECTURES
 from tabpfn.architectures.shared.bar_distribution import FullSupportBarDistribution
+from tabpfn.architectures.shared.workaround_mps_linear_bug import (
+    maybe_replace_linears_on_mps,
+)
 from tabpfn.checkpoint import Checkpoint
 from tabpfn.constants import ModelVersion
 from tabpfn.errors import TabPFNHuggingFaceGatedRepoError
@@ -892,6 +895,9 @@ def load_model(
         model_config,
         cache_trainset_representation=cache_trainset_representation,
     )
+
+    # Work around a bug with nn.Linear on some Macs. No-op elsewhere.
+    maybe_replace_linears_on_mps(model)
 
     if "test_targets_MB" in inspect.signature(model.forward).parameters:
         # The model computes the loss internally. Strip criterion keys that

--- a/src/tabpfn/model_loading.py
+++ b/src/tabpfn/model_loading.py
@@ -31,9 +31,6 @@ from torch import nn
 
 from tabpfn.architectures import ARCHITECTURES
 from tabpfn.architectures.shared.bar_distribution import FullSupportBarDistribution
-from tabpfn.architectures.shared.workaround_mps_linear_bug import (
-    maybe_replace_linears_on_mps,
-)
 from tabpfn.checkpoint import Checkpoint
 from tabpfn.constants import ModelVersion
 from tabpfn.errors import TabPFNHuggingFaceGatedRepoError
@@ -895,9 +892,6 @@ def load_model(
         model_config,
         cache_trainset_representation=cache_trainset_representation,
     )
-
-    # Work around a bug with nn.Linear on some Macs. No-op elsewhere.
-    maybe_replace_linears_on_mps(model)
 
     if "test_targets_MB" in inspect.signature(model.forward).parameters:
         # The model computes the loss internally. Strip criterion keys that

--- a/tests/test_architectures/test_shared/__init__.py
+++ b/tests/test_architectures/test_shared/__init__.py
@@ -1,0 +1,1 @@
+#  Copyright (c) Prior Labs GmbH 2026.

--- a/tests/test_architectures/test_shared/test_workaround_mps_linear_bug.py
+++ b/tests/test_architectures/test_shared/test_workaround_mps_linear_bug.py
@@ -1,0 +1,85 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
+"""Tests for tabpfn.architectures.shared.workaround_mps_linear_bug."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from torch import nn
+
+from tabpfn.architectures.shared import workaround_mps_linear_bug
+from tabpfn.architectures.shared.workaround_mps_linear_bug import (
+    MpsSafeLinear,
+    maybe_replace_linears_on_mps,
+)
+
+# Shape known to trigger the macOS-26 / M1 bug: >2D with a unary dim, small in_features.
+_TRIGGER_SHAPE = (80, 1, 2)
+
+
+def _make_model() -> nn.Module:
+    """A module mixing a bias-enabled Linear, a bias=False Linear, and a nested one."""
+    return nn.Sequential(
+        nn.Linear(2, 8, bias=True),
+        nn.GELU(),
+        nn.Linear(8, 4, bias=False),
+        nn.Sequential(nn.Linear(4, 3, bias=True)),
+    )
+
+
+def test__maybe_replace_linears_on_mps__noop_when_not_buggy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        workaround_mps_linear_bug, "_mps_linear_bias_is_buggy", lambda: False
+    )
+    model = _make_model()
+    maybe_replace_linears_on_mps(model)
+    linears = [m for m in model.modules() if isinstance(m, nn.Linear)]
+    assert all(type(m) is nn.Linear for m in linears)
+
+
+def test__maybe_replace_linears_on_mps__retypes_only_linears_with_bias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        workaround_mps_linear_bug, "_mps_linear_bias_is_buggy", lambda: True
+    )
+    model = _make_model()
+    maybe_replace_linears_on_mps(model)
+
+    linears = [m for m in model.modules() if isinstance(m, nn.Linear)]
+    with_bias = [m for m in linears if m.bias is not None]
+    without_bias = [m for m in linears if m.bias is None]
+
+    assert with_bias, "expected at least one bias-enabled Linear"
+    assert all(isinstance(m, MpsSafeLinear) for m in with_bias)
+    assert all(type(m) is nn.Linear for m in without_bias)
+
+
+def test__maybe_replace_linears_on_mps__on_cpu__does_not_affect_model_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """On CPU the swapped model must produce identical output (fall-through path)."""
+    monkeypatch.setattr(
+        workaround_mps_linear_bug, "_mps_linear_bias_is_buggy", lambda: True
+    )
+    torch.manual_seed(0)
+    model = _make_model()
+    x = torch.randn(*_TRIGGER_SHAPE)
+    before = model(x)
+
+    maybe_replace_linears_on_mps(model)
+    after = model(x)
+
+    torch.testing.assert_close(before, after, rtol=0, atol=0)
+
+
+def test__MpsSafeLinear__on_cpu__matches_built_in_linear() -> None:
+    torch.manual_seed(0)
+    plain = nn.Linear(2, 192, bias=True)
+    safe = MpsSafeLinear(2, 192, bias=True)
+    safe.load_state_dict(plain.state_dict())
+    x = torch.randn(*_TRIGGER_SHAPE)
+    torch.testing.assert_close(safe(x), plain(x), rtol=0, atol=0)

--- a/tests/test_architectures/test_shared/test_workaround_mps_linear_bug.py
+++ b/tests/test_architectures/test_shared/test_workaround_mps_linear_bug.py
@@ -28,26 +28,40 @@ def _make_model() -> nn.Module:
     )
 
 
-def test__maybe_replace_linears_on_mps__noop_when_not_buggy(
+def test__maybe_replace_linears_on_mps__mps_not_selected__does_not_test_for_bug(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        workaround_mps_linear_bug,
+        "_mps_linear_bias_is_buggy",
+        lambda: pytest.fail("self-test must not run without an MPS device"),
+    )
+    model = _make_model()
+    maybe_replace_linears_on_mps(model, [torch.device("cpu")])
+    linears = [m for m in model.modules() if isinstance(m, nn.Linear)]
+    assert all(type(m) is nn.Linear for m in linears)
+
+
+def test__maybe_replace_linears_on_mps__bug_not_present__model_unchanged(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
         workaround_mps_linear_bug, "_mps_linear_bias_is_buggy", lambda: False
     )
     model = _make_model()
-    maybe_replace_linears_on_mps(model)
+    maybe_replace_linears_on_mps(model, [torch.device("mps")])
     linears = [m for m in model.modules() if isinstance(m, nn.Linear)]
     assert all(type(m) is nn.Linear for m in linears)
 
 
-def test__maybe_replace_linears_on_mps__retypes_only_linears_with_bias(
+def test__maybe_replace_linears_on_mps__retypes_only_bias_linears(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
         workaround_mps_linear_bug, "_mps_linear_bias_is_buggy", lambda: True
     )
     model = _make_model()
-    maybe_replace_linears_on_mps(model)
+    maybe_replace_linears_on_mps(model, [torch.device("mps")])
 
     linears = [m for m in model.modules() if isinstance(m, nn.Linear)]
     with_bias = [m for m in linears if m.bias is not None]
@@ -58,10 +72,9 @@ def test__maybe_replace_linears_on_mps__retypes_only_linears_with_bias(
     assert all(type(m) is nn.Linear for m in without_bias)
 
 
-def test__maybe_replace_linears_on_mps__on_cpu__does_not_affect_model_output(
+def test__maybe_replace_linears_on_mps__force_replac__output_unchanged_when_on_cpu(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """On CPU the swapped model must produce identical output (fall-through path)."""
     monkeypatch.setattr(
         workaround_mps_linear_bug, "_mps_linear_bias_is_buggy", lambda: True
     )
@@ -70,7 +83,7 @@ def test__maybe_replace_linears_on_mps__on_cpu__does_not_affect_model_output(
     x = torch.randn(*_TRIGGER_SHAPE)
     before = model(x)
 
-    maybe_replace_linears_on_mps(model)
+    maybe_replace_linears_on_mps(model, [torch.device("mps")])
     after = model(x)
 
     torch.testing.assert_close(before, after, rtol=0, atol=0)

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -10,16 +10,20 @@ from typing_extensions import override
 import pytest
 import torch
 from numpy.random import default_rng
-from torch import Tensor
+from torch import Tensor, nn
 
 from tabpfn import TabPFNClassifier, TabPFNRegressor
 from tabpfn.architectures.interface import Architecture, PerformanceOptions
 from tabpfn.architectures.kv_cache import KVCacheEntry
+from tabpfn.architectures.shared import workaround_mps_linear_bug
+from tabpfn.architectures.shared.workaround_mps_linear_bug import MpsSafeLinear
 from tabpfn.architectures.tabpfn_v3 import TabPFNV3Cache
+from tabpfn.base import create_inference_engine
 from tabpfn.inference import (
     InferenceEngineCachePreprocessing,
     InferenceEngineExplicitKVCache,
     InferenceEngineOnDemand,
+    MultiDeviceInferenceEngine,
 )
 from tabpfn.preprocessing import (
     ClassifierEnsembleConfig,
@@ -648,3 +652,125 @@ def test__public_keep_cache_on_device__controls_cache_placement(
     # Prediction still works end-to-end (caches moved to device on demand).
     preds = est.predict(X[:5])
     assert len(preds) == 5
+
+
+class _TestModelWithLinear(_TestModelWithKVCache):
+    """A test model with Linear layers that also supports the KV-cache forward."""
+
+    def __init__(self) -> None:
+        """Create a new instance."""
+        super().__init__()
+        self.linear = nn.Linear(2, 3, bias=True)
+        self.linear_no_bias = nn.Linear(3, 2, bias=False)
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="requires the MPS backend"
+)
+@pytest.mark.parametrize(
+    "fit_mode", ["low_memory", "fit_preprocessors", "fit_with_cache"]
+)
+def test__init__mps_target_device__applies_mps_linear_bug_workaround(
+    fit_mode: Literal["low_memory", "fit_preprocessors", "fit_with_cache"],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Moving an engine to MPS replaces Linears with MpsSafeLinear.
+
+    See tabpfn.architectures.shared.workaround_mps_linear_bug.
+    """
+    monkeypatch.setattr(
+        workaround_mps_linear_bug, "_mps_linear_bias_is_buggy", lambda: True
+    )
+    rng = default_rng(seed=0)
+    X_train = rng.standard_normal((20, 4))
+    y_train = rng.integers(0, 3, (20, 1))
+    mps = torch.device("mps")
+    engine = create_inference_engine(
+        fit_mode=fit_mode,
+        X_train=X_train,
+        y_train=y_train,
+        ensemble_preprocessor=TabPFNEnsemblePreprocessor(
+            configs=_create_test_ensemble_configs(
+                n_configs=2, n_classes=3, num_models=1
+            ),
+            n_samples=X_train.shape[0],
+            feature_schema=FeatureSchema.from_only_categorical_indices([], 4),
+            random_state=rng,
+            n_preprocessing_jobs=1,
+        ),
+        models=[_TestModelWithLinear()],
+        devices_=[mps],
+        byte_size=4,
+        forced_inference_dtype_=None,
+        memory_saving_mode=True,
+        use_autocast_=False,
+        inference_mode=True,
+    )
+
+    engine.to([torch.device(mps)], force_inference_dtype=None, dtype_byte_size=4)
+
+    assert isinstance(engine, MultiDeviceInferenceEngine)
+    model = engine.model_caches[0].get(torch.device(mps))
+    linears = [m for m in model.modules() if isinstance(m, nn.Linear)]
+    bias_linears = [m for m in linears if m.bias is not None]
+    no_bias_linears = [m for m in linears if m.bias is None]
+
+    assert bias_linears, "expected at least one bias-enabled Linear"
+    assert all(isinstance(m, MpsSafeLinear) for m in bias_linears)
+    assert all(type(m) is nn.Linear for m in no_bias_linears)
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="requires the MPS backend"
+)
+@pytest.mark.parametrize(
+    "fit_mode", ["low_memory", "fit_preprocessors", "fit_with_cache"]
+)
+def test__to__mps_target_device__applies_mps_linear_bug_workaround(
+    fit_mode: Literal["low_memory", "fit_preprocessors", "fit_with_cache"],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Moving an engine to MPS replaces Linears with MpsSafeLinear.
+
+    See tabpfn.architectures.shared.workaround_mps_linear_bug.
+    """
+    monkeypatch.setattr(
+        workaround_mps_linear_bug, "_mps_linear_bias_is_buggy", lambda: True
+    )
+    rng = default_rng(seed=0)
+    X_train = rng.standard_normal((20, 4))
+    y_train = rng.integers(0, 3, (20, 1))
+    engine = create_inference_engine(
+        fit_mode=fit_mode,
+        X_train=X_train,
+        y_train=y_train,
+        ensemble_preprocessor=TabPFNEnsemblePreprocessor(
+            configs=_create_test_ensemble_configs(
+                n_configs=2, n_classes=3, num_models=1
+            ),
+            n_samples=X_train.shape[0],
+            feature_schema=FeatureSchema.from_only_categorical_indices([], 4),
+            random_state=rng,
+            n_preprocessing_jobs=1,
+        ),
+        models=[_TestModelWithLinear()],
+        devices_=[torch.device("cpu")],
+        byte_size=4,
+        forced_inference_dtype_=None,
+        memory_saving_mode=True,
+        use_autocast_=False,
+        inference_mode=True,
+    )
+
+    mps = torch.device("mps")
+    engine.to([torch.device(mps)], force_inference_dtype=None, dtype_byte_size=4)
+
+    assert isinstance(engine, MultiDeviceInferenceEngine)
+    model = engine.model_caches[0].get(torch.device(mps))
+    linears = [m for m in model.modules() if isinstance(m, nn.Linear)]
+    bias_linears = [m for m in linears if m.bias is not None]
+    no_bias_linears = [m for m in linears if m.bias is None]
+
+    assert bias_linears, "expected at least one bias-enabled Linear"
+    assert all(isinstance(m, MpsSafeLinear) for m in bias_linears)
+    assert all(type(m) is nn.Linear for m in no_bias_linears)


### PR DESCRIPTION
On at least MacOS 26 + M1, nn.Linear can have the wrong output when bias is enabled: https://github.com/pytorch/pytorch/issues/188438
This PR tests if we hit the bug. If so, it replaces nn.Linear layers in the model with a decomposed version.

Switch the runner back to macos-latest (which is either macos-15 or macos-26 on M1).

Testing: in [this run](https://github.com/PriorLabs/TabPFN/actions/runs/28606803966/job/84829060784) I forced it to macos-26, the tests pass

Fixes PRI-331