### PR TITLE
feat: advertise inf as MCAR indicator

### DIFF
--- a/src/tabpfn/validation.py
+++ b/src/tabpfn/validation.py
@@ -207,7 +207,7 @@ def ensure_compatible_fit_inputs_sklearn(
             )
     except (ValueError, TypeError) as e:
         e_str = str(e)
-        if "infinity" in e_str:
+        if "X contains infinity" in e_str:
             e_str += (
                 "\nHint: TabPFN uses infinite values as missing completely at random "  # noqa: S608
                 "(MCAR) markers. If this matches your use case, try using "

--- a/src/tabpfn/validation.py
+++ b/src/tabpfn/validation.py
@@ -207,7 +207,7 @@ def ensure_compatible_fit_inputs_sklearn(
             )
     except (ValueError, TypeError) as e:
         e_str = str(e)
-        if "contains infinity" in e_str:
+        if "infinity" in e_str:
             e_str += (
                 "\nHint: TabPFN uses infinite values as missing completely at random "  # noqa: S608
                 "(MCAR) markers. If this matches your use case, try using "

--- a/src/tabpfn/validation.py
+++ b/src/tabpfn/validation.py
@@ -206,7 +206,17 @@ def ensure_compatible_fit_inputs_sklearn(
                 ensure_2d=False,
             )
     except (ValueError, TypeError) as e:
-        raise TabPFNValidationError(str(e)) from e
+        e_str = str(e)
+        if "contains infinity" in e_str:
+            e_str += (
+                "\nHint: TabPFN uses infinite values as missing completely at random "  # noqa: S608
+                "(MCAR) markers. If this matches your use case, try using "
+                f"{estimator.__class__.__name__}"
+                '(inference_config={"PASSTHROUGH_INF": True}).\n'
+                "Otherwise, replace your infinite values with NaN to indicate "
+                "missingness."
+            )
+        raise TabPFNValidationError(e_str) from e
 
     # NOTE: Theoretically we don't need to return the feature names and number,
     # but it makes it clearer in the calling code that these variables now exist


### PR DESCRIPTION
Document how TabPFN handles infinite values when detecting them during either `fit` or `predict`.
See RES-1537 and #1055.