### PR TITLE
add cache calculator

### DIFF
--- a/changelog/1087.added.md
+++ b/changelog/1087.added.md
@@ -1,1 +1,1 @@
-Add `estimate_cache_size` for TabPFN v3 to compute the KV-cache memory (and, for classifiers, the decoder activations) for a given train-set size, ensemble size, and dtype — without running inference.
+Add `calculate_cache_size` for TabPFN v3 to compute the resident cache memory (ICL KV cache, decoder activations, distribution-embedder inducing states, and scaler stats) for a given train-set size, column count, ensemble size, and dtype — without running inference.

--- a/changelog/1087.added.md
+++ b/changelog/1087.added.md
@@ -1,0 +1,1 @@
+Add `estimate_cache_size` for TabPFN v3 to compute the KV-cache memory (and, for classifiers, the decoder activations) for a given train-set size, ensemble size, and dtype — without running inference.

--- a/src/tabpfn/architectures/kv_cache.py
+++ b/src/tabpfn/architectures/kv_cache.py
@@ -19,9 +19,7 @@ from dataclasses import dataclass, field
 import torch
 from torch import Tensor
 
-# Default integer dtype the KV cache is quantized to. Single source of truth
-# shared by :meth:`KVCacheEntry.quantize` and any cache-size estimation, so the
-# stored dtype is never hardcoded in two places.
+# only supported KV quantization so far
 QUANTIZED_KV_DTYPE: torch.dtype = torch.int8
 
 # Low, high, max-magnitude value for each dtype.
@@ -89,7 +87,7 @@ class KVCacheEntry:
         """Quantize this entry with per-tensor symmetric scaling.
 
         Args:
-            dtype: Target integer dtype (default :data:`QUANTIZED_KV_DTYPE`).
+            dtype: Target integer dtype (default `QUANTIZED_KV_DTYPE`).
         """
         assert self.is_valid()
         k_q, k_s = _quantize_tensor(self.key, dtype)

--- a/src/tabpfn/architectures/kv_cache.py
+++ b/src/tabpfn/architectures/kv_cache.py
@@ -19,6 +19,11 @@ from dataclasses import dataclass, field
 import torch
 from torch import Tensor
 
+# Default integer dtype the KV cache is quantized to. Single source of truth
+# shared by :meth:`KVCacheEntry.quantize` and any cache-size estimation, so the
+# stored dtype is never hardcoded in two places.
+QUANTIZED_KV_DTYPE: torch.dtype = torch.int8
+
 # Low, high, max-magnitude value for each dtype.
 # int8 uses the symmetric range [-127, 127] (one code below the full int8
 # range) so that ``-max * scale`` equals ``+max * scale`` and dequantization
@@ -78,11 +83,13 @@ class KVCacheEntry:
             return KVCacheEntry()
         return KVCacheEntry(key=self.key.to(device), value=self.value.to(device))
 
-    def quantize(self, dtype: torch.dtype = torch.int8) -> QuantizedKVCacheEntry:
+    def quantize(
+        self, dtype: torch.dtype = QUANTIZED_KV_DTYPE
+    ) -> QuantizedKVCacheEntry:
         """Quantize this entry with per-tensor symmetric scaling.
 
         Args:
-            dtype: Target integer dtype (default ``torch.int8``).
+            dtype: Target integer dtype (default :data:`QUANTIZED_KV_DTYPE`).
         """
         assert self.is_valid()
         k_q, k_s = _quantize_tensor(self.key, dtype)

--- a/src/tabpfn/architectures/tabpfn_v3.py
+++ b/src/tabpfn/architectures/tabpfn_v3.py
@@ -260,7 +260,7 @@ def get_cache_size(
     X_train: Any,
     *,
     model_config: TabPFNV3Config,
-    dtype: torch.dtype | Literal["autocast"],
+    base_dtype: torch.dtype | Literal["autocast"],
     quantize_kv_cache: bool = True,
 ) -> int:
     """Calculate the cached memory in bytes for a single TabPFN v3 estimator.
@@ -299,7 +299,7 @@ def get_cache_size(
             end-to-end runs preprocessing may change it (SVD features, categorical
             expansion, per-member subsampling), making those terms approximate.
         model_config: The v3 architecture config.
-        dtype: Either a ``torch.dtype`` (forced-precision path -- every term is
+        base_dtype: Either a ``torch.dtype`` (forced-precision path -- every term is
             sized at this dtype; on CPU this is usually Float32) or the string
             ``"autocast"`` (GPU autocast path -- KV and ``train_embeddings`` are
             sized at fp16 while ``inducing_hidden`` and ``scaler_cache`` stay
@@ -317,7 +317,7 @@ def get_cache_size(
     # Set the stored dtype of each cached component up front. On the forced-
     # precision path the model and inputs are cast to ``dtype``, so every
     # component is ``dtype``. Under autocast the cache is mixed precision.
-    if dtype == "autocast":
+    if base_dtype == "autocast":
         # Autocast keeps fp32 weights and casts ops to fp16 at runtime, so KV and
         # train_embeddings (matmul outputs) are fp16, while inducing_hidden and
         # the scaler (fp32 reduction/norm ops, scaler fit on the fp32 input) stay
@@ -328,11 +328,11 @@ def get_cache_size(
         inducing_dtype = torch.float32
         scaler_dtype = torch.float32
     else:
-        kv_dtype = QUANTIZED_KV_DTYPE if quantize_kv_cache else dtype
-        kv_scale_dtype = dtype
-        train_emb_dtype = dtype
-        inducing_dtype = dtype
-        scaler_dtype = dtype
+        kv_dtype = QUANTIZED_KV_DTYPE if quantize_kv_cache else base_dtype
+        kv_scale_dtype = base_dtype
+        train_emb_dtype = base_dtype
+        inducing_dtype = base_dtype
+        scaler_dtype = base_dtype
 
     # Accept either an array-like (read ``.shape``) or a (n_rows, n_features) tuple.
     if hasattr(X_train, "shape"):

--- a/src/tabpfn/architectures/tabpfn_v3.py
+++ b/src/tabpfn/architectures/tabpfn_v3.py
@@ -45,7 +45,12 @@ from tabpfn.architectures.interface import (
     ArchitectureConfig,
     PerformanceOptions,
 )
-from tabpfn.architectures.kv_cache import KVCache, KVCacheEntry, QuantizedKVCacheEntry
+from tabpfn.architectures.kv_cache import (
+    QUANTIZED_KV_DTYPE,
+    KVCache,
+    KVCacheEntry,
+    QuantizedKVCacheEntry,
+)
 from tabpfn.architectures.shared.chunked_evaluate import chunked_evaluate_maybe_inplace
 from tabpfn.architectures.shared.scaled_dot_product_attention import (
     scaled_dot_product_attention,
@@ -229,14 +234,14 @@ class TabPFNV3Cache(KVCache):
             inducing_hidden=self._list_of_tensors_to(self.inducing_hidden, device),
         )
 
-    def quantize(self, dtype: torch.dtype = torch.int8) -> TabPFNV3Cache:
+    def quantize(self, dtype: torch.dtype = QUANTIZED_KV_DTYPE) -> TabPFNV3Cache:
         """Return a new cache with quantized ICL KV entries.
 
         Only the ICL KV cache is quantized; ``train_embeddings``,
         ``scaler_cache``, and ``inducing_hidden`` stay in full precision.
 
         Args:
-            dtype: Target integer dtype (default ``torch.int8``).
+            dtype: Target integer dtype (default :data:`QUANTIZED_KV_DTYPE`).
         """
         quantized_kv = {
             idx: (entry.quantize(dtype) if isinstance(entry, KVCacheEntry) else entry)
@@ -249,6 +254,90 @@ class TabPFNV3Cache(KVCache):
             scaler_cache=self.scaler_cache,
             inducing_hidden=self.inducing_hidden,
         )
+
+
+def estimate_cache_size(
+    X_train: Any,
+    *,
+    model_config: TabPFNV3Config,
+    ensemble_size: int,
+    dtype: torch.dtype,
+    quantize_kv_cache: bool = True,
+    include_decoder_activations: bool = True,
+) -> int:
+    """Estimate the cached memory in bytes for a TabPFN v3 inference run.
+
+    Analytical counterpart of the (removed) ``TabPFNV3Cache.cache_size_mb``:
+    it works from shapes alone, so it can be called before fitting to size an
+    inference run. Two terms are counted:
+
+    1. The ICL transformer KV cache (always). Per layer it caches a key and a
+       value tensor each of shape ``(N_train, H_kv, head_dim)`` per estimator;
+       only training rows are cached (test rows produce queries only), where:
+
+       * ``head_dim = embed_dim * feat_agg_num_cls_tokens // icl_num_heads``,
+       * ``H_kv`` is the number of *cached* KV heads: ``icl_num_kv_heads_test``
+         if set (MQA/GQA for the test partition), else ``icl_num_kv_heads``
+         (GQA), else ``icl_num_heads`` (plain MHA).
+
+    2. The last-layer train activations ``train_embeddings`` of shape
+       ``(N_train, embed_dim * feat_agg_num_cls_tokens)`` per estimator -- **only
+       for classification** (binary or multiclass), where the ``ManyClassDecoder``
+       attends test queries to them as retrieval keys. Regression never uses
+       them. Controlled by ``include_decoder_activations`` (on by default).
+
+    The KV cache and the activations are stored at *different* dtypes: the
+    default engine int8-quantizes the KV cache (``quantize_kv_cache``) but leaves
+    ``train_embeddings`` at the compute dtype. Each term is therefore sized with
+    its own dtype rather than a single shared one. The ``scaler_cache`` /
+    ``inducing_hidden`` entries are small and not counted.
+
+    Args:
+        X_train: Training features; only ``X_train.shape[0]`` (the row count)
+            is used.
+        model_config: The v3 architecture config.
+        ensemble_size: Number of ensemble members (estimators). At inference
+            each estimator runs its own forward and holds a separate cache, so
+            the total scales linearly with this.
+        dtype: The compute dtype (e.g. from autocast / ``inference_precision``).
+            Sizes the decoder activations, and the KV cache too when
+            ``quantize_kv_cache`` is False.
+        quantize_kv_cache: If True (default), the KV cache is sized at
+            :data:`~tabpfn.architectures.kv_cache.QUANTIZED_KV_DTYPE` (mirrors
+            the engine's ``maybe_quantize_kv_cache``); if False, at ``dtype``.
+        include_decoder_activations: If True (default), add the classification
+            ``train_embeddings`` term. Has no effect for regression configs,
+            which do not cache decoder activations.
+
+    Returns:
+        Estimated cache size in bytes. Divide by ``1024 ** 2`` for MB.
+    """
+    n_train = int(X_train.shape[0])
+    icl_emsize = model_config.embed_dim * model_config.feat_agg_num_cls_tokens
+    head_dim = icl_emsize // model_config.icl_num_heads
+    if model_config.icl_num_kv_heads_test is not None:
+        num_kv_heads = model_config.icl_num_kv_heads_test
+    elif model_config.icl_num_kv_heads is not None:
+        num_kv_heads = model_config.icl_num_kv_heads
+    else:
+        num_kv_heads = model_config.icl_num_heads
+
+    kv_dtype = QUANTIZED_KV_DTYPE if quantize_kv_cache else dtype
+
+    # ICL KV cache: key + value (the factor of 2), per layer, over all layers,
+    # per ensemble member.
+    kv_elements = model_config.nlayers * 2 * n_train * num_kv_heads * head_dim
+    total_bytes = kv_elements * kv_dtype.itemsize
+
+    # Classification (binary or multiclass) runs the ManyClassDecoder, which
+    # attends to the cached train activations as retrieval keys; regression
+    # (max_num_classes == 0) does not. classification == "has any classes".
+    # These activations are not quantized with the KV cache -> sized at dtype.
+    is_classification = model_config.max_num_classes > 0
+    if include_decoder_activations and is_classification:
+        total_bytes += n_train * icl_emsize * dtype.itemsize
+
+    return ensemble_size * total_bytes
 
 
 # ---------------------------------------------------------------------------
@@ -1480,6 +1569,7 @@ class TabPFNV3(Architecture):
         dtype: torch.dtype | str | None = None,
     ):
         super().__init__()
+        self.config = config
         self.ff_factor = config.ff_factor
         self.icl_emsize = config.embed_dim * config.feat_agg_num_cls_tokens
         self.n_out = n_out

--- a/src/tabpfn/architectures/tabpfn_v3.py
+++ b/src/tabpfn/architectures/tabpfn_v3.py
@@ -256,50 +256,24 @@ class TabPFNV3Cache(KVCache):
         )
 
 
-def calculate_cache_size(
+def get_cache_size(
     X_train: Any,
     *,
     model_config: TabPFNV3Config,
-    ensemble_size: int,
     dtype: torch.dtype,
     quantize_kv_cache: bool = True,
-    include_decoder_activations: bool = True,
-    include_inducing_points: bool = True,
 ) -> int:
-    """Calculate the cached memory in bytes for a TabPFN v3 inference run.
+    """Calculate the cached memory in bytes for a single TabPFN v3 estimator.
 
     Works from shapes alone, so it can be called before fitting to size an
-    inference run. With all terms enabled it is the exact resident cache size
-    (``TabPFNV3Cache``), summing:
+    inference run. It is the exact resident cache size (``TabPFNV3Cache``) for
+    one estimator, summing every tensor a built cache holds:
 
-    1. The ICL transformer KV cache (always). Per layer it caches a key and a
-       value tensor each of shape ``(N_train, H_kv, head_dim)`` per estimator;
-       only training rows are cached (test rows produce queries only), where:
-
-       * ``head_dim = embed_dim * feat_agg_num_cls_tokens // icl_num_heads``,
-       * ``H_kv`` is the number of *cached* KV heads: ``icl_num_kv_heads_test``
-         if set (MQA/GQA for the test partition), else ``icl_num_kv_heads``
-         (GQA), else ``icl_num_heads`` (plain MHA).
-
-       When ``quantize_kv_cache`` is True the K/V are int8 plus one scalar scale
-       per key and per value tensor (``nlayers * 2`` scalars at ``dtype``).
-
-    2. The last-layer train activations ``train_embeddings`` of shape
-       ``(N_train, embed_dim * feat_agg_num_cls_tokens)`` per estimator -- **only
-       for classification** (binary or multiclass), where the ``ManyClassDecoder``
-       attends test queries to them as retrieval keys. Regression never uses
-       them. Controlled by ``include_decoder_activations`` (on by default).
-
-    3. The distribution-embedder ``inducing_hidden`` states: one
-       ``(n_features, dist_embed_num_inducing_points, embed_dim)`` tensor per
-       block (``dist_embed_num_blocks``), per estimator, for both tasks. Unlike
-       the other terms this is **independent of ``N_train``** (inducing points
-       compress the train rows into a fixed set) and instead scales with the
-       column count, so it can dominate on wide, small-``N`` datasets. Controlled
-       by ``include_inducing_points`` (on by default).
-
-    4. The fitted scaler stats ``scaler_cache`` (``mean`` + ``std``), of shape
-       ``(2, n_features)`` per estimator. Always counted (small).
+    1. The ICL transformer KV cache (int8 + per-tensor scales when quantized).
+    2. The last-layer train activations (cached for both tasks; regression
+       stores but ignores them).
+    3. The distribution-embedder ``inducing_hidden`` states.
+    4. The fitted scaler stats ``scaler_cache`` (``mean`` + ``std``).
 
     Each term is sized with its own dtype: the default engine int8-quantizes the
     KV cache (``quantize_kv_cache``) but leaves everything else at the compute
@@ -313,9 +287,6 @@ def calculate_cache_size(
             end-to-end runs preprocessing may change it (SVD features, categorical
             expansion, per-member subsampling), making those terms approximate.
         model_config: The v3 architecture config.
-        ensemble_size: Number of ensemble members (estimators). At inference
-            each estimator runs its own forward and holds a separate cache, so
-            the total scales linearly with this.
         dtype: The compute dtype (e.g. from autocast / ``inference_precision``).
             On GPUs this is usually FP16, otherwise Float32.
             Sizes every term except the int8 KV cache when ``quantize_kv_cache``
@@ -324,14 +295,10 @@ def calculate_cache_size(
             :data:`~tabpfn.architectures.kv_cache.QUANTIZED_KV_DTYPE` (mirrors
             the engine's ``maybe_quantize_kv_cache``) plus per-tensor scales; if
             False, the K/V are sized at ``dtype`` with no scales.
-        include_decoder_activations: If True (default), add the classification
-            ``train_embeddings`` term. Has no effect for regression configs,
-            which do not use decoder activations.
-        include_inducing_points: If True (default), add the distribution-embedder
-            ``inducing_hidden`` term (see point 3).
 
     Returns:
-        Cache size in bytes. Divide by ``1024 ** 2`` for MB.
+        Per-estimator cache size in bytes. Multiply by the ensemble size for the
+        total (each estimator holds its own cache); divide by ``1024 ** 2`` for MB.
     """
     # Accept either an array-like (read ``.shape``) or a (n_rows, n_features) tuple.
     if hasattr(X_train, "shape"):
@@ -349,38 +316,29 @@ def calculate_cache_size(
 
     kv_dtype = QUANTIZED_KV_DTYPE if quantize_kv_cache else dtype
 
-    # ICL KV cache: key + value (the factor of 2), per layer, over all layers,
-    # per ensemble member.
+    # 1. ICL KV cache: key + value (the factor of 2), per layer, over all layers.
     kv_elements = model_config.nlayers * 2 * n_train * num_kv_heads * head_dim
     total_bytes = kv_elements * kv_dtype.itemsize
     if quantize_kv_cache:
         # One scalar scale per key and per value tensor, stored at ``dtype``.
         total_bytes += model_config.nlayers * 2 * dtype.itemsize
 
-    # Classification (binary or multiclass) runs the ManyClassDecoder, which
-    # attends to the cached train activations as retrieval keys; regression
-    # (max_num_classes == 0) does not. classification == "has any classes".
-    # These activations are not quantized with the KV cache -> sized at dtype.
-    is_classification = model_config.max_num_classes > 0
-    if include_decoder_activations and is_classification:
-        total_bytes += n_train * icl_emsize * dtype.itemsize
+    # 2. Train activations, (N_train, icl_emsize). Cached for both tasks.
+    total_bytes += n_train * icl_emsize * dtype.itemsize
 
-    # Distribution-embedder inducing states: one
+    # 3. Distribution-embedder inducing states: one
     # (n_features, dist_embed_num_inducing_points, embed_dim) tensor per block.
-    # Independent of N_train; scales with the column count. Not quantized.
-    if include_inducing_points:
-        inducing_elements = (
-            model_config.dist_embed_num_blocks
-            * n_features
-            * model_config.dist_embed_num_inducing_points
-            * model_config.embed_dim
-        )
-        total_bytes += inducing_elements * dtype.itemsize
+    total_bytes += (
+        model_config.dist_embed_num_blocks
+        * n_features
+        * model_config.dist_embed_num_inducing_points
+        * model_config.embed_dim
+    ) * dtype.itemsize
 
-    # Fitted scaler stats: mean + std, each (n_features,). Always cached.
+    # 4. Fitted scaler stats: mean + std, each (n_features,).
     total_bytes += 2 * n_features * dtype.itemsize
 
-    return ensemble_size * total_bytes
+    return total_bytes
 
 
 # ---------------------------------------------------------------------------

--- a/src/tabpfn/architectures/tabpfn_v3.py
+++ b/src/tabpfn/architectures/tabpfn_v3.py
@@ -30,7 +30,7 @@ import logging as _logging
 import math
 from collections.abc import Callable
 from functools import partial
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 from typing_extensions import override
 
 import numpy as np
@@ -260,7 +260,7 @@ def get_cache_size(
     X_train: Any,
     *,
     model_config: TabPFNV3Config,
-    dtype: torch.dtype,
+    dtype: torch.dtype | Literal["autocast"],
     quantize_kv_cache: bool = True,
 ) -> int:
     """Calculate the cached memory in bytes for a single TabPFN v3 estimator.
@@ -275,9 +275,21 @@ def get_cache_size(
     3. The distribution-embedder ``inducing_hidden`` states.
     4. The fitted scaler stats ``scaler_cache`` (``mean`` + ``std``).
 
-    Each term is sized with its own dtype: the default engine int8-quantizes the
-    KV cache (``quantize_kv_cache``) but leaves everything else at the compute
-    ``dtype``.
+    The cache is not uniformly one dtype, so each term is sized at its own
+    precision. This depends on the inference mode, selected via ``dtype``:
+
+    * **Forced precision** (``dtype`` a ``torch.dtype``, mirroring
+      ``inference_precision`` set to a dtype): the model and inputs are cast to
+      ``dtype``, so every non-KV term lands at ``dtype``.
+    * **Autocast** (``dtype="autocast"``, the GPU default for
+      ``inference_precision='auto'``): weights stay fp32 and ops are cast at
+      runtime to fp16. The matmul-lineage tensors (KV, and ``train_embeddings``
+      via its explicit cast to the KV dtype) take fp16, while the
+      reduction/norm-lineage tensors (``inducing_hidden``, ``scaler_cache``)
+      stay fp32.
+
+    The KV cache is additionally int8-quantized when ``quantize_kv_cache`` is
+    True (mirroring the engine's ``maybe_quantize_kv_cache``).
 
     Args:
         X_train: Either the training features (a 2-D array/tensor/DataFrame, read
@@ -287,19 +299,41 @@ def get_cache_size(
             end-to-end runs preprocessing may change it (SVD features, categorical
             expansion, per-member subsampling), making those terms approximate.
         model_config: The v3 architecture config.
-        dtype: The compute dtype (e.g. from autocast / ``inference_precision``).
-            On GPUs this is usually FP16, otherwise Float32.
-            Sizes every term except the int8 KV cache when ``quantize_kv_cache``
-            is True (the KV keys/values are then int8, their scales at ``dtype``).
+        dtype: Either a ``torch.dtype`` (forced-precision path -- every term is
+            sized at this dtype; on CPU this is usually Float32) or the string
+            ``"autocast"`` (GPU autocast path -- KV and ``train_embeddings`` are
+            sized at fp16 while ``inducing_hidden`` and ``scaler_cache`` stay
+            fp32, since autocast keeps those ops in fp32).
         quantize_kv_cache: If True (default), the KV cache is sized at
             :data:`~tabpfn.architectures.kv_cache.QUANTIZED_KV_DTYPE` (mirrors
-            the engine's ``maybe_quantize_kv_cache``) plus per-tensor scales; if
-            False, the K/V are sized at ``dtype`` with no scales.
+            the engine's ``maybe_quantize_kv_cache``) plus per-tensor scales at
+            the KV compute dtype; if False, the K/V are sized at the compute
+            dtype with no scales.
 
     Returns:
         Per-estimator cache size in bytes. Multiply by the ensemble size for the
         total (each estimator holds its own cache); divide by ``1024 ** 2`` for MB.
     """
+    # Set the stored dtype of each cached component up front. On the forced-
+    # precision path the model and inputs are cast to ``dtype``, so every
+    # component is ``dtype``. Under autocast the cache is mixed precision.
+    if dtype == "autocast":
+        # Autocast keeps fp32 weights and casts ops to fp16 at runtime, so KV and
+        # train_embeddings (matmul outputs) are fp16, while inducing_hidden and
+        # the scaler (fp32 reduction/norm ops, scaler fit on the fp32 input) stay
+        # fp32.
+        kv_dtype = QUANTIZED_KV_DTYPE if quantize_kv_cache else torch.float16
+        kv_scale_dtype = torch.float16  # per-tensor scales, at the KV fp16 dtype
+        train_emb_dtype = torch.float16
+        inducing_dtype = torch.float32
+        scaler_dtype = torch.float32
+    else:
+        kv_dtype = QUANTIZED_KV_DTYPE if quantize_kv_cache else dtype
+        kv_scale_dtype = dtype
+        train_emb_dtype = dtype
+        inducing_dtype = dtype
+        scaler_dtype = dtype
+
     # Accept either an array-like (read ``.shape``) or a (n_rows, n_features) tuple.
     if hasattr(X_train, "shape"):
         n_train, n_features = int(X_train.shape[0]), int(X_train.shape[1])
@@ -314,17 +348,15 @@ def get_cache_size(
     else:
         num_kv_heads = model_config.icl_num_heads
 
-    kv_dtype = QUANTIZED_KV_DTYPE if quantize_kv_cache else dtype
-
     # 1. ICL KV cache: key + value (the factor of 2), per layer, over all layers.
     kv_elements = model_config.nlayers * 2 * n_train * num_kv_heads * head_dim
     total_bytes = kv_elements * kv_dtype.itemsize
     if quantize_kv_cache:
-        # One scalar scale per key and per value tensor, stored at ``dtype``.
-        total_bytes += model_config.nlayers * 2 * dtype.itemsize
+        # One scalar scale per key and per value tensor.
+        total_bytes += model_config.nlayers * 2 * kv_scale_dtype.itemsize
 
     # 2. Train activations, (N_train, icl_emsize). Cached for both tasks.
-    total_bytes += n_train * icl_emsize * dtype.itemsize
+    total_bytes += n_train * icl_emsize * train_emb_dtype.itemsize
 
     # 3. Distribution-embedder inducing states: one
     # (n_features, dist_embed_num_inducing_points, embed_dim) tensor per block.
@@ -333,10 +365,10 @@ def get_cache_size(
         * n_features
         * model_config.dist_embed_num_inducing_points
         * model_config.embed_dim
-    ) * dtype.itemsize
+    ) * inducing_dtype.itemsize
 
     # 4. Fitted scaler stats: mean + std, each (n_features,).
-    total_bytes += 2 * n_features * dtype.itemsize
+    total_bytes += 2 * n_features * scaler_dtype.itemsize
 
     return total_bytes
 

--- a/src/tabpfn/architectures/tabpfn_v3.py
+++ b/src/tabpfn/architectures/tabpfn_v3.py
@@ -257,8 +257,9 @@ class TabPFNV3Cache(KVCache):
 
 
 def get_cache_size(
-    X_train: Any,
     *,
+    n_train: int,
+    n_features: int,
     model_config: TabPFNV3Config,
     base_dtype: torch.dtype | Literal["autocast"],
     quantize_kv_cache: bool = True,
@@ -292,12 +293,13 @@ def get_cache_size(
     True (mirroring the engine's ``maybe_quantize_kv_cache``).
 
     Args:
-        X_train: Either the training features (a 2-D array/tensor/DataFrame, read
-            via ``.shape``) or a ``(n_rows, n_features)`` tuple. Gives ``N_train``
-            and the column count (used by the inducing-point and scaler terms).
-            The column count is exact for the columns the model sees; for real
-            end-to-end runs preprocessing may change it (SVD features, categorical
-            expansion, per-member subsampling), making those terms approximate.
+        n_train: Number of training rows. The KV cache and train activations
+            scale with this; test rows are not cached.
+        n_features: Number of feature columns the model sees (used by the
+            inducing-point and scaler terms). Exact for the columns the model
+            sees; for real end-to-end runs preprocessing may change it (SVD
+            features, categorical expansion, per-member subsampling), making
+            those terms approximate.
         model_config: The v3 architecture config.
         base_dtype: Either a ``torch.dtype`` (forced-precision path -- every term is
             sized at this dtype; on CPU this is usually Float32) or the string
@@ -334,11 +336,6 @@ def get_cache_size(
         inducing_dtype = base_dtype
         scaler_dtype = base_dtype
 
-    # Accept either an array-like (read ``.shape``) or a (n_rows, n_features) tuple.
-    if hasattr(X_train, "shape"):
-        n_train, n_features = int(X_train.shape[0]), int(X_train.shape[1])
-    else:
-        n_train, n_features = (int(v) for v in X_train)
     icl_emsize = model_config.embed_dim * model_config.feat_agg_num_cls_tokens
     head_dim = icl_emsize // model_config.icl_num_heads
     if model_config.icl_num_kv_heads_test is not None:

--- a/src/tabpfn/architectures/tabpfn_v3.py
+++ b/src/tabpfn/architectures/tabpfn_v3.py
@@ -256,7 +256,7 @@ class TabPFNV3Cache(KVCache):
         )
 
 
-def estimate_cache_size(
+def calculate_cache_size(
     X_train: Any,
     *,
     model_config: TabPFNV3Config,
@@ -264,11 +264,13 @@ def estimate_cache_size(
     dtype: torch.dtype,
     quantize_kv_cache: bool = True,
     include_decoder_activations: bool = True,
+    include_inducing_points: bool = True,
 ) -> int:
-    """Estimate the cached memory in bytes for a TabPFN v3 inference run.
+    """Calculate the cached memory in bytes for a TabPFN v3 inference run.
 
     Works from shapes alone, so it can be called before fitting to size an
-    inference run. Two terms are counted:
+    inference run. With all terms enabled it is the exact resident cache size
+    (``TabPFNV3Cache``), summing:
 
     1. The ICL transformer KV cache (always). Per layer it caches a key and a
        value tensor each of shape ``(N_train, H_kv, head_dim)`` per estimator;
@@ -279,39 +281,63 @@ def estimate_cache_size(
          if set (MQA/GQA for the test partition), else ``icl_num_kv_heads``
          (GQA), else ``icl_num_heads`` (plain MHA).
 
+       When ``quantize_kv_cache`` is True the K/V are int8 plus one scalar scale
+       per key and per value tensor (``nlayers * 2`` scalars at ``dtype``).
+
     2. The last-layer train activations ``train_embeddings`` of shape
        ``(N_train, embed_dim * feat_agg_num_cls_tokens)`` per estimator -- **only
        for classification** (binary or multiclass), where the ``ManyClassDecoder``
        attends test queries to them as retrieval keys. Regression never uses
        them. Controlled by ``include_decoder_activations`` (on by default).
 
-    The KV cache and the activations are stored at *different* dtypes: the
-    default engine int8-quantizes the KV cache (``quantize_kv_cache``) but leaves
-    ``train_embeddings`` at the compute dtype. Each term is therefore sized with
-    its own dtype rather than a single shared one. The ``scaler_cache`` /
-    ``inducing_hidden`` entries are small and not counted.
+    3. The distribution-embedder ``inducing_hidden`` states: one
+       ``(n_features, dist_embed_num_inducing_points, embed_dim)`` tensor per
+       block (``dist_embed_num_blocks``), per estimator, for both tasks. Unlike
+       the other terms this is **independent of ``N_train``** (inducing points
+       compress the train rows into a fixed set) and instead scales with the
+       column count, so it can dominate on wide, small-``N`` datasets. Controlled
+       by ``include_inducing_points`` (on by default).
+
+    4. The fitted scaler stats ``scaler_cache`` (``mean`` + ``std``), of shape
+       ``(2, n_features)`` per estimator. Always counted (small).
+
+    Each term is sized with its own dtype: the default engine int8-quantizes the
+    KV cache (``quantize_kv_cache``) but leaves everything else at the compute
+    ``dtype``.
 
     Args:
-        X_train: Training features; only ``X_train.shape[0]`` (the row count)
-            is used.
+        X_train: Either the training features (a 2-D array/tensor/DataFrame, read
+            via ``.shape``) or a ``(n_rows, n_features)`` tuple. Gives ``N_train``
+            and the column count (used by the inducing-point and scaler terms).
+            The column count is exact for the columns the model sees; for real
+            end-to-end runs preprocessing may change it (SVD features, categorical
+            expansion, per-member subsampling), making those terms approximate.
         model_config: The v3 architecture config.
         ensemble_size: Number of ensemble members (estimators). At inference
             each estimator runs its own forward and holds a separate cache, so
             the total scales linearly with this.
         dtype: The compute dtype (e.g. from autocast / ``inference_precision``).
-            Sizes the decoder activations, and the KV cache too when
-            ``quantize_kv_cache`` is False.
+            Sizes every term except the int8 KV cache when ``quantize_kv_cache``
+            is True (the KV keys/values are then int8, their scales at ``dtype``).
         quantize_kv_cache: If True (default), the KV cache is sized at
             :data:`~tabpfn.architectures.kv_cache.QUANTIZED_KV_DTYPE` (mirrors
-            the engine's ``maybe_quantize_kv_cache``); if False, at ``dtype``.
+            the engine's ``maybe_quantize_kv_cache``) plus per-tensor scales; if
+            False, the K/V are sized at ``dtype`` with no scales.
+            On GPUs this is usually FP16, otherwise Float32.
         include_decoder_activations: If True (default), add the classification
             ``train_embeddings`` term. Has no effect for regression configs,
-            which do not cache decoder activations.
+            which do not use decoder activations.
+        include_inducing_points: If True (default), add the distribution-embedder
+            ``inducing_hidden`` term (see point 3).
 
     Returns:
-        Estimated cache size in bytes. Divide by ``1024 ** 2`` for MB.
+        Cache size in bytes. Divide by ``1024 ** 2`` for MB.
     """
-    n_train = int(X_train.shape[0])
+    # Accept either an array-like (read ``.shape``) or a (n_rows, n_features) tuple.
+    if hasattr(X_train, "shape"):
+        n_train, n_features = int(X_train.shape[0]), int(X_train.shape[1])
+    else:
+        n_train, n_features = (int(v) for v in X_train)
     icl_emsize = model_config.embed_dim * model_config.feat_agg_num_cls_tokens
     head_dim = icl_emsize // model_config.icl_num_heads
     if model_config.icl_num_kv_heads_test is not None:
@@ -327,6 +353,9 @@ def estimate_cache_size(
     # per ensemble member.
     kv_elements = model_config.nlayers * 2 * n_train * num_kv_heads * head_dim
     total_bytes = kv_elements * kv_dtype.itemsize
+    if quantize_kv_cache:
+        # One scalar scale per key and per value tensor, stored at ``dtype``.
+        total_bytes += model_config.nlayers * 2 * dtype.itemsize
 
     # Classification (binary or multiclass) runs the ManyClassDecoder, which
     # attends to the cached train activations as retrieval keys; regression
@@ -335,6 +364,21 @@ def estimate_cache_size(
     is_classification = model_config.max_num_classes > 0
     if include_decoder_activations and is_classification:
         total_bytes += n_train * icl_emsize * dtype.itemsize
+
+    # Distribution-embedder inducing states: one
+    # (n_features, dist_embed_num_inducing_points, embed_dim) tensor per block.
+    # Independent of N_train; scales with the column count. Not quantized.
+    if include_inducing_points:
+        inducing_elements = (
+            model_config.dist_embed_num_blocks
+            * n_features
+            * model_config.dist_embed_num_inducing_points
+            * model_config.embed_dim
+        )
+        total_bytes += inducing_elements * dtype.itemsize
+
+    # Fitted scaler stats: mean + std, each (n_features,). Always cached.
+    total_bytes += 2 * n_features * dtype.itemsize
 
     return ensemble_size * total_bytes
 

--- a/src/tabpfn/architectures/tabpfn_v3.py
+++ b/src/tabpfn/architectures/tabpfn_v3.py
@@ -317,13 +317,13 @@ def calculate_cache_size(
             each estimator runs its own forward and holds a separate cache, so
             the total scales linearly with this.
         dtype: The compute dtype (e.g. from autocast / ``inference_precision``).
+            On GPUs this is usually FP16, otherwise Float32.
             Sizes every term except the int8 KV cache when ``quantize_kv_cache``
             is True (the KV keys/values are then int8, their scales at ``dtype``).
         quantize_kv_cache: If True (default), the KV cache is sized at
             :data:`~tabpfn.architectures.kv_cache.QUANTIZED_KV_DTYPE` (mirrors
             the engine's ``maybe_quantize_kv_cache``) plus per-tensor scales; if
             False, the K/V are sized at ``dtype`` with no scales.
-            On GPUs this is usually FP16, otherwise Float32.
         include_decoder_activations: If True (default), add the classification
             ``train_embeddings`` term. Has no effect for regression configs,
             which do not use decoder activations.

--- a/src/tabpfn/architectures/tabpfn_v3.py
+++ b/src/tabpfn/architectures/tabpfn_v3.py
@@ -267,8 +267,7 @@ def estimate_cache_size(
 ) -> int:
     """Estimate the cached memory in bytes for a TabPFN v3 inference run.
 
-    Analytical counterpart of the (removed) ``TabPFNV3Cache.cache_size_mb``:
-    it works from shapes alone, so it can be called before fitting to size an
+    Works from shapes alone, so it can be called before fitting to size an
     inference run. Two terms are counted:
 
     1. The ICL transformer KV cache (always). Per layer it caches a key and a

--- a/tests/test_architectures/test_tabpfn_v3.py
+++ b/tests/test_architectures/test_tabpfn_v3.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import dataclasses
+
 import pytest
 import torch
 
@@ -14,7 +16,7 @@ from tabpfn.architectures.kv_cache import (
     KVCacheEntry,
     QuantizedKVCacheEntry,
 )
-from tabpfn.architectures.tabpfn_v3 import TabPFNV3Cache, estimate_cache_size
+from tabpfn.architectures.tabpfn_v3 import TabPFNV3Cache, calculate_cache_size
 
 
 def _get_model() -> tabpfn_v3.TabPFNV3:
@@ -528,17 +530,23 @@ def test__quantized_kv_cache__multiclass__close_to_standard_forward() -> None:
     )
 
 
-def _actual_cache_bytes(cache: TabPFNV3Cache, *, include_activations: bool) -> int:
-    """Sum the real byte size of a built cache's KV (and optional activations)."""
-    total = 0
-    for entry in cache.kv.values():
-        assert entry.key is not None
-        assert entry.value is not None
-        total += entry.key.numel() * entry.key.element_size()
-        total += entry.value.numel() * entry.value.element_size()
-    if include_activations and cache.train_embeddings is not None:
-        total += cache.train_embeddings.numel() * cache.train_embeddings.element_size()
-    return total
+def _sum_cache_tensors(obj: object) -> int:
+    """Recursively sum ``numel * element_size`` over every tensor in a cache.
+
+    Walks dataclasses / dicts / lists so a newly-added cached tensor field is
+    automatically included -- the completeness guard for ``calculate_cache_size``.
+    """
+    if isinstance(obj, torch.Tensor):
+        return obj.numel() * obj.element_size()
+    if isinstance(obj, dict):
+        return sum(_sum_cache_tensors(v) for v in obj.values())
+    if isinstance(obj, (list, tuple)):
+        return sum(_sum_cache_tensors(v) for v in obj)
+    if dataclasses.is_dataclass(obj):
+        return sum(
+            _sum_cache_tensors(getattr(obj, f.name)) for f in dataclasses.fields(obj)
+        )
+    return 0
 
 
 def _build_cache(
@@ -557,91 +565,90 @@ def _build_cache(
 
 @torch.no_grad()
 @pytest.mark.parametrize("quantize_kv_cache", [True, False])
-def test__estimate_cache_size__matches_actual_multiclass(
+def test__calculate_cache_size__matches_whole_classifier_cache(
     quantize_kv_cache: bool,
 ) -> None:
-    """Estimate matches a real multiclass cache, with the engine's quantization
-    step applied or not (default: quantized).
+    """calculate_cache_size (all terms on) equals the exact byte size of every
+    tensor in a real classifier cache -- KV (+ int8 scales), decoder activations,
+    inducing states, and scaler stats.
     """
     arch = _get_model()
     cfg = arch.config
-    n_train = 10
+    n_train, n_features = 10, 5
 
     torch.manual_seed(0)
-    x = torch.randn(20, 1, 5, dtype=torch.float32) * 0.1
+    x = torch.randn(20, 1, n_features, dtype=torch.float32) * 0.1
     y = torch.randint(0, 10, (n_train,), dtype=torch.float32)
     cache = _build_cache(arch, x, y, quantize_kv_cache=quantize_kv_cache)
-    x_train = torch.zeros(n_train, 5)
+    x_train = torch.zeros(n_train, n_features)
 
-    est_kv = estimate_cache_size(
+    total = calculate_cache_size(
         x_train,
         model_config=cfg,
         ensemble_size=1,
         dtype=torch.float32,
         quantize_kv_cache=quantize_kv_cache,
-        include_decoder_activations=False,
     )
-    est_all = estimate_cache_size(
-        x_train,
-        model_config=cfg,
-        ensemble_size=1,
-        dtype=torch.float32,
-        quantize_kv_cache=quantize_kv_cache,
-        include_decoder_activations=True,
+    # Exact: accounts for every tensor the real cache holds.
+    assert total == _sum_cache_tensors(cache)
+    # A (n_rows, n_features) tuple is accepted in place of an array.
+    assert (
+        calculate_cache_size(
+            (n_train, n_features),
+            model_config=cfg,
+            ensemble_size=1,
+            dtype=torch.float32,
+            quantize_kv_cache=quantize_kv_cache,
+        )
+        == total
     )
-
-    # _actual_cache_bytes counts K/V at their stored dtype (int8 when quantized,
-    # else float32) + float32 activations, ignoring the tiny per-tensor quant
-    # scales that the estimate also omits.
-    assert est_kv == _actual_cache_bytes(cache, include_activations=False)
-    assert est_all == _actual_cache_bytes(cache, include_activations=True)
-    # Activations must add something for a classifier.
-    assert est_all > est_kv
     # ensemble_size is a linear multiplier over the per-estimator cache.
-    est_ensemble = estimate_cache_size(
-        x_train,
-        model_config=cfg,
-        ensemble_size=3,
-        dtype=torch.float32,
-        quantize_kv_cache=quantize_kv_cache,
-        include_decoder_activations=True,
+    assert (
+        calculate_cache_size(
+            x_train,
+            model_config=cfg,
+            ensemble_size=3,
+            dtype=torch.float32,
+            quantize_kv_cache=quantize_kv_cache,
+        )
+        == 3 * total
     )
-    assert est_ensemble == 3 * est_all
 
 
 @torch.no_grad()
-def test__estimate_cache_size__regression_excludes_activations() -> None:
-    """Regression never caches decoder activations, even with the flag on."""
+def test__calculate_cache_size__regression_omits_unused_activations() -> None:
+    """Regression physically caches train_embeddings but never uses them, so
+    calculate_cache_size omits exactly that term (and the activations flag is a
+    no-op for regression).
+    """
     arch = _get_regression_model()
     cfg = arch.config
-    n_train = 10
+    n_train, n_features = 10, 5
 
     torch.manual_seed(0)
-    x = torch.randn(20, 1, 5, dtype=torch.float32)
+    x = torch.randn(20, 1, n_features, dtype=torch.float32)
     y = torch.randn(n_train, dtype=torch.float32)
-    # Engine default: build then quantize the KV cache.
     cache = _build_cache(arch, x, y, quantize_kv_cache=True)
-    x_train = torch.zeros(n_train, 5)
+    x_train = torch.zeros(n_train, n_features)
 
-    est_on = estimate_cache_size(
-        x_train,
-        model_config=cfg,
-        ensemble_size=1,
-        dtype=torch.float32,
-        include_decoder_activations=True,
+    total = calculate_cache_size(
+        x_train, model_config=cfg, ensemble_size=1, dtype=torch.float32
     )
-    est_off = estimate_cache_size(
+    # Activation flag is a no-op for regression.
+    assert total == calculate_cache_size(
         x_train,
         model_config=cfg,
         ensemble_size=1,
         dtype=torch.float32,
         include_decoder_activations=False,
     )
-    assert est_on == est_off  # flag is a no-op for regression
-    assert est_on == _actual_cache_bytes(cache, include_activations=False)
+    # Everything in the cache except the (unused) train_embeddings.
+    assert cache.train_embeddings is not None
+    dead = cache.train_embeddings.numel() * cache.train_embeddings.element_size()
+    assert total == _sum_cache_tensors(cache) - dead
 
 
-def test__estimate_cache_size__mqa_smaller_than_mha() -> None:
+def test__calculate_cache_size__mqa_smaller_than_mha() -> None:
     """Fewer cached KV heads (MQA on the test partition) shrinks the KV term."""
     common = {
         "max_num_classes": -1,
@@ -654,44 +661,51 @@ def test__estimate_cache_size__mqa_smaller_than_mha() -> None:
     }
     mha = tabpfn_v3.TabPFNV3Config(**common)  # H_kv = icl_num_heads = 4
     mqa = tabpfn_v3.TabPFNV3Config(**common, icl_num_kv_heads_test=1)  # H_kv = 1
-    x_train = torch.zeros(50, 5)
-    est_mha = estimate_cache_size(
-        x_train,
-        model_config=mha,
-        ensemble_size=1,
-        dtype=torch.int8,
-    )
-    est_mqa = estimate_cache_size(
-        x_train,
-        model_config=mqa,
-        ensemble_size=1,
-        dtype=torch.int8,
-    )
-    assert est_mqa * 4 == est_mha
+    n_train = 50
+    x_train = torch.zeros(n_train, 5)
+    kw = {"ensemble_size": 1, "dtype": torch.int8, "include_inducing_points": False}
+    est_mha = calculate_cache_size(x_train, model_config=mha, **kw)
+    est_mqa = calculate_cache_size(x_train, model_config=mqa, **kw)
+
+    # mha and mqa differ ONLY in the KV term (H_kv 4 vs 1); scales/scaler match.
+    icl_emsize = mha.embed_dim * mha.feat_agg_num_cls_tokens
+    head_dim = icl_emsize // mha.icl_num_heads
+    kv_per_head = mha.nlayers * 2 * n_train * head_dim  # int8 -> 1 byte
+    assert est_mqa < est_mha
+    assert est_mha - est_mqa == (4 - 1) * kv_per_head
 
 
 @pytest.mark.slow
-def test__estimate_cache_size__tabpfn3_classifier_1000_rows() -> None:
-    """Pin the KV-cache estimate for the real Prior-Labs/tabpfn_3 classifier at
-    1,000 train rows (1 estimator, engine defaults: int8 KV, fp16 activations).
+def test__calculate_cache_size__tabpfn3_classifier_1000_rows() -> None:
+    """Pin calculate_cache_size for the real Prior-Labs/tabpfn_3 classifier at
+    1,000 train rows (1 estimator, engine defaults: int8 KV, fp16 rest).
     """
     clf = TabPFNClassifier()
     # Loads the checkpoint (config + weights) without needing fit data.
     clf._initialize_model_variables()
     config = clf.model_.config
 
-    x_train = torch.zeros(1000, 1)
+    x_train = torch.zeros(1000, 1)  # n_features = 1
     common = {
         "model_config": config,
         "ensemble_size": 1,
         "dtype": torch.float16,
         "quantize_kv_cache": True,
+        # Inducing points off: their size depends on the shipped checkpoint's
+        # dist-embedder config, which we don't want to hardcode here.
+        "include_inducing_points": False,
     }
-    # KV int8: nlayers*2*H_kv*head_dim * N = 24*2*1*64 * 1000 = 3,072,000.
-    # + fp16 train_embeddings: icl_emsize * N * 2 = 512 * 1000 * 2 = 1,024,000.
-    kv_only = estimate_cache_size(x_train, include_decoder_activations=False, **common)
-    with_emb = estimate_cache_size(x_train, include_decoder_activations=True, **common)
+    # KV int8:            nlayers*2*H_kv*head_dim * N = 24*2*1*64 * 1000 = 3,072,000
+    # + int8 KV scales:   nlayers*2 * 2 bytes         = 24*2*2           =        96
+    # + scaler stats:     2 * n_features(1) * 2 bytes                    =         4
+    kv_and_scaler = calculate_cache_size(
+        x_train, include_decoder_activations=False, **common
+    )
+    # + fp16 train_embeddings: icl_emsize * N * 2 = 512 * 1000 * 2 = 1,024,000
+    with_activations = calculate_cache_size(
+        x_train, include_decoder_activations=True, **common
+    )
 
-    # Numbers need manual update if we bump the default architecture
-    assert kv_only == 3_072_000
-    assert with_emb == 4_096_000
+    # Numbers need manual update if we bump the default architecture.
+    assert kv_and_scaler == 3_072_100
+    assert with_activations == 4_096_100

--- a/tests/test_architectures/test_tabpfn_v3.py
+++ b/tests/test_architectures/test_tabpfn_v3.py
@@ -591,26 +591,16 @@ def test__calculate_cache_size__matches_whole_classifier_cache(
     x = (torch.randn(20, 1, n_features, dtype=torch.float32) * 0.1).to(dtype)
     y = torch.randint(0, 10, (n_train,), dtype=torch.float32).to(dtype)
     cache = _build_cache(arch, x, y, quantize_kv_cache=quantize_kv_cache)
-    x_train = torch.zeros(n_train, n_features)
 
     total = get_cache_size(
-        x_train,
+        n_train=n_train,
+        n_features=n_features,
         model_config=cfg,
         base_dtype=dtype,
         quantize_kv_cache=quantize_kv_cache,
     )
     # Exact: accounts for every tensor the real cache holds.
     assert total == _sum_cache_tensors(cache)
-    # A (n_rows, n_features) tuple is accepted in place of an array.
-    assert (
-        get_cache_size(
-            (n_train, n_features),
-            model_config=cfg,
-            base_dtype=dtype,
-            quantize_kv_cache=quantize_kv_cache,
-        )
-        == total
-    )
 
 
 @torch.no_grad()
@@ -648,10 +638,10 @@ def test__calculate_cache_size__matches_whole_classifier_cache_autocast(
         _, cache = arch(x, y, return_kv_cache=True)
     if quantize_kv_cache:
         cache = cache.quantize()
-    x_train = torch.zeros(n_train, n_features)
 
     total = get_cache_size(
-        x_train,
+        n_train=n_train,
+        n_features=n_features,
         model_config=cfg,
         # "autocast": KV/train_embeddings sized at fp16, inducing/scaler at fp32.
         base_dtype="autocast",
@@ -682,9 +672,10 @@ def test__calculate_cache_size__matches_whole_regression_cache(
     x = torch.randn(20, 1, n_features, dtype=torch.float32).to(dtype)
     y = torch.randn(n_train, dtype=torch.float32).to(dtype)
     cache = _build_cache(arch, x, y, quantize_kv_cache=True)
-    x_train = torch.zeros(n_train, n_features)
 
-    total = get_cache_size(x_train, model_config=cfg, base_dtype=dtype)
+    total = get_cache_size(
+        n_train=n_train, n_features=n_features, model_config=cfg, base_dtype=dtype
+    )
     assert total == _sum_cache_tensors(cache)
 
 
@@ -702,12 +693,11 @@ def test__calculate_cache_size__mqa_smaller_than_mha() -> None:
     mha = tabpfn_v3.TabPFNV3Config(**common)  # H_kv = icl_num_heads = 4
     mqa = tabpfn_v3.TabPFNV3Config(**common, icl_num_kv_heads_test=1)  # H_kv = 1
     n_train = 50
-    x_train = torch.zeros(n_train, 5)
     # quantize_kv_cache defaults to True, so the KV cache is int8 (1 byte)
     # regardless of base_dtype; base_dtype only sizes the (cancelling) non-KV terms.
-    kw = {"base_dtype": torch.float32}
-    est_mha = get_cache_size(x_train, model_config=mha, **kw)
-    est_mqa = get_cache_size(x_train, model_config=mqa, **kw)
+    kw = {"n_train": n_train, "n_features": 5, "base_dtype": torch.float32}
+    est_mha = get_cache_size(model_config=mha, **kw)
+    est_mqa = get_cache_size(model_config=mqa, **kw)
 
     # mha and mqa differ ONLY in the KV term (H_kv 4 vs 1); every other term
     # (activations, inducing, scaler) is identical, so it cancels in the diff.
@@ -728,8 +718,9 @@ def test__calculate_cache_size__tabpfn3_classifier_1000_rows() -> None:
     clf._initialize_model_variables()
     config = clf.model_.config
 
-    x_train = torch.zeros(1000, 1)  # n_features = 1
     common = {
+        "n_train": 1000,
+        "n_features": 1,
         "model_config": config,
         "base_dtype": torch.float16,
         "quantize_kv_cache": True,
@@ -749,7 +740,7 @@ def test__calculate_cache_size__tabpfn3_classifier_1000_rows() -> None:
         * config.embed_dim
     ) * torch.float16.itemsize
 
-    total = get_cache_size(x_train, **common)
+    total = get_cache_size(**common)
 
     # Numbers need manual update if we bump the default architecture.
     assert total == 3_072_000 + 96 + 4 + 1_024_000 + inducing

--- a/tests/test_architectures/test_tabpfn_v3.py
+++ b/tests/test_architectures/test_tabpfn_v3.py
@@ -17,6 +17,7 @@ from tabpfn.architectures.kv_cache import (
     QuantizedKVCacheEntry,
 )
 from tabpfn.architectures.tabpfn_v3 import TabPFNV3Cache, get_cache_size
+from tabpfn.utils import get_autocast_context
 
 
 def _get_model() -> tabpfn_v3.TabPFNV3:
@@ -564,28 +565,38 @@ def _build_cache(
 
 
 @torch.no_grad()
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
 @pytest.mark.parametrize("quantize_kv_cache", [True, False])
 def test__calculate_cache_size__matches_whole_classifier_cache(
     quantize_kv_cache: bool,
+    dtype: torch.dtype,
 ) -> None:
-    """calculate_cache_size (all terms on) equals the exact byte size of every
-    tensor in a real classifier cache -- KV (+ int8 scales), decoder activations,
-    inducing states, and scaler stats.
+    """get_cache_size equals the exact byte size of every tensor in a real
+    classifier cache -- KV (+ int8 scales), decoder activations, inducing states,
+    and scaler stats.
+
+    Parametrized over ``dtype`` to cover the engine's forced-precision path
+    (``inference_precision`` set to a ``torch.dtype``): the engine casts the model
+    (``set_dtype`` -> ``model.type``) and inputs to that dtype and runs the forward
+    with autocast disabled, so every non-KV term lands at that one dtype -- exactly
+    what get_cache_size models. (The autocast default is a separate, mixed-dtype
+    path this exact-equality check does not cover.)
     """
     arch = _get_model()
+    arch.type(dtype)  # mirror the engine's set_dtype for forced precision.
     cfg = arch.config
     n_train, n_features = 10, 5
 
     torch.manual_seed(0)
-    x = torch.randn(20, 1, n_features, dtype=torch.float32) * 0.1
-    y = torch.randint(0, 10, (n_train,), dtype=torch.float32)
+    x = (torch.randn(20, 1, n_features, dtype=torch.float32) * 0.1).to(dtype)
+    y = torch.randint(0, 10, (n_train,), dtype=torch.float32).to(dtype)
     cache = _build_cache(arch, x, y, quantize_kv_cache=quantize_kv_cache)
     x_train = torch.zeros(n_train, n_features)
 
     total = get_cache_size(
         x_train,
         model_config=cfg,
-        dtype=torch.float32,
+        dtype=dtype,
         quantize_kv_cache=quantize_kv_cache,
     )
     # Exact: accounts for every tensor the real cache holds.
@@ -595,7 +606,7 @@ def test__calculate_cache_size__matches_whole_classifier_cache(
         get_cache_size(
             (n_train, n_features),
             model_config=cfg,
-            dtype=torch.float32,
+            dtype=dtype,
             quantize_kv_cache=quantize_kv_cache,
         )
         == total
@@ -603,9 +614,59 @@ def test__calculate_cache_size__matches_whole_classifier_cache(
 
 
 @torch.no_grad()
-def test__calculate_cache_size__matches_whole_regression_cache() -> None:
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="Autocast inference is only enabled on CUDA (disabled on CPU/MPS), so "
+    "the mixed-precision cache it produces can only be built on a GPU.",
+)
+@pytest.mark.parametrize("quantize_kv_cache", [True, False])
+def test__calculate_cache_size__matches_whole_classifier_cache_autocast(
+    quantize_kv_cache: bool,
+) -> None:
+    """get_cache_size matches the exact byte size of a real classifier cache built
+    on the GPU autocast path (the default for ``inference_precision='auto'`` on a
+    GPU).
+
+    Unlike the forced-precision path, autocast keeps fp32 model weights and casts
+    ops at runtime -- matmul-lineage tensors (KV, and ``train_embeddings`` via its
+    explicit cast to the KV dtype) become the 2-byte compute dtype, while
+    reduction/norm-lineage tensors (``inducing_hidden``, ``scaler_cache``) stay
+    fp32. ``get_cache_size(autocast=True)`` must size each term at its real
+    precision and still match to the byte.
+    """
+    device = torch.device("cuda")
+    # fp32 weights: autocast casts individual ops at runtime, it does not force a
+    # model dtype (mirrors force_inference_dtype=None on the autocast path).
+    arch = _get_model().to(device)
+    cfg = arch.config
+    n_train, n_features = 10, 5
+
+    torch.manual_seed(0)
+    x = torch.randn(20, 1, n_features, dtype=torch.float32, device=device) * 0.1
+    y = torch.randint(0, 10, (n_train,), dtype=torch.float32, device=device)
+    with get_autocast_context(device, enabled=True):
+        _, cache = arch(x, y, return_kv_cache=True)
+    if quantize_kv_cache:
+        cache = cache.quantize()
+    x_train = torch.zeros(n_train, n_features)
+
+    total = get_cache_size(
+        x_train,
+        model_config=cfg,
+        # CUDA autocast computes in fp16 (2-byte); inducing/scaler remain fp32.
+        dtype=torch.float16,
+        quantize_kv_cache=quantize_kv_cache,
+    )
+    assert total == _sum_cache_tensors(cache)
+
+
+@torch.no_grad()
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
+def test__calculate_cache_size__matches_whole_regression_cache(
+    dtype: torch.dtype,
+) -> None:
     """get_cache_size equals the exact byte size of every tensor in a real
-    regression cache.
+    regression cache, across the engine's forced-precision dtypes.
 
     Regression currently *stores* train_embeddings even though it never uses
     them, so counting the full physical cache is correct today. If a future
@@ -613,16 +674,17 @@ def test__calculate_cache_size__matches_whole_regression_cache() -> None:
     -- signalling that get_cache_size should then drop that term for regression.
     """
     arch = _get_regression_model()
+    arch.type(dtype)  # mirror the engine's set_dtype for forced precision.
     cfg = arch.config
     n_train, n_features = 10, 5
 
     torch.manual_seed(0)
-    x = torch.randn(20, 1, n_features, dtype=torch.float32)
-    y = torch.randn(n_train, dtype=torch.float32)
+    x = torch.randn(20, 1, n_features, dtype=torch.float32).to(dtype)
+    y = torch.randn(n_train, dtype=torch.float32).to(dtype)
     cache = _build_cache(arch, x, y, quantize_kv_cache=True)
     x_train = torch.zeros(n_train, n_features)
 
-    total = get_cache_size(x_train, model_config=cfg, dtype=torch.float32)
+    total = get_cache_size(x_train, model_config=cfg, dtype=dtype)
     assert total == _sum_cache_tensors(cache)
 
 

--- a/tests/test_architectures/test_tabpfn_v3.py
+++ b/tests/test_architectures/test_tabpfn_v3.py
@@ -596,7 +596,7 @@ def test__calculate_cache_size__matches_whole_classifier_cache(
     total = get_cache_size(
         x_train,
         model_config=cfg,
-        dtype=dtype,
+        base_dtype=dtype,
         quantize_kv_cache=quantize_kv_cache,
     )
     # Exact: accounts for every tensor the real cache holds.
@@ -606,7 +606,7 @@ def test__calculate_cache_size__matches_whole_classifier_cache(
         get_cache_size(
             (n_train, n_features),
             model_config=cfg,
-            dtype=dtype,
+            base_dtype=dtype,
             quantize_kv_cache=quantize_kv_cache,
         )
         == total
@@ -654,7 +654,7 @@ def test__calculate_cache_size__matches_whole_classifier_cache_autocast(
         x_train,
         model_config=cfg,
         # "autocast": KV/train_embeddings sized at fp16, inducing/scaler at fp32.
-        dtype="autocast",
+        base_dtype="autocast",
         quantize_kv_cache=quantize_kv_cache,
     )
     assert total == _sum_cache_tensors(cache)
@@ -684,7 +684,7 @@ def test__calculate_cache_size__matches_whole_regression_cache(
     cache = _build_cache(arch, x, y, quantize_kv_cache=True)
     x_train = torch.zeros(n_train, n_features)
 
-    total = get_cache_size(x_train, model_config=cfg, dtype=dtype)
+    total = get_cache_size(x_train, model_config=cfg, base_dtype=dtype)
     assert total == _sum_cache_tensors(cache)
 
 
@@ -703,7 +703,9 @@ def test__calculate_cache_size__mqa_smaller_than_mha() -> None:
     mqa = tabpfn_v3.TabPFNV3Config(**common, icl_num_kv_heads_test=1)  # H_kv = 1
     n_train = 50
     x_train = torch.zeros(n_train, 5)
-    kw = {"dtype": torch.int8}
+    # quantize_kv_cache defaults to True, so the KV cache is int8 (1 byte)
+    # regardless of base_dtype; base_dtype only sizes the (cancelling) non-KV terms.
+    kw = {"base_dtype": torch.float32}
     est_mha = get_cache_size(x_train, model_config=mha, **kw)
     est_mqa = get_cache_size(x_train, model_config=mqa, **kw)
 
@@ -711,7 +713,7 @@ def test__calculate_cache_size__mqa_smaller_than_mha() -> None:
     # (activations, inducing, scaler) is identical, so it cancels in the diff.
     icl_emsize = mha.embed_dim * mha.feat_agg_num_cls_tokens
     head_dim = icl_emsize // mha.icl_num_heads
-    kv_per_head = mha.nlayers * 2 * n_train * head_dim  # int8 -> 1 byte
+    kv_per_head = mha.nlayers * 2 * n_train * head_dim  # int8 KV -> 1 byte/element
     assert est_mqa < est_mha
     assert est_mha - est_mqa == (4 - 1) * kv_per_head
 
@@ -729,7 +731,7 @@ def test__calculate_cache_size__tabpfn3_classifier_1000_rows() -> None:
     x_train = torch.zeros(1000, 1)  # n_features = 1
     common = {
         "model_config": config,
-        "dtype": torch.float16,
+        "base_dtype": torch.float16,
         "quantize_kv_cache": True,
     }
     # get_cache_size always sums the full cache. Fixed terms (n_features = 1):

--- a/tests/test_architectures/test_tabpfn_v3.py
+++ b/tests/test_architectures/test_tabpfn_v3.py
@@ -16,7 +16,7 @@ from tabpfn.architectures.kv_cache import (
     KVCacheEntry,
     QuantizedKVCacheEntry,
 )
-from tabpfn.architectures.tabpfn_v3 import TabPFNV3Cache, calculate_cache_size
+from tabpfn.architectures.tabpfn_v3 import TabPFNV3Cache, get_cache_size
 
 
 def _get_model() -> tabpfn_v3.TabPFNV3:
@@ -582,10 +582,9 @@ def test__calculate_cache_size__matches_whole_classifier_cache(
     cache = _build_cache(arch, x, y, quantize_kv_cache=quantize_kv_cache)
     x_train = torch.zeros(n_train, n_features)
 
-    total = calculate_cache_size(
+    total = get_cache_size(
         x_train,
         model_config=cfg,
-        ensemble_size=1,
         dtype=torch.float32,
         quantize_kv_cache=quantize_kv_cache,
     )
@@ -593,33 +592,25 @@ def test__calculate_cache_size__matches_whole_classifier_cache(
     assert total == _sum_cache_tensors(cache)
     # A (n_rows, n_features) tuple is accepted in place of an array.
     assert (
-        calculate_cache_size(
+        get_cache_size(
             (n_train, n_features),
             model_config=cfg,
-            ensemble_size=1,
             dtype=torch.float32,
             quantize_kv_cache=quantize_kv_cache,
         )
         == total
     )
-    # ensemble_size is a linear multiplier over the per-estimator cache.
-    assert (
-        calculate_cache_size(
-            x_train,
-            model_config=cfg,
-            ensemble_size=3,
-            dtype=torch.float32,
-            quantize_kv_cache=quantize_kv_cache,
-        )
-        == 3 * total
-    )
 
 
 @torch.no_grad()
-def test__calculate_cache_size__regression_omits_unused_activations() -> None:
-    """Regression physically caches train_embeddings but never uses them, so
-    calculate_cache_size omits exactly that term (and the activations flag is a
-    no-op for regression).
+def test__calculate_cache_size__matches_whole_regression_cache() -> None:
+    """get_cache_size equals the exact byte size of every tensor in a real
+    regression cache.
+
+    Regression currently *stores* train_embeddings even though it never uses
+    them, so counting the full physical cache is correct today. If a future
+    change stops caching those for regression, this exact-equality assert breaks
+    -- signalling that get_cache_size should then drop that term for regression.
     """
     arch = _get_regression_model()
     cfg = arch.config
@@ -631,21 +622,8 @@ def test__calculate_cache_size__regression_omits_unused_activations() -> None:
     cache = _build_cache(arch, x, y, quantize_kv_cache=True)
     x_train = torch.zeros(n_train, n_features)
 
-    total = calculate_cache_size(
-        x_train, model_config=cfg, ensemble_size=1, dtype=torch.float32
-    )
-    # Activation flag is a no-op for regression.
-    assert total == calculate_cache_size(
-        x_train,
-        model_config=cfg,
-        ensemble_size=1,
-        dtype=torch.float32,
-        include_decoder_activations=False,
-    )
-    # Everything in the cache except the (unused) train_embeddings.
-    assert cache.train_embeddings is not None
-    dead = cache.train_embeddings.numel() * cache.train_embeddings.element_size()
-    assert total == _sum_cache_tensors(cache) - dead
+    total = get_cache_size(x_train, model_config=cfg, dtype=torch.float32)
+    assert total == _sum_cache_tensors(cache)
 
 
 def test__calculate_cache_size__mqa_smaller_than_mha() -> None:
@@ -663,11 +641,12 @@ def test__calculate_cache_size__mqa_smaller_than_mha() -> None:
     mqa = tabpfn_v3.TabPFNV3Config(**common, icl_num_kv_heads_test=1)  # H_kv = 1
     n_train = 50
     x_train = torch.zeros(n_train, 5)
-    kw = {"ensemble_size": 1, "dtype": torch.int8, "include_inducing_points": False}
-    est_mha = calculate_cache_size(x_train, model_config=mha, **kw)
-    est_mqa = calculate_cache_size(x_train, model_config=mqa, **kw)
+    kw = {"dtype": torch.int8}
+    est_mha = get_cache_size(x_train, model_config=mha, **kw)
+    est_mqa = get_cache_size(x_train, model_config=mqa, **kw)
 
-    # mha and mqa differ ONLY in the KV term (H_kv 4 vs 1); scales/scaler match.
+    # mha and mqa differ ONLY in the KV term (H_kv 4 vs 1); every other term
+    # (activations, inducing, scaler) is identical, so it cancels in the diff.
     icl_emsize = mha.embed_dim * mha.feat_agg_num_cls_tokens
     head_dim = icl_emsize // mha.icl_num_heads
     kv_per_head = mha.nlayers * 2 * n_train * head_dim  # int8 -> 1 byte
@@ -688,24 +667,25 @@ def test__calculate_cache_size__tabpfn3_classifier_1000_rows() -> None:
     x_train = torch.zeros(1000, 1)  # n_features = 1
     common = {
         "model_config": config,
-        "ensemble_size": 1,
         "dtype": torch.float16,
         "quantize_kv_cache": True,
-        # Inducing points off: their size depends on the shipped checkpoint's
-        # dist-embedder config, which we don't want to hardcode here.
-        "include_inducing_points": False,
     }
-    # KV int8:            nlayers*2*H_kv*head_dim * N = 24*2*1*64 * 1000 = 3,072,000
-    # + int8 KV scales:   nlayers*2 * 2 bytes         = 24*2*2           =        96
-    # + scaler stats:     2 * n_features(1) * 2 bytes                    =         4
-    kv_and_scaler = calculate_cache_size(
-        x_train, include_decoder_activations=False, **common
-    )
-    # + fp16 train_embeddings: icl_emsize * N * 2 = 512 * 1000 * 2 = 1,024,000
-    with_activations = calculate_cache_size(
-        x_train, include_decoder_activations=True, **common
-    )
+    # get_cache_size always sums the full cache. Fixed terms (n_features = 1):
+    #   KV int8:            nlayers*2*H_kv*head_dim * N = 24*2*1*64 * 1000 = 3,072,000
+    #   + int8 KV scales:   nlayers*2 * 2 bytes         = 24*2*2           =        96
+    #   + scaler stats:     2 * n_features(1) * 2 bytes                    =         4
+    #   + fp16 activations: icl_emsize * N * 2 = 512 * 1000 * 2            = 1,024,000
+    # The inducing term depends on the shipped dist-embedder config, so derive it
+    # from the config instead of hardcoding it.
+    n_features = 1
+    inducing = (
+        config.dist_embed_num_blocks
+        * n_features
+        * config.dist_embed_num_inducing_points
+        * config.embed_dim
+    ) * torch.float16.itemsize
+
+    total = get_cache_size(x_train, **common)
 
     # Numbers need manual update if we bump the default architecture.
-    assert kv_and_scaler == 3_072_100
-    assert with_activations == 4_096_100
+    assert total == 3_072_000 + 96 + 4 + 1_024_000 + inducing

--- a/tests/test_architectures/test_tabpfn_v3.py
+++ b/tests/test_architectures/test_tabpfn_v3.py
@@ -631,7 +631,7 @@ def test__calculate_cache_size__matches_whole_classifier_cache_autocast(
     ops at runtime -- matmul-lineage tensors (KV, and ``train_embeddings`` via its
     explicit cast to the KV dtype) become the 2-byte compute dtype, while
     reduction/norm-lineage tensors (``inducing_hidden``, ``scaler_cache``) stay
-    fp32. ``get_cache_size(autocast=True)`` must size each term at its real
+    fp32. ``get_cache_size(dtype="autocast")`` must size each term at its real
     precision and still match to the byte.
     """
     device = torch.device("cuda")
@@ -653,8 +653,8 @@ def test__calculate_cache_size__matches_whole_classifier_cache_autocast(
     total = get_cache_size(
         x_train,
         model_config=cfg,
-        # CUDA autocast computes in fp16 (2-byte); inducing/scaler remain fp32.
-        dtype=torch.float16,
+        # "autocast": KV/train_embeddings sized at fp16, inducing/scaler at fp32.
+        dtype="autocast",
         quantize_kv_cache=quantize_kv_cache,
     )
     assert total == _sum_cache_tensors(cache)

--- a/tests/test_architectures/test_tabpfn_v3.py
+++ b/tests/test_architectures/test_tabpfn_v3.py
@@ -7,13 +7,14 @@ from __future__ import annotations
 import pytest
 import torch
 
+from tabpfn import TabPFNClassifier
 from tabpfn.architectures import tabpfn_v3
 from tabpfn.architectures.interface import PerformanceOptions
 from tabpfn.architectures.kv_cache import (
     KVCacheEntry,
     QuantizedKVCacheEntry,
 )
-from tabpfn.architectures.tabpfn_v3 import TabPFNV3Cache
+from tabpfn.architectures.tabpfn_v3 import TabPFNV3Cache, estimate_cache_size
 
 
 def _get_model() -> tabpfn_v3.TabPFNV3:
@@ -525,3 +526,172 @@ def test__quantized_kv_cache__multiclass__close_to_standard_forward() -> None:
         f"Quantized multiclass cache output too far from non-quantized cached "
         f"(max diff: {(out_cached - out_quantized).abs().max().item():.2e})"
     )
+
+
+def _actual_cache_bytes(cache: TabPFNV3Cache, *, include_activations: bool) -> int:
+    """Sum the real byte size of a built cache's KV (and optional activations)."""
+    total = 0
+    for entry in cache.kv.values():
+        assert entry.key is not None
+        assert entry.value is not None
+        total += entry.key.numel() * entry.key.element_size()
+        total += entry.value.numel() * entry.value.element_size()
+    if include_activations and cache.train_embeddings is not None:
+        total += cache.train_embeddings.numel() * cache.train_embeddings.element_size()
+    return total
+
+
+def _build_cache(
+    arch: tabpfn_v3.TabPFNV3,
+    x: torch.Tensor,
+    y: torch.Tensor,
+    *,
+    quantize_kv_cache: bool,
+) -> TabPFNV3Cache:
+    """Build a cache the way the inference engine does: forward to populate it,
+    then apply the ``maybe_quantize_kv_cache`` step (``cache.quantize()``).
+    """
+    _, cache = arch(x, y, return_kv_cache=True)
+    return cache.quantize() if quantize_kv_cache else cache
+
+
+@torch.no_grad()
+@pytest.mark.parametrize("quantize_kv_cache", [True, False])
+def test__estimate_cache_size__matches_actual_multiclass(
+    quantize_kv_cache: bool,
+) -> None:
+    """Estimate matches a real multiclass cache, with the engine's quantization
+    step applied or not (default: quantized).
+    """
+    arch = _get_model()
+    cfg = arch.config
+    n_train = 10
+
+    torch.manual_seed(0)
+    x = torch.randn(20, 1, 5, dtype=torch.float32) * 0.1
+    y = torch.randint(0, 10, (n_train,), dtype=torch.float32)
+    cache = _build_cache(arch, x, y, quantize_kv_cache=quantize_kv_cache)
+    x_train = torch.zeros(n_train, 5)
+
+    est_kv = estimate_cache_size(
+        x_train,
+        model_config=cfg,
+        ensemble_size=1,
+        dtype=torch.float32,
+        quantize_kv_cache=quantize_kv_cache,
+        include_decoder_activations=False,
+    )
+    est_all = estimate_cache_size(
+        x_train,
+        model_config=cfg,
+        ensemble_size=1,
+        dtype=torch.float32,
+        quantize_kv_cache=quantize_kv_cache,
+        include_decoder_activations=True,
+    )
+
+    # _actual_cache_bytes counts K/V at their stored dtype (int8 when quantized,
+    # else float32) + float32 activations, ignoring the tiny per-tensor quant
+    # scales that the estimate also omits.
+    assert est_kv == _actual_cache_bytes(cache, include_activations=False)
+    assert est_all == _actual_cache_bytes(cache, include_activations=True)
+    # Activations must add something for a classifier.
+    assert est_all > est_kv
+    # ensemble_size is a linear multiplier over the per-estimator cache.
+    est_ensemble = estimate_cache_size(
+        x_train,
+        model_config=cfg,
+        ensemble_size=3,
+        dtype=torch.float32,
+        quantize_kv_cache=quantize_kv_cache,
+        include_decoder_activations=True,
+    )
+    assert est_ensemble == 3 * est_all
+
+
+@torch.no_grad()
+def test__estimate_cache_size__regression_excludes_activations() -> None:
+    """Regression never caches decoder activations, even with the flag on."""
+    arch = _get_regression_model()
+    cfg = arch.config
+    n_train = 10
+
+    torch.manual_seed(0)
+    x = torch.randn(20, 1, 5, dtype=torch.float32)
+    y = torch.randn(n_train, dtype=torch.float32)
+    # Engine default: build then quantize the KV cache.
+    cache = _build_cache(arch, x, y, quantize_kv_cache=True)
+    x_train = torch.zeros(n_train, 5)
+
+    est_on = estimate_cache_size(
+        x_train,
+        model_config=cfg,
+        ensemble_size=1,
+        dtype=torch.float32,
+        include_decoder_activations=True,
+    )
+    est_off = estimate_cache_size(
+        x_train,
+        model_config=cfg,
+        ensemble_size=1,
+        dtype=torch.float32,
+        include_decoder_activations=False,
+    )
+    assert est_on == est_off  # flag is a no-op for regression
+    assert est_on == _actual_cache_bytes(cache, include_activations=False)
+
+
+def test__estimate_cache_size__mqa_smaller_than_mha() -> None:
+    """Fewer cached KV heads (MQA on the test partition) shrinks the KV term."""
+    common = {
+        "max_num_classes": -1,
+        "num_buckets": 5,
+        "embed_dim": 48,
+        "nlayers": 1,
+        "icl_num_heads": 4,
+        "dist_embed_num_heads": 4,
+        "feat_agg_num_heads": 4,
+    }
+    mha = tabpfn_v3.TabPFNV3Config(**common)  # H_kv = icl_num_heads = 4
+    mqa = tabpfn_v3.TabPFNV3Config(**common, icl_num_kv_heads_test=1)  # H_kv = 1
+    x_train = torch.zeros(50, 5)
+    est_mha = estimate_cache_size(
+        x_train,
+        model_config=mha,
+        ensemble_size=1,
+        dtype=torch.int8,
+    )
+    est_mqa = estimate_cache_size(
+        x_train,
+        model_config=mqa,
+        ensemble_size=1,
+        dtype=torch.int8,
+    )
+    assert est_mqa * 4 == est_mha
+
+
+@pytest.mark.slow
+def test__estimate_cache_size__tabpfn3_classifier_1000_rows() -> None:
+    """Pin the KV-cache estimate for the real Prior-Labs/tabpfn_3 classifier at
+    1,000 train rows (1 estimator, engine defaults: int8 KV, fp16 activations).
+    """
+    clf = TabPFNClassifier()
+    # Loads the checkpoint (config + weights) without needing fit data.
+    clf._initialize_model_variables()
+    config = clf.model_.config
+
+    x_train = torch.zeros(1000, 1)
+    common = {
+        "model_config": config,
+        "ensemble_size": 1,
+        "dtype": torch.float16,
+        "quantize_kv_cache": True,
+    }
+    # KV int8: nlayers*2*H_kv*head_dim * N = 24*2*1*64 * 1000 = 3,072,000.
+    # + fp16 train_embeddings: icl_emsize * N * 2 = 512 * 1000 * 2 = 1,024,000.
+    kv_only = estimate_cache_size(x_train, include_decoder_activations=False, **common)
+    with_emb = estimate_cache_size(x_train, include_decoder_activations=True, **common)
+
+    # Numbers need manual update if we bump the default architecture
+    assert kv_only == 3_072_000
+    assert with_emb == 4_096_000


### PR DESCRIPTION
## Issue

This fixes issue PriorLabs/TabPFN#1086 <br>Fixes PriorLabs/TabPFN#1086

## Motivation and Context

When analyzing the size of the Cache it is good to have a theoretical model to query without having to really build the cache

---

## Public API Changes

- [X] No Public API changes
- [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?

Added unit tests that compare the estimate with the actual cache size. Also for TabPFNv3 we test actual numbers we computed ourselves.

---

## Checklist

- [X] The changes have been tested locally.
- [ ] Documentation has been updated (if the public API or usage changes).
- [X] A changelog entry has been added (see `changelog/README.md`), or "no changelog needed" label requested.
- [X] The code follows the project's style guidelines.
- [X] I have considered the impact of these changes on the public API.

---