### PR TITLE
Fix the workflow for assigning PRs from external collaborators.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,3 @@
-* @PriorLabs/opensource-review-team
-
 # Release automation – only release maintainers can modify these workflows
 .github/workflows/release-create-pr.yml  @PriorLabs/release-maintainers
 .github/workflows/release-tag-on-merge.yml       @PriorLabs/release-maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,3 +9,7 @@
 # supply-chain surface meaningfully.
 .github/workflows/claude.yml             @PriorLabs/release-maintainers
 .github/workflows/claude-code-review.yml @PriorLabs/release-maintainers
+
+# This file contains the list of people who will be automatically assigned as reviewers
+# for external PRs.
+.github/pr-reviewers.txt                 @PriorLabs/release-maintainers

--- a/.github/pr-reviewers.txt
+++ b/.github/pr-reviewers.txt
@@ -1,0 +1,11 @@
+oscarkey
+TuanaCelik
+bejaeger
+anuragg1209
+klemens-floege
+priorphil
+adrian-prior
+psinger-prior
+alanprior
+eliott-kalfon
+arthur-priorlabs

--- a/.github/workflows/assign-pr-reviewer.yml
+++ b/.github/workflows/assign-pr-reviewer.yml
@@ -1,9 +1,13 @@
-# When a PR is opened from a fork or by dependabot, request a review from the
-# opensource-review-team so a reviewer is randomly assigned.
+# When a PR is opened from a fork or by dependabot, request a review from a randomly
+# chosen reviewer so the PR gets picked up.
 #
 # We use this workflow instead of GitHub's built-in auto-assignment system because we
 # want to avoid auto assigning reviewers to PRs from Prior Labs team members, and GitHub
 # does not support this.
+#
+# The list of eligible reviewers lives in .github/pr-reviewers.txt (one username per
+# line). Using this rather than a GitHub team avoids needing a PAT to access the
+# organisation.
 #
 # UNDER NO CIRCUMSTANCES MAY ACTIONS/CHECKOUT BE ADDED TO THIS WORKFLOW. IT INTRODUCES
 # A CRITICAL SECURITY HOLE. DO NOT REMOVE THIS WARNING!
@@ -16,10 +20,8 @@ on:
   # This is safe, as we do not check out any code. See
   # https://docs.github.com/en/enterprise-cloud@latest/actions/reference/security/secure-use#mitigating-the-risks-of-untrusted-code-checkout
   # DO NOT ADD ACTIONS/CHECKOUT TO THIS WORKFLOW.
-  # pull_request_target:
-  #   types: [opened, reopened, ready_for_review]
-  # Disable the workflow while we fix it.
-  workflow_dispatch:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
 
 permissions:
   pull-requests: write
@@ -39,12 +41,33 @@ jobs:
       )
     runs-on: ubuntu-slim
     steps:
-      - name: Request review from opensource-review-team
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          gh api \
-            --method POST \
-            "repos/${{ github.repository }}/pulls/$PR_NUMBER/requested_reviewers" \
-            -f 'team_reviewers[]=opensource-review-team'
+      - name: Request review from a random reviewer
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            // Read the reviewer list from the main branch, never from the PR head, so a
+            // fork cannot swap in an attacker-controlled list via pull_request_target.
+            const url = "https://raw.githubusercontent.com/PriorLabs/TabPFN/main/.github/pr-reviewers.txt";
+            const response = await fetch(url);
+            if (!response.ok) {
+              throw new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`);
+            }
+
+            const reviewers = (await response.text())
+              .split("\n")
+              .map((line) => line.trim())
+              .filter(Boolean);
+
+            if (reviewers.length === 0) {
+              throw new Error("pr-reviewers.txt is empty; cannot assign a reviewer.");
+            }
+
+            const reviewer = reviewers[Math.floor(Math.random() * reviewers.length)];
+            core.info(`Requesting review from ${reviewer}`);
+
+            await github.rest.pulls.requestReviewers({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              reviewers: [reviewer],
+            });


### PR DESCRIPTION
The existing workflow doesn't work (and is disabled) because it needs a PAT to access the Open Source Review team inside the organisation, in order to assign to it. To avoid the PAT, instead just put a list of reviewers in a text file in this repository, and select one at random. We can re-use this workflow and list in other repositories, incl. tabpfn-extensions.

Remove the team from CODEOWNERS to disable GitHub's auto assignment. Write access to the repo is still restricted to Prior Labs people by the repo collaborator settings.

Security things considered:
- Directly fetch the reviewer list txt using a hardcoded url to main, to avoid accidentally fetching the wrong thing
- Use github-script rather than bash, to avoid manually building a "gh api" command to request the reviewer
- We could still be in trouble if github.rest.pulls.requestReviewers isn't injection proof, and someone sneaks a command onto our main branch. Let me know what you think. Note this workflow runs under pull_request_target.
