### PR TITLE
Fix MacOS test flakes by releasing cached MPS memory between tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,9 @@
 
 from __future__ import annotations
 
+import gc
 import random
+from collections.abc import Generator
 
 import numpy as np
 import pytest
@@ -17,3 +19,19 @@ def set_global_seed() -> None:
     torch.manual_seed(seed)
     np.random.seed(seed)  # noqa: NPY002
     random.seed(seed)
+
+
+@pytest.fixture(autouse=True)
+def release_mps_memory() -> Generator[None]:
+    """Release cached MPS memory after each test.
+
+    PyTorch's MPS caching allocator holds freed memory for the lifetime of the
+    process. On the ~7GB macos-latest CI runners the cache accumulates across
+    tests until the ~3.3 GiB MPS limit is hit and unrelated tests OOM.
+    gc.collect() first so tensors kept alive by reference cycles (e.g.
+    unittest.mock call records) are actually freed before emptying the cache.
+    """
+    yield
+    if torch.backends.mps.is_available():
+        gc.collect()
+        torch.mps.empty_cache()


### PR DESCRIPTION
## Issue
Please link the corresponding GitHub issue. If an issue does not already exist,
please open one to describe the bug or feature request before creating a pull request.

This allows us to discuss the proposal and helps avoid unnecessary work.

## Motivation and Context


PyTorch's MPS caching allocator holds freed memory for the process lifetime. On ~7GB macos-latest runners the cache accumulates across tests (finetuning tests move ~1GB of model weights, optimizer state, and eval clones through MPS per parametrization) until the ~3.3 GiB limit is hit and unrelated tests OOM on KiB-sized allocations. Add an autouse fixture running gc.collect() + torch.mps.empty_cache() after each test; the gc pass is needed because autospec'd mocks keep MPS tensors alive in reference cycles. Fixes PRI-339.

## Public API Changes

-   [x] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?

Tested locally on an MPS device, and the MPS cache is now released between tests. 

## Checklist

-   [ ] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [ ] A changelog entry has been added (see `changelog/README.md`), or "no changelog needed" label requested.
-   [ ] The code follows the project's style guidelines.
-   [ ] I have considered the impact of these changes on the public API.

---
