### PR TITLE
Cold-start DDP finetuning: concurrent dataset downloads race across ranks. 

### DIFF
--- a/changelog/1094.added.md
+++ b/changelog/1094.added.md
@@ -1,0 +1,1 @@
+Add a public `tabpfn.finetuning.main_process_first()` context manager for multi-GPU (`torchrun`) scripts: the main process runs the with-block first while the other ranks wait at a barrier, then the other ranks run it — useful for one-time work such as dataset downloads that should warm a shared cache. The process group it initializes is reused by the subsequent `fit()`.

--- a/changelog/1094.fixed.md
+++ b/changelog/1094.fixed.md
@@ -1,0 +1,1 @@
+Fix the fine-tuning examples crashing or redundantly downloading their dataset once per rank when launched with `torchrun --nproc-per-node=N` on a cold sklearn cache; the dataset fetch is now wrapped in `main_process_first()` so only the main process downloads.

--- a/examples/finetune_classifier.py
+++ b/examples/finetune_classifier.py
@@ -17,10 +17,12 @@ import warnings
 import numpy as np
 import sklearn.datasets
 import torch
+import torch.distributed as dist
 from sklearn.metrics import log_loss, roc_auc_score
 from sklearn.model_selection import train_test_split
 
 from tabpfn import TabPFNClassifier
+from tabpfn.finetuning import main_process_first
 from tabpfn.finetuning.finetuned_classifier import (
     FinetunedTabPFNClassifier,
 )
@@ -73,7 +75,15 @@ def main() -> None:
 
     # We use the "Higgs" dataset (see https://www.openml.org/search?type=data&sort=runs&id=44129&status=active)
     # but only take a random subset of 100k samples for this example.
-    data = sklearn.datasets.fetch_openml(data_id=44129, as_frame=True, parser="auto")
+    # Under torchrun, the main process downloads the dataset first and the
+    # other ranks then read it from the warm sklearn cache — otherwise every
+    # rank would download it, and not all sklearn fetchers write their cache
+    # atomically.
+    with main_process_first():
+        data = sklearn.datasets.fetch_openml(
+            data_id=44129, as_frame=True, parser="auto"
+        )
+
     _, X_all, _, y_all = train_test_split(
         data.data,
         data.target,
@@ -145,6 +155,9 @@ def main() -> None:
 
         print(f"📊 Finetuned TabPFN Test ROC: {roc_auc:.4f}")
         print(f"📊 Finetuned TabPFN Test Log Loss: {loss:.4f}")
+
+    if dist.is_initialized():
+        dist.destroy_process_group()
 
 
 if __name__ == "__main__":

--- a/examples/finetune_regressor.py
+++ b/examples/finetune_regressor.py
@@ -16,10 +16,12 @@ import warnings
 
 import sklearn.datasets
 import torch
+import torch.distributed as dist
 from sklearn.metrics import mean_squared_error, r2_score
 from sklearn.model_selection import train_test_split
 
 from tabpfn import TabPFNRegressor
+from tabpfn.finetuning import main_process_first
 from tabpfn.finetuning.finetuned_regressor import FinetunedTabPFNRegressor
 
 warnings.filterwarnings(
@@ -64,7 +66,13 @@ RANDOM_STATE = 0
 def main() -> None:
     is_main_process = int(os.environ.get("LOCAL_RANK", "0")) == 0
 
-    data = sklearn.datasets.fetch_california_housing(as_frame=True)
+    # Under torchrun, the main process downloads the dataset first and the
+    # other ranks then read it from the warm sklearn cache — otherwise every
+    # rank would download it, and not all sklearn fetchers write their cache
+    # atomically.
+    with main_process_first():
+        data = sklearn.datasets.fetch_california_housing(as_frame=True)
+
     X_all = data.data
     y_all = data.target
 
@@ -130,6 +138,9 @@ def main() -> None:
 
         print(f"📊 Finetuned TabPFN Test MSE: {mse:.4f}")
         print(f"📊 Finetuned TabPFN Test R²: {r2:.4f}")
+
+    if dist.is_initialized():
+        dist.destroy_process_group()
 
 
 if __name__ == "__main__":

--- a/src/tabpfn/finetuning/__init__.py
+++ b/src/tabpfn/finetuning/__init__.py
@@ -3,7 +3,11 @@
 """Single-dataset fine-tuning wrappers for TabPFN models."""
 
 from tabpfn.finetuning.data_util import ClassifierBatch, RegressorBatch
-from tabpfn.finetuning.finetuned_base import EvalResult, FinetunedTabPFNBase
+from tabpfn.finetuning.finetuned_base import (
+    EvalResult,
+    FinetunedTabPFNBase,
+    main_process_first,
+)
 from tabpfn.finetuning.finetuned_classifier import FinetunedTabPFNClassifier
 from tabpfn.finetuning.finetuned_regressor import FinetunedTabPFNRegressor
 from tabpfn.finetuning.logging import FinetuningLogger, NullLogger, WandbLogger
@@ -18,4 +22,5 @@ __all__ = [
     "NullLogger",
     "RegressorBatch",
     "WandbLogger",
+    "main_process_first",
 ]

--- a/src/tabpfn/finetuning/finetuned_base.py
+++ b/src/tabpfn/finetuning/finetuned_base.py
@@ -149,7 +149,13 @@ def main_process_first() -> Iterator[None]:
         yield
         return
 
-    _init_distributed_if_needed("cuda")
+    using_ddp, _, _ = _init_distributed_if_needed("cuda")
+    if not using_ddp:
+        # WORLD_SIZE was set by something other than torchrun (no LOCAL_RANK),
+        # so there is no process group to coordinate through.
+        yield
+        return
+
     is_main_process = dist.get_rank() == 0
     if not is_main_process:
         dist.barrier()

--- a/src/tabpfn/finetuning/finetuned_base.py
+++ b/src/tabpfn/finetuning/finetuned_base.py
@@ -16,6 +16,7 @@ import os
 import time
 import warnings
 from abc import ABC, abstractmethod
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from functools import partial
 from pathlib import Path
@@ -55,6 +56,8 @@ from tabpfn.validation import ensure_compatible_fit_inputs_sklearn
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from tabpfn.constants import ModelVersion, XType, YType
 
 # Currently, we only support a batch size of 1 for finetuning.
@@ -126,6 +129,35 @@ def _maybe_setup_ddp(
         device_str,
         is_main_process,
     )
+
+
+@contextmanager
+def main_process_first() -> Iterator[None]:
+    """Run the with-block on the main process before all other ranks.
+
+    Useful under ``torchrun`` for work that should happen once and be read
+    from a shared cache afterwards, such as dataset downloads: the main
+    process runs the block while the other ranks wait at a barrier, then the
+    other ranks run it against the warm cache.
+
+    Initializes the process group from the torchrun env vars if needed, and
+    leaves it initialized so that a subsequent ``fit()`` reuses it. Call
+    ``torch.distributed.destroy_process_group()`` at the end of your script.
+    No-op when running with a single process.
+    """
+    if int(os.environ.get("WORLD_SIZE", "1")) <= 1:
+        yield
+        return
+
+    _init_distributed_if_needed("cuda")
+    is_main_process = dist.get_rank() == 0
+    if not is_main_process:
+        dist.barrier()
+    try:
+        yield
+    finally:
+        if is_main_process:
+            dist.barrier()
 
 
 def _move_tabpfn_cached_contexts_to_device(estimator: Any, device: str) -> None:

--- a/src/tabpfn/finetuning/finetuned_base.py
+++ b/src/tabpfn/finetuning/finetuned_base.py
@@ -16,6 +16,7 @@ import os
 import time
 import warnings
 from abc import ABC, abstractmethod
+from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from functools import partial
@@ -56,8 +57,6 @@ from tabpfn.validation import ensure_compatible_fit_inputs_sklearn
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
-
     from tabpfn.constants import ModelVersion, XType, YType
 
 # Currently, we only support a batch size of 1 for finetuning.


### PR DESCRIPTION
## Issue
Please link the corresponding GitHub issue. If an issue does not already exist,
please open one to describe the bug or feature request before creating a pull request.

This allows us to discuss the proposal and helps avoid unnecessary work.

## Motivation and Context

When running the finetuning examples with multiple GPUs (torchrun --nproc-per-node=N examples/finetune_classifier.py / finetune_regressor.py) for the first time on a machine with a cold sklearn dataset cache, all N ranks call the sklearn dataset fetcher simultaneously, which can crash the run.

## Public API Changes

-   [x] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?

- Added a public` tabpfn.finetuning.main_process_first()` context manager (in `finetuned_base.py`, reusing `_init_distributed_if_needed` so the NCCL backend/timeout stay defined in one place): rank 0 runs the block (downloads and warms the cache) while other ranks wait at a barrier, then read from the warm cache. Leaves the process group initialized for `fit()` to reuse; no-op in single-process runs.
- Both finetune examples now wrap their dataset fetch in with `main_process_first()`:.

Verified with a 2-rank torchrun test asserting rank 1 only enters the block after rank 0 completes it.

## Checklist

-   [x] The changes have been tested locally.
-   [x] Documentation has been updated (if the public API or usage changes).
-   [x] A changelog entry has been added (see `changelog/README.md`), or "no changelog needed" label requested.
-   [x] The code follows the project's style guidelines.
-   [x] I have considered the impact of these changes on the public API.

---
