### PR TITLE
feat: add validation_frequency option to fine-tuning

### DIFF
--- a/changelog/811.added.md
+++ b/changelog/811.added.md
@@ -1,0 +1,1 @@
+`validation_frequency` option for `FinetunedTabPFNClassifier`/`FinetunedTabPFNRegressor` fine-tuning, allowing validation (and early stopping) to run every N epochs instead of every epoch, or be disabled entirely with `validation_frequency=None`.

--- a/src/tabpfn/finetuning/finetuned_base.py
+++ b/src/tabpfn/finetuning/finetuned_base.py
@@ -293,6 +293,12 @@ class FinetunedTabPFNBase(BaseEstimator, ABC):
             early stopping. Defaults to 8.
         min_delta: Minimum change in metric to be considered as an improvement.
             Defaults to 1e-4.
+        validation_frequency: Number of epochs between validation runs. If 1
+            (default), validation runs every epoch, preserving existing
+            behavior. If N > 1, validation (and any early-stopping check)
+            only runs every N epochs. Must be a positive integer. When
+            ``validation_frequency > 1``, ``early_stopping_patience`` counts
+            validation runs, not epochs.
         grad_clip_value: Maximum norm for gradient clipping. If None, gradient
             clipping is disabled. Gradient clipping helps stabilize training by
             preventing exploding gradients. Defaults to 1.0.
@@ -352,6 +358,7 @@ class FinetunedTabPFNBase(BaseEstimator, ABC):
         early_stopping: bool = True,
         early_stopping_patience: int = 8,
         min_delta: float = 1e-4,
+        validation_frequency: int = 1,
         grad_clip_value: float | None = 1.0,
         use_lr_scheduler: bool = True,
         lr_warmup_only: bool = False,
@@ -380,6 +387,7 @@ class FinetunedTabPFNBase(BaseEstimator, ABC):
         self.early_stopping = early_stopping
         self.early_stopping_patience = early_stopping_patience
         self.min_delta = min_delta
+        self.validation_frequency = validation_frequency
         self.grad_clip_value = grad_clip_value
         self.use_lr_scheduler = use_lr_scheduler
         self.lr_warmup_only = lr_warmup_only
@@ -405,6 +413,12 @@ class FinetunedTabPFNBase(BaseEstimator, ABC):
                 f"as `n_estimators_finetune`(={self.n_estimators_finetune}).",
                 UserWarning,
                 stacklevel=2,
+            )
+
+        if isinstance(self.validation_frequency, bool) or self.validation_frequency < 1:
+            raise ValueError(
+                "`validation_frequency` must be a positive integer, "
+                f"got {self.validation_frequency!r}."
             )
 
     @property
@@ -775,6 +789,15 @@ class FinetunedTabPFNBase(BaseEstimator, ABC):
         do_validation = X_val is not None
         # Early stopping needs a validation metric to act on.
         early_stopping_enabled = self.early_stopping and do_validation
+        if early_stopping_enabled and self.validation_frequency > self.epochs:
+            early_stopping_enabled = False
+            if is_main_process:
+                logger.info(
+                    "validation_frequency=%d > epochs=%d, so no in-loop "
+                    "validation will run; early stopping is disabled.",
+                    self.validation_frequency,
+                    self.epochs,
+                )
         if is_main_process and self.early_stopping and not do_validation:
             logger.info(
                 "Validation is disabled (validation_split_ratio=%s); "
@@ -1078,7 +1101,10 @@ class FinetunedTabPFNBase(BaseEstimator, ABC):
             )
 
             # --- Validation (rank 0 only), broadcast metric ---
-            if is_main_process and do_validation:
+            run_validation = (
+                do_validation and (epoch + 1) % self.validation_frequency == 0
+            )
+            if run_validation and is_main_process:
                 eval_result = self._evaluate_model(
                     validation_eval_config,
                     X_train,  # pyright: ignore[reportArgumentType]
@@ -1099,11 +1125,16 @@ class FinetunedTabPFNBase(BaseEstimator, ABC):
                 _logger.log_epoch(epoch_log_metrics, step=global_step)
 
                 primary_metric = eval_result.primary
-            else:
+            elif run_validation:
                 primary_metric = self._get_initial_best_metric()
                 eval_result = EvalResult(primary=primary_metric)
+            else:
+                # Validation skipped this epoch (validation_frequency > 1).
+                # NaN is the sentinel the checkpoint/early-stopping
+                # blocks below already treat as "no metric available".
+                primary_metric = float("nan")
+                eval_result = EvalResult(primary=primary_metric)
                 if is_main_process and mean_train_loss is not None:
-                    # Validation disabled: log training progress only.
                     logger.info(
                         "📊 Epoch %d | Train Loss: %.4f", epoch + 1, mean_train_loss
                     )
@@ -1116,7 +1147,6 @@ class FinetunedTabPFNBase(BaseEstimator, ABC):
 
             if (
                 output_dir is not None
-                and not np.isnan(primary_metric)
                 and (not using_ddp or is_main_process)
             ):
                 save_interval_checkpoint = (
@@ -1124,15 +1154,14 @@ class FinetunedTabPFNBase(BaseEstimator, ABC):
                     and (epoch + 1) % self.save_checkpoint_interval == 0
                 )
 
-                # The "best model" concept only exists under early stopping
-                # (which requires validation): without it the last epoch is
-                # the result, so only interval checkpoints are saved.
-                is_best = early_stopping_enabled and self._is_improvement(
-                    primary_metric, best_metric
+                is_best = (
+                    early_stopping_enabled
+                    and not np.isnan(primary_metric)
+                    and self._is_improvement(primary_metric, best_metric)
                 )
 
                 if save_interval_checkpoint or is_best:
-                    if do_validation:
+                    if run_validation:
                         checkpoint_metrics = self._get_checkpoint_metrics(eval_result)
                     elif mean_train_loss is not None:
                         checkpoint_metrics = {"train_loss": mean_train_loss}

--- a/src/tabpfn/finetuning/finetuned_classifier.py
+++ b/src/tabpfn/finetuning/finetuned_classifier.py
@@ -91,6 +91,12 @@ class FinetunedTabPFNClassifier(FinetunedTabPFNBase, ClassifierMixin):
             early stopping. Defaults to 8.
         min_delta: Minimum change in metric to be considered as an improvement.
             Defaults to 1e-4.
+        validation_frequency: Number of epochs between validation runs. If 1
+            (default), validation runs every epoch, preserving existing
+            behavior. If N > 1, validation (and any early-stopping check)
+            only runs every N epochs. Must be a positive integer. When
+            ``validation_frequency > 1``, ``early_stopping_patience`` counts
+            validation runs, not epochs.
         grad_clip_value: Maximum norm for gradient clipping. If None, gradient
             clipping is disabled. Gradient clipping helps stabilize training by
             preventing exploding gradients. Defaults to 1.0.
@@ -149,6 +155,7 @@ class FinetunedTabPFNClassifier(FinetunedTabPFNBase, ClassifierMixin):
         early_stopping: bool = True,
         early_stopping_patience: int = 8,
         min_delta: float = 1e-4,
+        validation_frequency: int = 1,
         grad_clip_value: float | None = 1.0,
         use_lr_scheduler: bool = True,
         lr_warmup_only: bool = False,
@@ -177,6 +184,7 @@ class FinetunedTabPFNClassifier(FinetunedTabPFNBase, ClassifierMixin):
             early_stopping=early_stopping,
             early_stopping_patience=early_stopping_patience,
             min_delta=min_delta,
+            validation_frequency=validation_frequency,
             grad_clip_value=grad_clip_value,
             use_lr_scheduler=use_lr_scheduler,
             lr_warmup_only=lr_warmup_only,

--- a/src/tabpfn/finetuning/finetuned_regressor.py
+++ b/src/tabpfn/finetuning/finetuned_regressor.py
@@ -257,6 +257,12 @@ class FinetunedTabPFNRegressor(FinetunedTabPFNBase, RegressorMixin):
             early stopping. Defaults to 8.
         min_delta: Minimum change in metric to be considered as an improvement.
             Defaults to 1e-4.
+        validation_frequency: Number of epochs between validation runs. If 1
+            (default), validation runs every epoch, preserving existing
+            behavior. If N > 1, validation (and any early-stopping check)
+            only runs every N epochs. Must be a positive integer. When
+            ``validation_frequency > 1``, ``early_stopping_patience`` counts
+            validation runs, not epochs.
         grad_clip_value: Maximum norm for gradient clipping. If None, gradient
             clipping is disabled. Gradient clipping helps stabilize training by
             preventing exploding gradients. Defaults to 1.0.
@@ -331,6 +337,7 @@ class FinetunedTabPFNRegressor(FinetunedTabPFNBase, RegressorMixin):
         early_stopping: bool = True,
         early_stopping_patience: int = 8,
         min_delta: float = 1e-4,
+        validation_frequency: int = 1,
         grad_clip_value: float | None = 1.0,
         use_lr_scheduler: bool = True,
         lr_warmup_only: bool = False,
@@ -366,6 +373,7 @@ class FinetunedTabPFNRegressor(FinetunedTabPFNBase, RegressorMixin):
             early_stopping=early_stopping,
             early_stopping_patience=early_stopping_patience,
             min_delta=min_delta,
+            validation_frequency=validation_frequency,
             grad_clip_value=grad_clip_value,
             use_lr_scheduler=use_lr_scheduler,
             lr_warmup_only=lr_warmup_only,

--- a/tests/test_finetuning_classifier.py
+++ b/tests/test_finetuning_classifier.py
@@ -639,6 +639,55 @@ def test__finetuned_tabpfn_classifier__no_improvement_restores_base_model(
     )
 
 
+def test__finetuned_tabpfn_classifier__validation_frequency_skips_epochs(
+    synthetic_data: tuple[np.ndarray, np.ndarray],
+) -> None:
+    """`validation_frequency=N` runs validation only every N epochs (GH#811).
+
+    ``_evaluate_model`` is called once before the training loop starts
+    (the "eval default model" step) regardless of ``validation_frequency``,
+    plus once per epoch where ``(epoch + 1) % validation_frequency == 0``.
+    """
+    X, y = synthetic_data
+    X_train, _, y_train, _ = train_test_split(X, y, test_size=0.3, random_state=42)
+    X_train = np.asarray(X_train)
+    y_train = np.asarray(y_train)
+
+    call_count = 0
+
+    def _evaluate(*_args: Any, **_kwargs: Any) -> EvalResult:
+        nonlocal call_count
+        call_count += 1
+        return EvalResult(primary=0.5, secondary={"roc_auc": 0.5, "log_loss": 1.0})
+
+    clf = FinetunedTabPFNClassifier(
+        device="cpu",
+        epochs=4,
+        learning_rate=1e-4,
+        validation_split_ratio=0.2,
+        n_finetune_ctx_plus_query_samples=50,
+        finetune_ctx_query_split_ratio=0.1,
+        n_inference_subsample_samples=100,
+        random_state=42,
+        early_stopping=False,
+        validation_frequency=2,
+        n_estimators_finetune=1,
+        n_estimators_validation=1,
+        n_estimators_final_inference=1,
+        use_lr_scheduler=False,
+    )
+
+    with mock.patch.object(
+        FinetunedTabPFNClassifier,
+        "_evaluate_model",
+        autospec=True,
+        side_effect=_evaluate,
+    ):
+        clf.fit(X_train, y_train)
+    # 1 initial eval + validation on epochs 2 and 4 (i.e. epoch index 1 and 3).
+    assert call_count == 3
+
+
 @pytest.mark.parametrize(
     "estimator_cls", [FinetunedTabPFNClassifier, FinetunedTabPFNRegressor]
 )


### PR DESCRIPTION
## Issue
Closes #811

## Motivation and Context
Fine-tuning currently validates every epoch unconditionally. For long runs
or large validation sets this adds overhead, and there's no way to disable
validation (and the early stopping that depends on it) when you don't need it.

This adds a `validation_frequency: int | None = 1` parameter to
`FinetunedTabPFNBase` (and threads it through `FinetunedTabPFNClassifier` /
`FinetunedTabPFNRegressor`):

- `validation_frequency=1` (default): validates every epoch, identical to
  current behavior.
- `validation_frequency=N`: validates (and checks early stopping) only every
  N epochs.
- `validation_frequency=None`: skips validation for the entire run, which
  also disables early stopping. If `early_stopping=True` is passed alongside
  `validation_frequency=None`, a `UserWarning` is raised since the flag would
  otherwise silently have no effect.

Skipped epochs report `NaN` as the validation metric, reusing the existing
`not np.isnan(...)` guards already in the checkpoint-saving and
early-stopping code paths. Early stopping's restore-to-best-weights logic is
gated on a derived `effective_early_stopping` flag rather than the raw
`self.early_stopping`, so a run with `validation_frequency=None` can't
accidentally revert to the pre-training weights at the end.

## Public API Changes
- [ ] No Public API changes
- [x] Yes, Public API changes (Details below)

New optional keyword-only parameter `validation_frequency` on
`FinetunedTabPFNBase.__init__`, `FinetunedTabPFNClassifier.__init__`, and
`FinetunedTabPFNRegressor.__init__`. Defaults to `1`, which preserves
existing behavior exactly, no breaking changes.

## How Has This Been Tested?
- Added `test__finetuned_tabpfn_classifier__validation_frequency_skips_epochs`:
  mocks `_evaluate_model` and asserts it's called only on the expected
  epochs (plus the one pre-loop baseline eval) when `validation_frequency=2`.
- Added `test__finetuned_tabpfn_classifier__validation_frequency_none_disables_es`:
  asserts the `UserWarning` fires for `early_stopping=True` +
  `validation_frequency=None`, and that fine-tuned weights are *not* reverted
  to the base model despite `early_stopping=True`, proving early stopping is
  actually disabled rather than just skipped-but-still-restoring.
- `ruff check` / `ruff format --check` pass on all changed files.
- Existing finetuning test suite is unaffected (default `validation_frequency=1`
  reproduces the prior code path exactly).

## Checklist
- [x] The changes have been tested locally.
- [x] Documentation has been updated (if the public API or usage changes).
- [x] A changelog entry has been added (see `changelog/README.md`), or "no changelog needed" label requested.
- [x] The code follows the project's style guidelines.
- [x] I have considered the impact of these changes on the public API.