### PR TITLE
Disable KV cache quantization when inference dtype specified.

### DIFF
--- a/changelog/1099.changed.md
+++ b/changelog/1099.changed.md
@@ -1,0 +1,1 @@
+Disable KV cache quantization when `TabPFNClassifier/Regressor(inference_precision=)` is specified.

--- a/src/tabpfn/classifier.py
+++ b/src/tabpfn/classifier.py
@@ -387,6 +387,11 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
                   faster inference on the same data at a large cost of memory.
                   Ideal with very high GPU memory and multiple calls to `.predict()`
                   with the same training data.
+                  By default, the key-value cache is quantized to 8 bits. We have not
+                  observed this to reduce performance, but it can lead to slight
+                  differences in the predictions compared to the other fit modes.
+                  Setting `inference_precision` to a value other than "auto" disables
+                  quantisation.
                 - If `"batched"`, the already pre-processed data is iterated over in
                   batches. This can only be done after the data has been preprocessed
                   with the get_preprocessed_datasets function. This is primarily used

--- a/src/tabpfn/inference.py
+++ b/src/tabpfn/inference.py
@@ -858,14 +858,15 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
             force_inference_dtype: The dtype to force inference to.
             save_peak_mem: Whether to save peak memory usage.
             autocast: Whether to use torch.autocast during cache build.
-            keep_cache_on_device: If True (default), keep each per-estimator
-                KV cache on the device where it was built.  Uses more device
-                memory but avoids CPU↔GPU transfers, giving lower latency.
-                When False, caches are moved to CPU after building and
-                transferred to the target device on every predict call.
-            maybe_quantize_kv_cache: If True (default), quantize the KV cache
-                to reduce memory footprint if it is supported by the architecture.
-                If False, the KV cache is not quantized.
+            keep_cache_on_device: If True (default), keep each per-estimator KV cache on
+                the device where it was built. Uses more device memory but avoids
+                CPU↔GPU transfers, giving lower latency.
+                When False, caches are moved to CPU after building and transferred to
+                the target device on every predict call.
+            maybe_quantize_kv_cache: If True (default), quantize the KV cache to reduce
+                the memory footprint, if it is supported by the architecture and
+                force_inference_dtype is None. If False, or if force_inference_dtype is
+                set, the KV cache is not quantized.
         """
         super().__init__(
             model_caches=[_PerDeviceModelCache(model) for model in models],
@@ -987,7 +988,11 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
             )
 
         assert cache is not None
-        if self.maybe_quantize_kv_cache and hasattr(cache, "quantize"):
+        if (
+            self.maybe_quantize_kv_cache
+            and self.force_inference_dtype is None
+            and hasattr(cache, "quantize")
+        ):
             cache = cache.quantize()
         if self.keep_cache_on_device:
             return cache

--- a/src/tabpfn/regressor.py
+++ b/src/tabpfn/regressor.py
@@ -388,6 +388,11 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
                   faster inference on the same data at a large cost of memory.
                   Ideal with very high GPU memory and multiple calls to `.predict()`
                   with the same training data.
+                  By default, the key-value cache is quantized to 8 bits. We have not
+                  observed this to reduce performance, but it can lead to slight
+                  differences in the predictions compared to the other fit modes.
+                  Setting `inference_precision` to a value other than "auto" disables
+                  quantisation.
                 - If `"batched"`, the already pre-processed data is iterated over in
                   batches. This can only be done after the data has been preprocessed
                   with the get_preprocessed_datasets function. This is primarily used

--- a/tests/test_classifier_interface.py
+++ b/tests/test_classifier_interface.py
@@ -7,7 +7,7 @@ import itertools
 import os
 from collections.abc import Callable
 from itertools import product
-from typing import Any, Literal
+from typing import Literal
 
 import numpy as np
 import pandas as pd
@@ -24,6 +24,7 @@ from torch import nn
 
 from tabpfn import TabPFNClassifier
 from tabpfn.architectures import tabpfn_v2_5
+from tabpfn.architectures.kv_cache import QuantizedKVCacheEntry
 from tabpfn.base import ClassifierModelSpecs, initialize_tabpfn_model
 from tabpfn.constants import ModelVersion
 from tabpfn.inference import InferenceEngineExplicitKVCache
@@ -539,7 +540,6 @@ def test__fit_preprocessors_and_with_cache_produce_equal_results(
     X_y: tuple[np.ndarray, np.ndarray],
     model_version: ModelVersion,
     device: str,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     kwargs = {
         "version": model_version,
@@ -558,18 +558,6 @@ def test__fit_preprocessors_and_with_cache_produce_equal_results(
     probs = tabpfn.predict_proba(X)
     preds = tabpfn.predict(X)
 
-    original_init = InferenceEngineExplicitKVCache.__init__
-
-    def _init_without_kv_quantization(
-        self: InferenceEngineExplicitKVCache, *args: Any, **kwargs: Any
-    ) -> None:
-        kwargs.setdefault("maybe_quantize_kv_cache", False)
-        original_init(self, *args, **kwargs)
-
-    monkeypatch.setattr(
-        InferenceEngineExplicitKVCache, "__init__", _init_without_kv_quantization
-    )
-
     torch.random.manual_seed(0)
     tabpfn = TabPFNClassifier.create_default_for_version(
         fit_mode="fit_with_cache", **kwargs
@@ -580,13 +568,14 @@ def test__fit_preprocessors_and_with_cache_produce_equal_results(
 
 
 @pytest.mark.parametrize("device", get_pytest_devices())
-def test__fit_preprocessors_and_with_cache_with_quantized_kv_cache__v3(
+def test__fit_preprocessors_and_with_cache_produce_equal_results__quantized_kv_cache(
     X_y: tuple[np.ndarray, np.ndarray], device: str
 ) -> None:
+    # Do not specify inference precision, as this would disable KV cache quantization.
     kwargs = {
+        # At the moment, only V3 supports a quantized KV cache.
         "version": ModelVersion.V3,
         "n_estimators": 2,
-        "inference_precision": torch.float32,
         "random_state": 0,
         "device": device,
     }
@@ -597,16 +586,25 @@ def test__fit_preprocessors_and_with_cache_with_quantized_kv_cache__v3(
         fit_mode="fit_preprocessors", **kwargs
     )
     tabpfn.fit(X, y)
-    probs = tabpfn.predict_proba(X)
-    preds = tabpfn.predict(X)
+    probs_without_cache = tabpfn.predict_proba(X)
+    preds_without_cache = tabpfn.predict(X)
 
     torch.random.manual_seed(0)
     tabpfn = TabPFNClassifier.create_default_for_version(
         fit_mode="fit_with_cache", **kwargs
     )
     tabpfn.fit(X, y)
-    np.testing.assert_array_almost_equal(probs, tabpfn.predict_proba(X), decimal=2)
-    np.testing.assert_allclose(preds, tabpfn.predict(X), rtol=0.1)
+    np.testing.assert_array_almost_equal(
+        probs_without_cache, tabpfn.predict_proba(X), decimal=2
+    )
+    np.testing.assert_allclose(preds_without_cache, tabpfn.predict(X), rtol=0.1)
+
+    assert isinstance(tabpfn.executor_, InferenceEngineExplicitKVCache)
+    cache_entries = [
+        entry for cache in tabpfn.executor_.kv_caches for entry in cache.kv.values()
+    ]
+    assert cache_entries
+    assert all(isinstance(entry, QuantizedKVCacheEntry) for entry in cache_entries)
 
 
 @pytest.mark.parametrize("model_version", list(ModelVersion))
@@ -1622,3 +1620,46 @@ def test__predict_proba_batched__does_not_mutate_estimator() -> None:
     fitted.predict_proba_batched(X_list, y_list, X_tests)
     after = fitted.predict_proba(a_x[:5])
     np.testing.assert_array_equal(before, after)
+
+
+def test__fit__fit_with_cache_and_dtype_specified__does_not_quantize_cache(
+    X_y: tuple[np.ndarray, np.ndarray],
+) -> None:
+    X, y = X_y
+    tabpfn = TabPFNClassifier.create_default_for_version(
+        # V3 is currently the only version to support cache quantization.
+        version=ModelVersion.V3,
+        fit_mode="fit_with_cache",
+        inference_precision=torch.float32,
+        n_estimators=2,
+        random_state=0,
+    )
+    tabpfn.fit(X, y)
+
+    assert isinstance(tabpfn.executor_, InferenceEngineExplicitKVCache)
+    cache_entries = [
+        entry for cache in tabpfn.executor_.kv_caches for entry in cache.kv.values()
+    ]
+    assert cache_entries
+    assert not any(isinstance(entry, QuantizedKVCacheEntry) for entry in cache_entries)
+
+
+def test__fit__fit_with_cache_and_dtype_auto__quantizes_cache(
+    X_y: tuple[np.ndarray, np.ndarray],
+) -> None:
+    X, y = X_y
+    tabpfn = TabPFNClassifier.create_default_for_version(
+        # V3 is currently the only version to support cache quantization.
+        version=ModelVersion.V3,
+        fit_mode="fit_with_cache",
+        n_estimators=2,
+        random_state=0,
+    )
+    tabpfn.fit(X, y)
+
+    assert isinstance(tabpfn.executor_, InferenceEngineExplicitKVCache)
+    cache_entries = [
+        entry for cache in tabpfn.executor_.kv_caches for entry in cache.kv.values()
+    ]
+    assert cache_entries
+    assert all(isinstance(entry, QuantizedKVCacheEntry) for entry in cache_entries)

--- a/tests/test_regressor_interface.py
+++ b/tests/test_regressor_interface.py
@@ -7,7 +7,7 @@ import itertools
 import os
 import typing
 from collections.abc import Callable
-from typing import Any, Literal
+from typing import Literal
 from unittest import mock
 
 import numpy as np
@@ -24,6 +24,7 @@ from torch import nn
 
 import tabpfn.regressor as regressor_module
 from tabpfn import TabPFNRegressor
+from tabpfn.architectures.kv_cache import QuantizedKVCacheEntry
 from tabpfn.base import RegressorModelSpecs, initialize_tabpfn_model
 from tabpfn.constants import ModelVersion
 from tabpfn.inference import InferenceEngineExplicitKVCache
@@ -295,7 +296,6 @@ def test__fit_preprocessors_and_with_cache_produce_equal_results(
     X_y: tuple[np.ndarray, np.ndarray],
     model_version: ModelVersion,
     device: str,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     kwargs = {
         "version": model_version,
@@ -313,18 +313,6 @@ def test__fit_preprocessors_and_with_cache_produce_equal_results(
     tabpfn.fit(X, y)
     preds = tabpfn.predict(X)
 
-    original_init = InferenceEngineExplicitKVCache.__init__
-
-    def _init_without_kv_quantization(
-        self: InferenceEngineExplicitKVCache, *args: Any, **kwargs: Any
-    ) -> None:
-        kwargs.setdefault("maybe_quantize_kv_cache", False)
-        original_init(self, *args, **kwargs)
-
-    monkeypatch.setattr(
-        InferenceEngineExplicitKVCache, "__init__", _init_without_kv_quantization
-    )
-
     torch.random.manual_seed(0)
     tabpfn = TabPFNRegressor.create_default_for_version(
         fit_mode="fit_with_cache", **kwargs
@@ -334,13 +322,14 @@ def test__fit_preprocessors_and_with_cache_produce_equal_results(
 
 
 @pytest.mark.parametrize("device", get_pytest_devices())
-def test__fit_preprocessors_and_with_cache_with_quantized_kv_cache__v3(
+def test__fit_preprocessors_and_with_cache_produce_equal_results__quantized_kv_cache(
     X_y: tuple[np.ndarray, np.ndarray], device: str
 ) -> None:
+    # Do not specify inference precision, as this would disable KV cache quantization.
     kwargs = {
+        # At the moment, only V3 supports a quantized KV cache.
         "version": ModelVersion.V3,
         "n_estimators": 2,
-        "inference_precision": torch.float32,
         "random_state": 0,
         "device": device,
     }
@@ -351,14 +340,21 @@ def test__fit_preprocessors_and_with_cache_with_quantized_kv_cache__v3(
         fit_mode="fit_preprocessors", **kwargs
     )
     tabpfn.fit(X, y)
-    preds = tabpfn.predict(X)
+    preds_without_cache = tabpfn.predict(X)
 
     torch.random.manual_seed(0)
     tabpfn = TabPFNRegressor.create_default_for_version(
         fit_mode="fit_with_cache", **kwargs
     )
     tabpfn.fit(X, y)
-    np.testing.assert_allclose(preds, tabpfn.predict(X), rtol=0.25)
+    np.testing.assert_allclose(preds_without_cache, tabpfn.predict(X), rtol=0.25)
+
+    assert isinstance(tabpfn.executor_, InferenceEngineExplicitKVCache)
+    cache_entries = [
+        entry for cache in tabpfn.executor_.kv_caches for entry in cache.kv.values()
+    ]
+    assert cache_entries
+    assert all(isinstance(entry, QuantizedKVCacheEntry) for entry in cache_entries)
 
 
 @pytest.mark.parametrize("model_version", list(ModelVersion))
@@ -1232,3 +1228,46 @@ def test__fit_with_differentiable_input__second_call_refreshes_target_stats() ->
     assert not torch.allclose(reg.raw_space_bardist_.borders, bardist_borders1), (
         "raw_space_bardist_ must be rebuilt to the new target scale"
     )
+
+
+def test__fit__fit_with_cache_and_dtype_specified__does_not_quantize_cache(
+    X_y: tuple[np.ndarray, np.ndarray],
+) -> None:
+    X, y = X_y
+    tabpfn = TabPFNRegressor.create_default_for_version(
+        # V3 is currently the only version to support cache quantization.
+        version=ModelVersion.V3,
+        fit_mode="fit_with_cache",
+        inference_precision=torch.float32,
+        n_estimators=2,
+        random_state=0,
+    )
+    tabpfn.fit(X, y)
+
+    assert isinstance(tabpfn.executor_, InferenceEngineExplicitKVCache)
+    cache_entries = [
+        entry for cache in tabpfn.executor_.kv_caches for entry in cache.kv.values()
+    ]
+    assert cache_entries
+    assert not any(isinstance(entry, QuantizedKVCacheEntry) for entry in cache_entries)
+
+
+def test__fit__fit_with_cache_and_dtype_auto__quantizes_cache(
+    X_y: tuple[np.ndarray, np.ndarray],
+) -> None:
+    X, y = X_y
+    tabpfn = TabPFNRegressor.create_default_for_version(
+        # V3 is currently the only version to support cache quantization.
+        version=ModelVersion.V3,
+        fit_mode="fit_with_cache",
+        n_estimators=2,
+        random_state=0,
+    )
+    tabpfn.fit(X, y)
+
+    assert isinstance(tabpfn.executor_, InferenceEngineExplicitKVCache)
+    cache_entries = [
+        entry for cache in tabpfn.executor_.kv_caches for entry in cache.kv.values()
+    ]
+    assert cache_entries
+    assert all(isinstance(entry, QuantizedKVCacheEntry) for entry in cache_entries)


### PR DESCRIPTION
A limitation of this approach is that you can't have the dtype automatically determined and also use this for the KV cache, but I'd guess anyone who is in deep enough to disable cache quantization is happy specifying a dtype.

Closes https://github.com/PriorLabs/TabPFN/issues/631
Fixes PRI-154