### PR TITLE
docs: document Tesla T4 (Turing/sm_75) GPU setup pitfalls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,70 @@
+# AGENTS.md
+
+Notes for agents/automation running TabPFN, especially on Turing-class
+datacenter GPUs (e.g. Tesla T4, sm_75). None of this changes default behavior —
+it documents what the code already does, verified on real hardware.
+
+## GPU detection can silently fall back to CPU
+
+`device="auto"` (the default) resolves via `torch.cuda.is_available()`. If that
+is `False` — most commonly because `pip install tabpfn` pulled in a PyTorch
+build compiled against a newer CUDA toolkit than your NVIDIA driver supports —
+TabPFN returns a CPU device **with no warning or error**. There is no log line
+telling you inference is running on CPU instead of GPU.
+
+If you expect GPU inference, verify it explicitly after installing:
+
+```bash
+python -c "import torch; print(torch.cuda.is_available(), torch.cuda.get_device_name(0))"
+```
+
+If this prints `False`, install a PyTorch build matching your driver's CUDA
+version from the [PyTorch installation selector](https://pytorch.org/get-started/locally/)
+before installing TabPFN. Example, for a driver that only supports CUDA 12.4
+(e.g. driver `550.163.01`, common on T4/A10G cloud and Colab instances):
+
+```bash
+pip install torch --index-url https://download.pytorch.org/whl/cu124
+pip install tabpfn
+```
+
+## Autocast dtype on Turing (sm_75) is fp16, and that's correct
+
+`inference_precision="auto"` enables autocast without specifying a dtype, so
+CUDA's autocast defaults to `torch.float16`. Verified at runtime on a T4
+(SDPA input tensors were `torch.float16`). This is the right choice for
+Turing — the architecture has no bf16 tensor cores, so forcing bf16 would run
+substantially slower. Do not override this to bf16 on T4/Turing hardware.
+
+(The `# bfloat16` comment next to `AUTOCAST_DTYPE_BYTE_SIZE` in
+`src/tabpfn/constants.py` refers to the byte size of the dtype — 2 bytes,
+shared by fp16 and bf16 — not the actual dtype used at inference. Don't read
+it as "autocast defaults to bf16".)
+
+## SDPA attention backend on sm_75
+
+TabPFN's SDPA backend list is `[FLASH, EFFICIENT, CUDNN, MATH]`, tried in
+order. On sm_75 (Turing/T4), FlashAttention and cuDNN kernels are unavailable
+(`RuntimeError: No available kernel`); the first eligible backend is
+`EFFICIENT` (memory-efficient attention), with `MATH` as the final fallback.
+This is already handled by the repo — no configuration needed — and was
+confirmed by forcing each backend explicitly on a T4.
+
+## v2 sample-count limit vs. OOM
+
+TabPFN-2 rejects fits with more than 10,000 samples via
+`TabPFNValidationError` rather than running out of memory. On a Tesla T4
+(16GB), measured peak VRAM stayed well under the 16GB budget across the
+supported range:
+
+| Dataset | Peak VRAM | fit / predict |
+|---|---|---|
+| breast-cancer (569×30) | 0.15 GB | 0.42s / 0.41s |
+| synthetic 2,000×50 | 0.59 GB | 0.70s / 3.57s |
+| synthetic 10,000×100 | 5.33 GB | 3.49s / 84.3s |
+| synthetic 24,000×200 | — | rejected: `TabPFNValidationError` (>10,000 samples) |
+
+Environment: Tesla T4 16GB, driver 550.163.01 (CUDA 12.4 runtime), Python
+3.10.12, `torch==2.6.0+cu124`, `tabpfn==8.0.8`. Measured via the repo's own
+`fit`/`predict_proba` API (`create_default_for_version(ModelVersion.V2)`,
+`load_breast_cancer` / synthetic data), no code changes.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,21 @@ Note: For best performance on Apple Silicon/MPS, consider installing a PyTorch
 version after the nightly "2.13.0.dev20260510". This enables flash attention
 without relying on MLX (the latter requires a GPU-CPU-GPU roundtrip).
 
+> [!NOTE]
+> **CUDA driver / PyTorch build mismatch:** `pip install tabpfn` resolves whatever
+> is the latest PyTorch wheel at install time, which is built against a recent CUDA
+> toolkit. If your NVIDIA driver is older than that toolkit (a common case on many
+> cloud/Colab GPUs, e.g. driver `550.x` only supports up to CUDA 12.4), CUDA
+> initialization fails and TabPFN **silently falls back to CPU** (see below) instead
+> of raising an error. If you have a GPU, pick a matching build for your driver's
+> CUDA version from the
+> [PyTorch installation selector](https://pytorch.org/get-started/locally/) — for
+> example, for a CUDA-12.4-only driver: `pip install torch --index-url
+> https://download.pytorch.org/whl/cu124` — and verify it worked before installing
+> TabPFN:
+> ```bash
+> python -c "import torch; print(torch.cuda.is_available(), torch.cuda.get_device_name(0))"
+> ```
 
 ### Basic Usage
 
@@ -43,8 +58,16 @@ without relying on MLX (the latter requires a GPU-CPU-GPU roundtrip).
 > For optimal performance, use a GPU (even older ones with ~8GB VRAM work well; 16GB needed for some large datasets).
 > On CPU, only small datasets (≲1000 samples) are feasible.
 > No GPU? Use our free hosted inference via [TabPFN Client](https://github.com/PriorLabs/tabpfn-client).
+>
+> Note: `device="auto"` (the default) picks CPU with no warning if
+> `torch.cuda.is_available()` is `False` — check the command above if you expect
+> GPU inference and it seems slow.
 
-To use our default TabPFN-3 model:
+To use our default TabPFN-3 model. Note: the TabPFN-3 checkpoint is
+license-gated — on first use it needs a one-time interactive browser login (or a
+`TABPFN_TOKEN`, see the Installation & Setup FAQ below for headless/CI setups). If
+you don't want to do that up front, use the ungated Apache-2.0 TabPFN-2 weights
+instead (`ModelVersion.V2`, see the [License](#license) section below):
 
 ```python
 from tabpfn import TabPFNClassifier, TabPFNRegressor


### PR DESCRIPTION
## Motivation

Verifying TabPFN inference end-to-end on a real Tesla T4 (16GB, Turing/sm_75)
surfaced two doc gaps that cost time on this common hardware/driver
combination, plus a couple of things worth stating explicitly since they were
non-obvious until measured:

1. **Silent CPU fallback.** README-verbatim `pip install tabpfn` resolved
   `torch==2.13.0+cu130` on this box. The driver (`550.163.01`) only supports
   CUDA up to 12.4, so `torch.cuda.is_available()` was `False` —
   `RuntimeError: The NVIDIA driver on your system is too old (found version
   12040)` during a manual check. `device="auto"` doesn't raise on this; it
   just returns a CPU device with no warning, so an agent/user can end up
   silently running on CPU while believing GPU is in use.
2. **License gate not visible where Quick Start is read.** The default
   TabPFN-3 checkpoint requires a one-time interactive browser login or a
   `TABPFN_TOKEN` (documented later, in the License / FAQ sections). Running
   the Quick Start example headless raises `tabpfn.errors.TabPFNLicenseError`
   with no forward-reference from Basic Usage to the ungated TabPFN-2
   (`ModelVersion.V2`, Apache-2.0) alternative.

This is a documentation-only PR — no code or default behavior changes — filed
directly per the `doc_improvement` issue template's own guidance ("Alternatively
you can just open a pull request with the suggested change").

## Changes

- **README — Installation:** add a note that `pip install tabpfn` can resolve
  a PyTorch build newer than the local CUDA driver supports, with the
  matching-wheel command for CUDA-12.4-only drivers and a one-line
  `torch.cuda.is_available()` verification snippet.
- **README — Basic Usage:** add a note that `device="auto"` silently falls
  back to CPU with no warning, and surface the TabPFN-3 license
  requirement + ungated V2 alternative right next to the Quick Start code
  (previously only in the License section further down).
- **New `AGENTS.md`:** documents, from direct T4 measurement:
  - autocast dtype under `inference_precision="auto"` is `torch.float16`
    (verified via SDPA input dtype) — correct for Turing, since sm_75 has no
    bf16 tensor cores; the `# bfloat16` comment next to
    `AUTOCAST_DTYPE_BYTE_SIZE` in `constants.py` refers to byte size, not the
    autocast dtype, and shouldn't be read as "bf16 is the default."
  - SDPA backend selection on sm_75: FlashAttention/cuDNN kernels are
    unavailable (`No available kernel`), so the repo's existing backend list
    (`[FLASH, EFFICIENT, CUDNN, MATH]`) already falls through to `EFFICIENT`
    (memory-efficient attention) — no config needed, just documenting that
    this is expected and already handled.
  - measured peak VRAM / timing on T4 across dataset sizes up to TabPFN-2's
    10,000-sample validation limit (rejected via `TabPFNValidationError`,
    not OOM).

No dependency pins, defaults, or code paths are changed.

## Testing

Environment: Tesla T4 16GB · driver `550.163.01` (CUDA 12.4 runtime) ·
Python 3.10.12 · `torch==2.6.0+cu124` · `tabpfn==8.0.8` · `numpy==2.2.6` ·
`scikit-learn==1.7.2`.

Reproduction of the documented issues:
```
# ENV — verbatim `pip install tabpfn` install:
torch 2.13.0+cu130 cuda_build 13.0
is_available False
RuntimeError('The NVIDIA driver on your system is too old (found version 12040). ...')

# After installing the matching cu124 build:
torch 2.6.0+cu124, is_available=True, get_device_name(0)='Tesla T4'

# DOC — default TabPFN-3 headless:
tabpfn.errors.TabPFNLicenseError: TabPFN requires a one-time license acceptance
to download model weights for local inference, but no interactive terminal is
available. ... export TABPFN_TOKEN="<your-api-key>" ...
```

Measured via the repo's own `fit`/`predict_proba` API
(`TabPFNClassifier.create_default_for_version(ModelVersion.V2)`, no code
changes), `torch.autocast`/SDPA dtype introspection, and
`torch.cuda.max_memory_allocated()`:

| Dataset | autocast dtype | SDPA backend | Peak VRAM | fit / predict |
|---|---|---|---|---|
| breast-cancer (569×30) | float16 | EFFICIENT | 0.15 GB | 0.42s / 0.41s (ROC-AUC 0.997) |
| synthetic 2,000×50 | float16 | EFFICIENT | 0.59 GB | 0.70s / 3.57s |
| synthetic 10,000×100 | float16 | EFFICIENT | 5.33 GB | 3.49s / 84.3s |
| synthetic 24,000×200 | — | — | — | rejected: `TabPFNValidationError` (>10,000 samples) |

SDPA backend probe on sm_75, each backend forced explicitly:
`FLASH: RuntimeError: No available kernel` · `EFFICIENT: OK` ·
`CUDNN: RuntimeError: No available kernel` · `MATH: OK`.

<details><summary>Raw metrics JSON</summary>

```json
{"breast_cancer_v2": {"device":"auto","use_autocast_":true,"forced_inference_dtype_":"None",
  "n_estimators":8,"inference_precision":"auto","autocast_enabled":true,
  "autocast_dtype":"torch.float16","q_dtype":"torch.float16","q_device":"cuda:0",
  "roc_auc":0.997,"acc":0.9734,"fit_s":0.423,"predict_warm_s_mean":0.4119,
  "peak_vram_gb":0.146},
 "sdpa_backend_probe_sm75": {"FLASH":"FAIL:RuntimeError:No available kernel. Aborting execution.",
  "EFFICIENT":"OK","CUDNN":"FAIL:RuntimeError:No available kernel. Aborting execution.","MATH":"OK"},
 "scale": [{"n":2000,"f":50,"n_est":8,"fit_s":0.7,"pred_s":3.57,"peak_vram_gb":0.59,"ok":true},
  {"n":10000,"f":100,"n_est":8,"fit_s":3.49,"pred_s":84.34,"peak_vram_gb":5.33,"ok":true},
  {"n":30000,"f":200,"ok":false,"err":"TabPFNValidationError: Number of samples 24,000 ... greater than the maximum number of samples 10,000 officially supported"}]}
```
</details>

- [x] The changes have been tested locally.
- [x] Documentation has been updated (this PR is documentation only).
- [ ] Changelog: docs-only change, no changelog entry added — happy to add one if maintainers prefer.
- [x] The code follows the project's style guidelines (Markdown only, no code changes).
- [x] I have considered the impact of these changes on the public API: none — no public API changes.
