### PR TITLE
Skip bf16 autocast KV-cache test on Windows CPU

### DIFF
--- a/changelog/1103.fixed.md
+++ b/changelog/1103.fixed.md
@@ -1,0 +1,1 @@
+Fix Windows CI crash (illegal instruction) by skipping the bfloat16 autocast KV-cache test on Windows without CUDA.

--- a/tests/test_architectures/test_tabpfn_v3.py
+++ b/tests/test_architectures/test_tabpfn_v3.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import dataclasses
+import sys
 
 import pytest
 import torch
@@ -344,7 +345,22 @@ def test__kv_cache__gqa_matches_standard() -> None:
 
 @torch.no_grad()
 @pytest.mark.parametrize("use_chunkwise", [False, True])
-@pytest.mark.parametrize("autocast_dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize(
+    "autocast_dtype",
+    [
+        torch.float16,
+        pytest.param(
+            torch.bfloat16,
+            marks=pytest.mark.skipif(
+                sys.platform == "win32" and not torch.cuda.is_available(),
+                reason=(
+                    "bf16 CPU kernels crash with STATUS_ILLEGAL_INSTRUCTION "
+                    "(0xc000001d) on Windows CI runners"
+                ),
+            ),
+        ),
+    ],
+)
 def test__kv_cache__works_under_autocast(
     use_chunkwise: bool, autocast_dtype: torch.dtype
 ) -> None:


### PR DESCRIPTION
## Summary
Windows CI on `main` is crashing with `0xc000001d` (STATUS_ILLEGAL_INSTRUCTION) inside `torch.nn.Linear.forward` during `test__kv_cache__works_under_autocast[autocast_dtype1-*]` — the `torch.bfloat16` variant added in #1087. PyTorch's bf16 CPU matmul kernels use instructions the GitHub Windows runner's CPU doesn't support, so the whole pytest process dies instead of the test failing.

## Fix
Skip the bfloat16 parametrization when running on Windows without CUDA, using the same `skipif(sys.platform == "win32")` pattern already used in `test_tabpfn_v2_5.py` / `test_tabpfn_v2_6.py`. The float16 variant (which passes on Windows) and all variants on other platforms are unchanged; Windows machines with CUDA still run the bf16 test since autocast there uses GPU kernels.

## Test plan
- [x] All four `works_under_autocast` variants pass locally (macOS)
- [x] ruff check + format pass
- [ ] Windows CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)