### PR TITLE
Synchronize the single-device stream in parallel_execute so timing reflects GPU compute

### DIFF
--- a/changelog/1113.fixed.md
+++ b/changelog/1113.fixed.md
@@ -1,0 +1,1 @@
+Fix timing on GPU to reflect full GPU work.

--- a/src/tabpfn/inference.py
+++ b/src/tabpfn/inference.py
@@ -48,17 +48,30 @@ _T = TypeVar("_T")
 
 
 class _TimedIterator(Iterator[_T]):
-    """Wraps an iterator, accumulating wall-clock time spent in ``__next__``."""
+    """Wraps an iterator, accumulating wall-clock time spent in ``__next__``.
 
-    def __init__(self, inner: Iterator[_T]) -> None:
+    On a single device it forces completion on that device before recording each
+    step, so the timing captures real GPU compute rather than kernel-launch time.
+    On multiple devices parallel_execute already waits on a per-output CUDA event,
+    so no extra sync is added.
+    """
+
+    def __init__(self, inner: Iterator[_T], devices: Sequence[torch.device]) -> None:
         super().__init__()
         self._inner = inner
+        self._device = devices[0]
+        self._synchronize = len(devices) == 1
         self.elapsed_seconds: float = 0.0
 
     @override
     def __next__(self) -> _T:
         start = time.perf_counter()
         value = next(self._inner)
+        if self._synchronize:
+            if self._device.type == "cuda":
+                torch.cuda.synchronize(self._device)
+            elif self._device.type == "mps" and hasattr(torch, "mps"):
+                torch.mps.synchronize()
         self.elapsed_seconds += time.perf_counter() - start
         return value
 
@@ -408,7 +421,8 @@ class InferenceEngineOnDemand(MultiDeviceInferenceEngine):
                 devices,
                 model_forward_functions,
                 prewarm_lapack=self.ensemble_preprocessor.any_estimator_uses_gpu_svd(),
-            )
+            ),
+            devices,
         )
 
         for config, output in zip(
@@ -551,44 +565,48 @@ class InferenceEngineBatchedNoPreprocessing(SingleDeviceInferenceEngine):
     ) -> Iterator[tuple[torch.Tensor | dict, list[EnsembleConfig]]]:
         device = _get_current_device(self.models[0])
         batch_size = len(self.X_trains)
-        forward_time = 0.0
-        for i in range(batch_size):
-            train_x_full = torch.cat([self.X_trains[i], X[i]], dim=-2)
-            train_y_batch = self.y_trains[i]
-            train_x_full = train_x_full.to(device)
-            train_y_batch = train_y_batch.to(device)
-            model = self.models[self.ensemble_configs[i][0]._model_index]
-            if self.force_inference_dtype is not None:
-                train_x_full = train_x_full.type(self.force_inference_dtype)
-                train_y_batch = train_y_batch.type(self.force_inference_dtype)  # type: ignore
-                model.type(self.force_inference_dtype)
 
-            kwargs = {}
-            if _model_expectes_task_type_arg(model):
-                kwargs["task_type"] = task_type
-            forward_start = time.perf_counter()
-            with (
-                get_autocast_context(device, enabled=autocast),
-                torch.inference_mode(self.inference_mode),
-            ):
-                output = model(
-                    train_x_full.transpose(0, 1),
-                    train_y_batch.transpose(0, 1),
-                    only_return_standard_out=True,
-                    categorical_inds=list(  # noqa: C411
-                        [
-                            cat_item[i].indices_for(FeatureModality.CATEGORICAL)
-                            for cat_item in self.feature_schema_list
-                        ]
-                    ),
-                    performance_options=self.performance_options,
-                    **kwargs,
-                )
-            forward_time += time.perf_counter() - forward_start
+        def _forward_outputs() -> Iterator[
+            tuple[torch.Tensor | dict, list[EnsembleConfig]]
+        ]:
+            for i in range(batch_size):
+                train_x_full = torch.cat([self.X_trains[i], X[i]], dim=-2)
+                train_y_batch = self.y_trains[i]
+                train_x_full = train_x_full.to(device)
+                train_y_batch = train_y_batch.to(device)
+                model = self.models[self.ensemble_configs[i][0]._model_index]
+                if self.force_inference_dtype is not None:
+                    train_x_full = train_x_full.type(self.force_inference_dtype)
+                    train_y_batch = train_y_batch.type(self.force_inference_dtype)  # type: ignore
+                    model.type(self.force_inference_dtype)
 
-            yield output, self.ensemble_configs[i]
+                kwargs = {}
+                if _model_expectes_task_type_arg(model):
+                    kwargs["task_type"] = task_type
+                with (
+                    get_autocast_context(device, enabled=autocast),
+                    torch.inference_mode(self.inference_mode),
+                ):
+                    output = model(
+                        train_x_full.transpose(0, 1),
+                        train_y_batch.transpose(0, 1),
+                        only_return_standard_out=True,
+                        categorical_inds=list(  # noqa: C411
+                            [
+                                cat_item[i].indices_for(FeatureModality.CATEGORICAL)
+                                for cat_item in self.feature_schema_list
+                            ]
+                        ),
+                        performance_options=self.performance_options,
+                        **kwargs,
+                    )
+                yield output, self.ensemble_configs[i]
 
-        self._speed_metrics["predict_model_forward_seconds"] = forward_time
+        timed_outputs = _TimedIterator(_forward_outputs(), [device])
+        yield from timed_outputs
+        self._speed_metrics["predict_model_forward_seconds"] = (
+            timed_outputs.elapsed_seconds
+        )
 
     @override
     def use_torch_inference_mode(self, *, use_inference: bool) -> None:
@@ -726,7 +744,8 @@ class InferenceEngineCachePreprocessing(MultiDeviceInferenceEngine):
                 devices,
                 model_forward_functions,
                 prewarm_lapack=self.ensemble_preprocessor.any_estimator_uses_gpu_svd(),
-            )
+            ),
+            devices,
         )
 
         for output, ensemble_member in zip(
@@ -912,7 +931,8 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
                 devices,
                 build_functions,
                 prewarm_lapack=self.ensemble_preprocessor.any_estimator_uses_gpu_svd(),
-            )
+            ),
+            devices,
         )
         self.kv_caches: list = list(timed_caches)
         self._speed_metrics["fit_model_forward_seconds"] = timed_caches.elapsed_seconds
@@ -1039,7 +1059,8 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
                 devices,
                 model_forward_functions,
                 prewarm_lapack=self.ensemble_preprocessor.any_estimator_uses_gpu_svd(),
-            )
+            ),
+            devices,
         )
 
         for output, ensemble_member in zip(

--- a/src/tabpfn/parallel_execute.py
+++ b/src/tabpfn/parallel_execute.py
@@ -94,15 +94,7 @@ def _execute_in_current_thread(
     device: torch.device, functions: Iterable[ParallelFunction[R_co]]
 ) -> Generator[R_co]:
     for function in functions:
-        output = function(device=device)
-        # Force GPU completion before yielding so a _TimedIterator around this
-        # measures real compute, not just kernel-launch time.
-        # Negligible overhead
-        if device.type == "cuda":
-            torch.cuda.synchronize(device)
-        elif device.type == "mps" and hasattr(torch, "mps"):
-            torch.mps.synchronize()
-        yield output
+        yield function(device=device)
 
 
 def _execute_with_multithreading(

--- a/src/tabpfn/parallel_execute.py
+++ b/src/tabpfn/parallel_execute.py
@@ -100,6 +100,8 @@ def _execute_in_current_thread(
         # Negligible overhead
         if device.type == "cuda":
             torch.cuda.synchronize(device)
+        elif device.type == "mps" and hasattr(torch, "mps"):
+            torch.mps.synchronize()
         yield output
 
 

--- a/src/tabpfn/parallel_execute.py
+++ b/src/tabpfn/parallel_execute.py
@@ -94,7 +94,13 @@ def _execute_in_current_thread(
     device: torch.device, functions: Iterable[ParallelFunction[R_co]]
 ) -> Generator[R_co]:
     for function in functions:
-        yield function(device=device)
+        output = function(device=device)
+        # Force GPU completion before yielding so a _TimedIterator around this
+        # measures real compute, not just kernel-launch time.
+        # Negligible overhead
+        if device.type == "cuda":
+            torch.cuda.synchronize(device)
+        yield output
 
 
 def _execute_with_multithreading(


### PR DESCRIPTION

## Issue
Resolves #1112 1112

## Motivation and Context
### What
In `_execute_in_current_thread` (the single-device path of `parallel_execute`),
call `torch.cuda.synchronize(device)` before yielding each result. 
This enables to correctly measure the forward time, without adding any overhead.

### Why
`InferenceEngine._speed_metrics` times the fit KV-cache build and the predict
forward by wrapping this generator in a `_TimedIterator`. On a single GPU the
prior path returned right after *launching* kernels, so the timer captured
kernel-launch time, not GPU compute — undercounting the forward badly and
increasingly with load. The multi-device path already forces completion (it
waits on a per-output `torch.cuda.Event`); this brings the single-device path
in line.

This is a timing-instrumentation fix, **not** a correctness change: single-device
consumers run on the same default stream, so result ordering was already correct
without the sync.

### Impact
Measured on one RTX PRO 6000, n_train=200k, 50 cols, fit_with_cache:

| config | phase | model_forward_s (before → after) | median_s (before → after) |
|---|---|---|---|
| n_est=1 | predict n=1    | 0.0125 → 0.0174 | 0.0210 → 0.0210 |
| n_est=1 | predict n=1000 | 0.0139 → 0.0577 | 0.0617 → 0.0617 |
| n_est=1 | fit            | 5.75 → 7.18     | 7.81 → 7.79     |
| n_est=8 | predict n=1    | 0.0972 → 0.1400 | 0.1416 → 0.1456 |
| n_est=8 | predict n=1000 | 0.1086 → 0.4607 | 0.4669 → 0.4673 |
| n_est=8 | fit            | 55.8 → 57.3     | 58.5 → 58.5     |

- Forward timings become accurate (predict was ~4× undercounted).
- End-to-end latency (`median_s`) is unchanged within noise → no measurable
  overhead, including at n_estimators=8.


---

## Public API Changes

-   [x] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?
(see above description)
---

## Checklist

-   [x] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [ ] A changelog entry has been added (see `changelog/README.md`), or "no changelog needed" label requested.
-   [x] The code follows the project's style guidelines.
-   [x] I have considered the impact of these changes on the public API.

---
