### PR TITLE
Add Dependabot cooldown so bumps clear uv's exclude-newer window

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
+    # Only propose versions old enough to pass uv's `exclude-newer = "7 days"`
+    # quarantine (see pyproject.toml).
+    cooldown:
+      default-days: 8
 
   # GitHub Actions
   - package-ecosystem: "github-actions"

--- a/changelog/1114.changed.md
+++ b/changelog/1114.changed.md
@@ -1,0 +1,1 @@
+Dependabot now waits 8 days before proposing a new dependency version, so bumps clear uv's `exclude-newer` quarantine and pass CI.

--- a/changelog/1114.changed.md
+++ b/changelog/1114.changed.md
@@ -1,1 +1,0 @@
-Dependabot now waits 8 days before proposing a new dependency version, so bumps clear uv's `exclude-newer` quarantine and pass CI.


### PR DESCRIPTION
## Why

Dependabot PRs pinning a freshly released version fail CI at `uv sync` because `pyproject.toml` sets `exclude-newer = "7 days"`, which filters out packages published in the last 7 days (see the mypy 2.2.0 bump in #1108).

## What

Add a `cooldown` to the pip ecosystem in `dependabot.yml` so Dependabot only proposes versions old enough to pass the quarantine. Set to 8 days rather than 7 because Dependabot counts whole days from the release date while uv compares exact timestamps at CI run time.

Per [the docs](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-), the cooldown is ignored for security updates — those may still fail CI until the version ages past the window, which is a useful signal (as discussed in #1108).

🤖 Generated with [Claude Code](https://claude.com/claude-code)