### PR TITLE
add KV cache dtype as explicit argument [PRI-347]

### DIFF
--- a/changelog/1120.changed.md
+++ b/changelog/1120.changed.md
@@ -1,0 +1,1 @@
+Expose the `kv_cache_dtype` as explicit argument.

--- a/src/tabpfn/architectures/interface.py
+++ b/src/tabpfn/architectures/interface.py
@@ -255,9 +255,7 @@ class Architecture(nn.Module, ABC):
 
         ``"auto"`` (keep the computed dtype) is always supported. Architectures
         whose cache implements quantization override this to additionally list
-        e.g. ``"int8"``. Used to resolve the estimator's ``kv_cache_precision``:
-        ``None`` picks the most compact supported value, and an unsupported
-        request falls back to ``"auto"``.
+        e.g. ``"int8"``.
         """
         return ("auto",)
 

--- a/src/tabpfn/architectures/interface.py
+++ b/src/tabpfn/architectures/interface.py
@@ -250,6 +250,17 @@ class Architecture(nn.Module, ABC):
             use_chunkwise_inference=False,
         )
 
+    def get_supported_kv_cache_precisions(self) -> tuple[str, ...]:
+        """KV cache storage dtypes this architecture supports (``fit_with_cache``).
+
+        ``"auto"`` (keep the computed dtype) is always supported. Architectures
+        whose cache implements quantization override this to additionally list
+        e.g. ``"int8"``. Used to resolve the estimator's ``kv_cache_precision``:
+        ``None`` picks the most compact supported value, and an unsupported
+        request falls back to ``"auto"``.
+        """
+        return ("auto",)
+
     @property
     @abstractmethod
     def embedding_dim(self) -> int:

--- a/src/tabpfn/architectures/tabpfn_v3.py
+++ b/src/tabpfn/architectures/tabpfn_v3.py
@@ -262,7 +262,7 @@ def get_cache_size(
     n_features: int,
     model_config: TabPFNV3Config,
     base_dtype: torch.dtype | Literal["autocast"],
-    quantize_kv_cache: bool = True,
+    kv_cache_dtype: Literal["auto", "int8"] = "int8",
 ) -> int:
     """Calculate the cached memory in bytes for a single TabPFN v3 estimator.
 
@@ -289,8 +289,8 @@ def get_cache_size(
       reduction/norm-lineage tensors (``inducing_hidden``, ``scaler_cache``)
       stay fp32.
 
-    The KV cache is additionally int8-quantized when ``quantize_kv_cache`` is
-    True (mirroring the engine's ``kv_cache_dtype="int8"``).
+    The KV cache is additionally int8-quantized when ``kv_cache_dtype="int8"``
+    (mirroring the engine's ``kv_cache_dtype`` option).
 
     Args:
         n_train: Number of training rows. The KV cache and train activations
@@ -306,16 +306,18 @@ def get_cache_size(
             ``"autocast"`` (GPU autocast path -- KV and ``train_embeddings`` are
             sized at fp16 while ``inducing_hidden`` and ``scaler_cache`` stay
             fp32, since autocast keeps those ops in fp32).
-        quantize_kv_cache: If True (default), the KV cache is sized at
+        kv_cache_dtype: If ``"int8"`` (default), the KV cache is sized at
             :data:`~tabpfn.architectures.kv_cache.QUANTIZED_KV_DTYPE` (mirrors
             the engine's ``kv_cache_dtype="int8"``) plus per-tensor scales at
-            the KV compute dtype; if False, the K/V are sized at the compute
-            dtype with no scales.
+            the KV compute dtype; if ``"auto"``, the K/V are sized at the
+            compute dtype with no scales.
 
     Returns:
         Per-estimator cache size in bytes. Multiply by the ensemble size for the
         total (each estimator holds its own cache); divide by ``1024 ** 2`` for MB.
     """
+    quantize_kv_cache = kv_cache_dtype == "int8"
+
     # Set the stored dtype of each cached component up front. On the forced-
     # precision path the model and inputs are cast to ``dtype``, so every
     # component is ``dtype``. Under autocast the cache is mixed precision.

--- a/src/tabpfn/architectures/tabpfn_v3.py
+++ b/src/tabpfn/architectures/tabpfn_v3.py
@@ -315,6 +315,11 @@ def get_cache_size(
         Per-estimator cache size in bytes. Multiply by the ensemble size for the
         total (each estimator holds its own cache); divide by ``1024 ** 2`` for MB.
     """
+    if kv_cache_dtype not in ("auto", "int8"):
+        raise ValueError(
+            f"Invalid kv_cache_dtype: {kv_cache_dtype}. "
+            "Must be one of 'auto' or 'int8'."
+        )
     quantize_kv_cache = kv_cache_dtype == "int8"
 
     # Set the stored dtype of each cached component up front. On the forced-

--- a/src/tabpfn/architectures/tabpfn_v3.py
+++ b/src/tabpfn/architectures/tabpfn_v3.py
@@ -262,7 +262,7 @@ def get_cache_size(
     n_features: int,
     model_config: TabPFNV3Config,
     base_dtype: torch.dtype | Literal["autocast"],
-    kv_cache_dtype: Literal["auto", "int8"] = "int8",
+    kv_cache_precision: Literal["auto", "int8"] = "int8",
 ) -> int:
     """Calculate the cached memory in bytes for a single TabPFN v3 estimator.
 
@@ -289,8 +289,8 @@ def get_cache_size(
       reduction/norm-lineage tensors (``inducing_hidden``, ``scaler_cache``)
       stay fp32.
 
-    The KV cache is additionally int8-quantized when ``kv_cache_dtype="int8"``
-    (mirroring the engine's ``kv_cache_dtype`` option).
+    The KV cache is additionally int8-quantized when ``kv_cache_precision="int8"``
+    (mirroring the engine's ``kv_cache_precision`` option).
 
     Args:
         n_train: Number of training rows. The KV cache and train activations
@@ -306,7 +306,7 @@ def get_cache_size(
             ``"autocast"`` (GPU autocast path -- KV and ``train_embeddings`` are
             sized at fp16 while ``inducing_hidden`` and ``scaler_cache`` stay
             fp32, since autocast keeps those ops in fp32).
-        kv_cache_dtype: If ``"int8"`` (default), the KV cache is sized at
+        kv_cache_precision: If ``"int8"`` (default), the KV cache is sized at
             :data:`~tabpfn.architectures.kv_cache.QUANTIZED_KV_DTYPE` plus
             per-tensor scales; if ``"auto"``, K/V are sized at the compute
             dtype with no scales.
@@ -315,12 +315,12 @@ def get_cache_size(
         Per-estimator cache size in bytes. Multiply by the ensemble size for the
         total (each estimator holds its own cache); divide by ``1024 ** 2`` for MB.
     """
-    if kv_cache_dtype not in ("auto", "int8"):
+    if kv_cache_precision not in ("auto", "int8"):
         raise ValueError(
-            f"Invalid kv_cache_dtype: {kv_cache_dtype}. "
+            f"Invalid kv_cache_precision: {kv_cache_precision}. "
             "Must be one of 'auto' or 'int8'."
         )
-    quantize_kv_cache = kv_cache_dtype == "int8"
+    quantize_kv_cache = kv_cache_precision == "int8"
 
     # Set the stored dtype of each cached component up front. On the forced-
     # precision path the model and inputs are cast to ``dtype``, so every
@@ -1935,6 +1935,10 @@ class TabPFNV3(Architecture):
             options,
             use_chunkwise_inference=True,
         )
+
+    @override
+    def get_supported_kv_cache_precisions(self) -> tuple[str, ...]:
+        return ("auto", "int8")
 
     def _prepare_y(
         self,

--- a/src/tabpfn/architectures/tabpfn_v3.py
+++ b/src/tabpfn/architectures/tabpfn_v3.py
@@ -290,7 +290,7 @@ def get_cache_size(
       stay fp32.
 
     The KV cache is additionally int8-quantized when ``quantize_kv_cache`` is
-    True (mirroring the engine's ``maybe_quantize_kv_cache``).
+    True (mirroring the engine's ``kv_cache_dtype="int8"``).
 
     Args:
         n_train: Number of training rows. The KV cache and train activations
@@ -308,7 +308,7 @@ def get_cache_size(
             fp32, since autocast keeps those ops in fp32).
         quantize_kv_cache: If True (default), the KV cache is sized at
             :data:`~tabpfn.architectures.kv_cache.QUANTIZED_KV_DTYPE` (mirrors
-            the engine's ``maybe_quantize_kv_cache``) plus per-tensor scales at
+            the engine's ``kv_cache_dtype="int8"``) plus per-tensor scales at
             the KV compute dtype; if False, the K/V are sized at the compute
             dtype with no scales.
 

--- a/src/tabpfn/architectures/tabpfn_v3.py
+++ b/src/tabpfn/architectures/tabpfn_v3.py
@@ -307,10 +307,9 @@ def get_cache_size(
             sized at fp16 while ``inducing_hidden`` and ``scaler_cache`` stay
             fp32, since autocast keeps those ops in fp32).
         kv_cache_dtype: If ``"int8"`` (default), the KV cache is sized at
-            :data:`~tabpfn.architectures.kv_cache.QUANTIZED_KV_DTYPE` (mirrors
-            the engine's ``kv_cache_dtype="int8"``) plus per-tensor scales at
-            the KV compute dtype; if ``"auto"``, the K/V are sized at the
-            compute dtype with no scales.
+            :data:`~tabpfn.architectures.kv_cache.QUANTIZED_KV_DTYPE` plus
+            per-tensor scales; if ``"auto"``, K/V are sized at the compute
+            dtype with no scales.
 
     Returns:
         Per-estimator cache size in bytes. Multiply by the ensemble size for the

--- a/src/tabpfn/base.py
+++ b/src/tabpfn/base.py
@@ -335,10 +335,9 @@ def create_inference_engine(  # noqa: PLR0913
             inference device. If False, caches are offloaded to CPU as they
             are built and moved back on demand during inference, lowering
             resident device memory at the cost of per-call transfers.
-        kv_cache_dtype: Only relevant for ``fit_mode="fit_with_cache"``. Dtype
-            the KV cache is stored in. ``"int8"`` (default) quantizes the cache
-            to reduce memory footprint (if supported by the architecture);
-            ``"auto"`` keeps the cache in the dtype it was computed in.
+        kv_cache_dtype: Only for ``fit_mode="fit_with_cache"``. ``"int8"``
+            (default) quantizes the KV cache to save memory; ``"auto"`` keeps
+            the computed dtype.
     """
     if fit_mode == "low_memory":
         return InferenceEngineOnDemand(

--- a/src/tabpfn/base.py
+++ b/src/tabpfn/base.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import pathlib
 import typing
-import warnings
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Literal
 
@@ -272,32 +271,6 @@ def determine_precision(
     return use_autocast_, forced_inference_dtype_, byte_size
 
 
-def warn_if_kv_cache_dtype_overrides_inference_precision(
-    *,
-    fit_mode: str,
-    kv_cache_dtype: Literal["auto", "int8"],
-    inference_precision: torch.dtype | Literal["autocast", "auto"],
-) -> None:
-    """Warn when a forced ``inference_precision`` is ignored by the int8 KV cache."""
-    if kv_cache_dtype not in ("auto", "int8"):
-        raise ValueError(
-            f"Invalid kv_cache_dtype: {kv_cache_dtype}. Expected 'auto' or 'int8'."
-        )
-    if (
-        fit_mode == "fit_with_cache"
-        and kv_cache_dtype == "int8"
-        and isinstance(inference_precision, torch.dtype)
-    ):
-        warnings.warn(
-            "inference_precision forces a dtype but kv_cache_dtype is 'int8', "
-            "so the KV cache is still stored as int8 regardless of the forced "
-            "dtype. Pass kv_cache_dtype='auto' to keep the KV cache in the "
-            "forced dtype.",
-            UserWarning,
-            stacklevel=3,
-        )
-
-
 def create_inference_engine(  # noqa: PLR0913
     *,
     fit_mode: Literal["low_memory", "fit_preprocessors", "fit_with_cache", "batched"],
@@ -312,7 +285,7 @@ def create_inference_engine(  # noqa: PLR0913
     use_autocast_: bool,
     inference_mode: bool = True,
     keep_cache_on_device: bool = True,
-    kv_cache_dtype: Literal["auto", "int8"] = "int8",
+    kv_cache_precision: Literal["auto", "int8"] | None = None,
 ) -> InferenceEngine:
     """Create the appropriate TabPFN inference engine based on `fit_mode`.
 
@@ -339,9 +312,11 @@ def create_inference_engine(  # noqa: PLR0913
             inference device. If False, caches are offloaded to CPU as they
             are built and moved back on demand during inference, lowering
             resident device memory at the cost of per-call transfers.
-        kv_cache_dtype: Only for ``fit_mode="fit_with_cache"``. ``"int8"``
-            (default) quantizes the KV cache to save memory; ``"auto"`` keeps
-            the computed dtype.
+        kv_cache_precision: Only for ``fit_mode="fit_with_cache"``. Resolved
+            against what the architecture supports. ``None`` (default) picks the
+            architecture default (``"int8"`` when it can quantize, else
+            ``"auto"``); ``"int8"`` quantizes the KV cache to save memory;
+            ``"auto"`` keeps the computed dtype.
     """
     if fit_mode == "low_memory":
         return InferenceEngineOnDemand(
@@ -378,7 +353,7 @@ def create_inference_engine(  # noqa: PLR0913
             save_peak_mem=memory_saving_mode,
             autocast=use_autocast_,
             keep_cache_on_device=keep_cache_on_device,
-            kv_cache_dtype=kv_cache_dtype,
+            kv_cache_precision=kv_cache_precision,
         )
     if fit_mode == "batched":
         raise ValueError(

--- a/src/tabpfn/base.py
+++ b/src/tabpfn/base.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import pathlib
 import typing
+import warnings
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Literal
 
@@ -271,6 +272,28 @@ def determine_precision(
     return use_autocast_, forced_inference_dtype_, byte_size
 
 
+def warn_if_kv_cache_dtype_overrides_inference_precision(
+    *,
+    fit_mode: str,
+    kv_cache_dtype: Literal["auto", "int8"],
+    inference_precision: torch.dtype | Literal["autocast", "auto"],
+) -> None:
+    """Warn when a forced ``inference_precision`` is ignored by the int8 KV cache."""
+    if (
+        fit_mode == "fit_with_cache"
+        and kv_cache_dtype == "int8"
+        and isinstance(inference_precision, torch.dtype)
+    ):
+        warnings.warn(
+            "inference_precision forces a dtype but kv_cache_dtype is 'int8', "
+            "so the KV cache is still stored as int8 regardless of the forced "
+            "dtype. Pass kv_cache_dtype='auto' to keep the KV cache in the "
+            "forced dtype.",
+            UserWarning,
+            stacklevel=3,
+        )
+
+
 def create_inference_engine(  # noqa: PLR0913
     *,
     fit_mode: Literal["low_memory", "fit_preprocessors", "fit_with_cache", "batched"],
@@ -285,6 +308,7 @@ def create_inference_engine(  # noqa: PLR0913
     use_autocast_: bool,
     inference_mode: bool = True,
     keep_cache_on_device: bool = True,
+    kv_cache_dtype: Literal["auto", "int8"] = "int8",
 ) -> InferenceEngine:
     """Create the appropriate TabPFN inference engine based on `fit_mode`.
 
@@ -311,6 +335,10 @@ def create_inference_engine(  # noqa: PLR0913
             inference device. If False, caches are offloaded to CPU as they
             are built and moved back on demand during inference, lowering
             resident device memory at the cost of per-call transfers.
+        kv_cache_dtype: Only relevant for ``fit_mode="fit_with_cache"``. Dtype
+            the KV cache is stored in. ``"int8"`` (default) quantizes the cache
+            to reduce memory footprint (if supported by the architecture);
+            ``"auto"`` keeps the cache in the dtype it was computed in.
     """
     if fit_mode == "low_memory":
         return InferenceEngineOnDemand(
@@ -347,6 +375,7 @@ def create_inference_engine(  # noqa: PLR0913
             save_peak_mem=memory_saving_mode,
             autocast=use_autocast_,
             keep_cache_on_device=keep_cache_on_device,
+            kv_cache_dtype=kv_cache_dtype,
         )
     if fit_mode == "batched":
         raise ValueError(

--- a/src/tabpfn/base.py
+++ b/src/tabpfn/base.py
@@ -279,6 +279,10 @@ def warn_if_kv_cache_dtype_overrides_inference_precision(
     inference_precision: torch.dtype | Literal["autocast", "auto"],
 ) -> None:
     """Warn when a forced ``inference_precision`` is ignored by the int8 KV cache."""
+    if kv_cache_dtype not in ("auto", "int8"):
+        raise ValueError(
+            f"Invalid kv_cache_dtype: {kv_cache_dtype}. Expected 'auto' or 'int8'."
+        )
     if (
         fit_mode == "fit_with_cache"
         and kv_cache_dtype == "int8"

--- a/src/tabpfn/classifier.py
+++ b/src/tabpfn/classifier.py
@@ -40,6 +40,7 @@ from tabpfn.base import (
     get_embeddings,
     initialize_model_variables_helper,
     reject_categoricals_for_differentiable_input,
+    warn_if_kv_cache_dtype_overrides_inference_precision,
 )
 from tabpfn.constants import (
     PROBABILITY_EPSILON_ROUND_ZERO,
@@ -233,6 +234,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
         ] = "fit_preprocessors",
         memory_saving_mode: MemorySavingMode = "auto",
         keep_cache_on_device: bool = True,
+        kv_cache_dtype: Literal["auto", "int8"] = "int8",
         random_state: int | np.random.RandomState | np.random.Generator | None = 0,
         n_jobs: Annotated[int | None, deprecated("Use n_preprocessing_jobs")] = None,
         n_preprocessing_jobs: int = 1,
@@ -419,6 +421,16 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
                 device (e.g. GPU). Uses more device
                 memory but gives lower latency. If False, the cache is stored on CPU.
 
+            kv_cache_dtype:
+                Only relevant when `fit_mode="fit_with_cache"`. Dtype the
+                key-value cache is stored in. `"int8"` (default) quantizes the
+                cache with per-tensor symmetric quantization to reduce memory
+                footprint (if supported by the architecture); `"auto"` keeps
+                the cache in the dtype it was computed in (no quantization).
+                Note that with the default `"int8"` the cache stays int8 even
+                when `inference_precision` forces another dtype; pass `"auto"`
+                to keep the KV cache in the forced dtype.
+
             random_state:
                 Controls the randomness of the model. Pass an int for reproducible
                 results and see the scikit-learn glossary for more information. If
@@ -503,6 +515,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
         self.show_progress_bar = show_progress_bar
         self.memory_saving_mode: MemorySavingMode = memory_saving_mode
         self.keep_cache_on_device = keep_cache_on_device
+        self.kv_cache_dtype = kv_cache_dtype
         self.random_state = random_state
         self.inference_config = inference_config
         self.differentiable_input = differentiable_input
@@ -815,6 +828,12 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
                 "batched",
             ] = "fit_preprocessors"
 
+        warn_if_kv_cache_dtype_overrides_inference_precision(
+            fit_mode=self.fit_mode,
+            kv_cache_dtype=self.kv_cache_dtype,
+            inference_precision=self.inference_precision,
+        )
+
         static_seed, _ = infer_random_state(self.random_state)
         byte_size = self._initialize_model_variables()
         ensemble_configs, X, y = self._initialize_dataset_preprocessing(
@@ -858,6 +877,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
             use_autocast_=self.use_autocast_,
             inference_mode=True,
             keep_cache_on_device=self.keep_cache_on_device,
+            kv_cache_dtype=self.kv_cache_dtype,
         )
 
         return self

--- a/src/tabpfn/classifier.py
+++ b/src/tabpfn/classifier.py
@@ -40,7 +40,6 @@ from tabpfn.base import (
     get_embeddings,
     initialize_model_variables_helper,
     reject_categoricals_for_differentiable_input,
-    warn_if_kv_cache_dtype_overrides_inference_precision,
 )
 from tabpfn.constants import (
     PROBABILITY_EPSILON_ROUND_ZERO,
@@ -234,7 +233,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
         ] = "fit_preprocessors",
         memory_saving_mode: MemorySavingMode = "auto",
         keep_cache_on_device: bool = True,
-        kv_cache_dtype: Literal["auto", "int8"] = "int8",
+        kv_cache_precision: Literal["auto", "int8"] | None = None,
         random_state: int | np.random.RandomState | np.random.Generator | None = 0,
         n_jobs: Annotated[int | None, deprecated("Use n_preprocessing_jobs")] = None,
         n_preprocessing_jobs: int = 1,
@@ -421,12 +420,14 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
                 device (e.g. GPU). Uses more device
                 memory but gives lower latency. If False, the cache is stored on CPU.
 
-            kv_cache_dtype:
-                Only relevant when `fit_mode="fit_with_cache"`. `"int8"`
-                (default) quantizes the key-value cache to save memory; `"auto"`
-                keeps the computed dtype. With `"int8"` the cache stays int8
-                even when `inference_precision` forces another dtype — pass
-                `"auto"` to keep it in the forced dtype.
+            kv_cache_precision:
+                Only relevant when `fit_mode="fit_with_cache"`. Resolved against
+                what the model architecture supports. `None` (default) picks the
+                architecture default (`"int8"` when it can quantize, e.g. TabPFN-3,
+                else `"auto"`); `"int8"` quantizes the key-value cache to save
+                memory; `"auto"` keeps the computed dtype. Requesting `"int8"` on
+                an architecture that cannot quantize warns and falls back to
+                `"auto"`.
 
             random_state:
                 Controls the randomness of the model. Pass an int for reproducible
@@ -512,7 +513,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
         self.show_progress_bar = show_progress_bar
         self.memory_saving_mode: MemorySavingMode = memory_saving_mode
         self.keep_cache_on_device = keep_cache_on_device
-        self.kv_cache_dtype = kv_cache_dtype
+        self.kv_cache_precision = kv_cache_precision
         self.random_state = random_state
         self.inference_config = inference_config
         self.differentiable_input = differentiable_input
@@ -825,12 +826,6 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
                 "batched",
             ] = "fit_preprocessors"
 
-        warn_if_kv_cache_dtype_overrides_inference_precision(
-            fit_mode=self.fit_mode,
-            kv_cache_dtype=getattr(self, "kv_cache_dtype", "int8"),
-            inference_precision=self.inference_precision,
-        )
-
         static_seed, _ = infer_random_state(self.random_state)
         byte_size = self._initialize_model_variables()
         ensemble_configs, X, y = self._initialize_dataset_preprocessing(
@@ -874,7 +869,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
             use_autocast_=self.use_autocast_,
             inference_mode=True,
             keep_cache_on_device=self.keep_cache_on_device,
-            kv_cache_dtype=self.kv_cache_dtype,
+            kv_cache_precision=self.kv_cache_precision,
         )
 
         return self

--- a/src/tabpfn/classifier.py
+++ b/src/tabpfn/classifier.py
@@ -422,14 +422,11 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
                 memory but gives lower latency. If False, the cache is stored on CPU.
 
             kv_cache_dtype:
-                Only relevant when `fit_mode="fit_with_cache"`. Dtype the
-                key-value cache is stored in. `"int8"` (default) quantizes the
-                cache with per-tensor symmetric quantization to reduce memory
-                footprint (if supported by the architecture); `"auto"` keeps
-                the cache in the dtype it was computed in (no quantization).
-                Note that with the default `"int8"` the cache stays int8 even
-                when `inference_precision` forces another dtype; pass `"auto"`
-                to keep the KV cache in the forced dtype.
+                Only relevant when `fit_mode="fit_with_cache"`. `"int8"`
+                (default) quantizes the key-value cache to save memory; `"auto"`
+                keeps the computed dtype. With `"int8"` the cache stays int8
+                even when `inference_precision` forces another dtype — pass
+                `"auto"` to keep it in the forced dtype.
 
             random_state:
                 Controls the randomness of the model. Pass an int for reproducible

--- a/src/tabpfn/classifier.py
+++ b/src/tabpfn/classifier.py
@@ -827,7 +827,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
 
         warn_if_kv_cache_dtype_overrides_inference_precision(
             fit_mode=self.fit_mode,
-            kv_cache_dtype=self.kv_cache_dtype,
+            kv_cache_dtype=getattr(self, "kv_cache_dtype", "int8"),
             inference_precision=self.inference_precision,
         )
 

--- a/src/tabpfn/inference.py
+++ b/src/tabpfn/inference.py
@@ -919,9 +919,9 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
         )
 
         self.keep_cache_on_device = keep_cache_on_device
-        self.kv_cache_precision = resolve_kv_cache_precision(
-            kv_cache_precision, architecture=models[0]
-        )
+        # Kept as the raw request; resolved per ensemble member in _build_cache
+        # against that member's own architecture (see resolve_kv_cache_precision).
+        self.kv_cache_precision = kv_cache_precision
         self.ensemble_preprocessor = ensemble_preprocessor
 
         # Place model copies on all devices before building caches
@@ -982,6 +982,9 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
         in parallel threads.
         """
         model = self.model_caches[model_index].get(device)
+        kv_cache_precision = resolve_kv_cache_precision(
+            self.kv_cache_precision, architecture=model
+        )
 
         # Cast model weights to match force_inference_dtype (else linear
         # layers throw a Half/Float mismatch).
@@ -1034,7 +1037,7 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
             )
 
         assert cache is not None
-        if self.kv_cache_precision == "int8":
+        if kv_cache_precision == "int8":
             cache = cache.quantize()
         if self.keep_cache_on_device:
             return cache

--- a/src/tabpfn/inference.py
+++ b/src/tabpfn/inference.py
@@ -835,11 +835,9 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
     When ``keep_cache_on_device=True``, each per-estimator cache is kept
     on the GPU for subsequent prediction calls, avoiding CPU↔GPU transfers.
 
-    For TabPFN-3 models, the KV cache can be stored as int8 (per-tensor
-    symmetric quantization) to reduce memory footprint, selected via
-    ``kv_cache_dtype="int8"`` (the default); dequantization then happens
-    on-the-fly in the attention layer. With ``kv_cache_dtype="auto"`` the
-    cache keeps whatever dtype it was computed in.
+    For TabPFN-3 models, ``kv_cache_dtype="int8"`` (the default) stores the KV
+    cache with per-tensor symmetric quantization to save memory, dequantizing
+    on-the-fly in the attention layer; ``"auto"`` keeps the computed dtype.
 
     At predict, only X_test is preprocessed (CPU and GPU). The model is
     called with ``x_is_test_only=True``. ``y`` still carries the full
@@ -885,10 +883,8 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
                 When False, caches are moved to CPU after building and
                 transferred to the target device on every predict call.
             kv_cache_dtype: Dtype the KV cache is stored in. ``"int8"``
-                (default) quantizes the cache with per-tensor symmetric
-                quantization to reduce memory footprint, if supported by the
-                architecture. ``"auto"`` keeps the cache in whatever dtype it
-                was computed in (no quantization).
+                (default) quantizes it to save memory (if the architecture
+                supports it); ``"auto"`` keeps the computed dtype.
         """
         super().__init__(
             model_caches=[_PerDeviceModelCache(model) for model in models],

--- a/src/tabpfn/inference.py
+++ b/src/tabpfn/inference.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import dataclasses
 import time
+import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Iterator, Sequence
 from copy import deepcopy
@@ -821,6 +822,27 @@ class InferenceEngineCachePreprocessing(MultiDeviceInferenceEngine):
         self.inference_mode = use_inference
 
 
+def resolve_kv_cache_precision(
+    kv_cache_precision: Literal["auto", "int8"] | None,
+    *,
+    architecture: Architecture,
+) -> Literal["auto", "int8"]:
+    """Resolve the KV cache dtype against ``architecture``."""
+    supported = architecture.get_supported_kv_cache_precisions()
+    if kv_cache_precision is None:
+        return "int8" if "int8" in supported else "auto"
+    if kv_cache_precision not in supported:
+        warnings.warn(
+            f"kv_cache_precision={kv_cache_precision!r} is not supported by "
+            f"{type(architecture).__name__} (supported: {supported}); "
+            "falling back to 'auto' (the KV cache is not quantized).",
+            UserWarning,
+            stacklevel=2,
+        )
+        return "auto"
+    return kv_cache_precision
+
+
 class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
     """Inference engine with explicit KV cache passed through forward().
 
@@ -835,7 +857,7 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
     When ``keep_cache_on_device=True``, each per-estimator cache is kept
     on the GPU for subsequent prediction calls, avoiding CPU↔GPU transfers.
 
-    For TabPFN-3 models, ``kv_cache_dtype="int8"`` (the default) stores the KV
+    For TabPFN-3 models, ``kv_cache_precision="int8"`` (the default) stores the KV
     cache with per-tensor symmetric quantization to save memory, dequantizing
     on-the-fly in the attention layer; ``"auto"`` keeps the computed dtype.
 
@@ -857,7 +879,7 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
         save_peak_mem: MemorySavingMode,
         autocast: bool,
         keep_cache_on_device: bool = True,
-        kv_cache_dtype: Literal["auto", "int8"] = "int8",
+        kv_cache_precision: Literal["auto", "int8"] | None = None,
     ) -> None:
         """Initialize the explicit KV cache inference engine.
 
@@ -882,9 +904,12 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
                 memory but avoids CPU↔GPU transfers, giving lower latency.
                 When False, caches are moved to CPU after building and
                 transferred to the target device on every predict call.
-            kv_cache_dtype: Dtype the KV cache is stored in. ``"int8"``
-                (default) quantizes it to save memory (if the architecture
-                supports it); ``"auto"`` keeps the computed dtype.
+            kv_cache_precision: Dtype the KV cache is stored in, resolved against
+                what the architecture supports (see
+                :func:`resolve_kv_cache_precision`). ``None`` (default) picks the
+                architecture default (``"int8"`` when it can quantize, else
+                ``"auto"``); ``"int8"`` quantizes to save memory; ``"auto"``
+                keeps the computed dtype.
         """
         super().__init__(
             model_caches=[_PerDeviceModelCache(model) for model in models],
@@ -894,7 +919,9 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
         )
 
         self.keep_cache_on_device = keep_cache_on_device
-        self.kv_cache_dtype = kv_cache_dtype
+        self.kv_cache_precision = resolve_kv_cache_precision(
+            kv_cache_precision, architecture=models[0]
+        )
         self.ensemble_preprocessor = ensemble_preprocessor
 
         # Place model copies on all devices before building caches
@@ -1007,7 +1034,7 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
             )
 
         assert cache is not None
-        if self.kv_cache_dtype == "int8" and hasattr(cache, "quantize"):
+        if self.kv_cache_precision == "int8":
             cache = cache.quantize()
         if self.keep_cache_on_device:
             return cache

--- a/src/tabpfn/inference.py
+++ b/src/tabpfn/inference.py
@@ -12,7 +12,7 @@ from copy import deepcopy
 from functools import partial
 from inspect import signature
 from pathlib import Path
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, Literal, TypeVar
 from typing_extensions import override
 
 import joblib
@@ -835,9 +835,11 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
     When ``keep_cache_on_device=True``, each per-estimator cache is kept
     on the GPU for subsequent prediction calls, avoiding CPU↔GPU transfers.
 
-    For TabPFN-3 models, the KV cache is stored as int8 (per-tensor symmetric
-    quantization) to reduce memory footprint; dequantization happens on-the-fly
-    in the attention layer.
+    For TabPFN-3 models, the KV cache can be stored as int8 (per-tensor
+    symmetric quantization) to reduce memory footprint, selected via
+    ``kv_cache_dtype="int8"`` (the default); dequantization then happens
+    on-the-fly in the attention layer. With ``kv_cache_dtype="auto"`` the
+    cache keeps whatever dtype it was computed in.
 
     At predict, only X_test is preprocessed (CPU and GPU). The model is
     called with ``x_is_test_only=True``. ``y`` still carries the full
@@ -857,7 +859,7 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
         save_peak_mem: MemorySavingMode,
         autocast: bool,
         keep_cache_on_device: bool = True,
-        maybe_quantize_kv_cache: bool = True,
+        kv_cache_dtype: Literal["auto", "int8"] = "int8",
     ) -> None:
         """Initialize the explicit KV cache inference engine.
 
@@ -882,9 +884,11 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
                 memory but avoids CPU↔GPU transfers, giving lower latency.
                 When False, caches are moved to CPU after building and
                 transferred to the target device on every predict call.
-            maybe_quantize_kv_cache: If True (default), quantize the KV cache
-                to reduce memory footprint if it is supported by the architecture.
-                If False, the KV cache is not quantized.
+            kv_cache_dtype: Dtype the KV cache is stored in. ``"int8"``
+                (default) quantizes the cache with per-tensor symmetric
+                quantization to reduce memory footprint, if supported by the
+                architecture. ``"auto"`` keeps the cache in whatever dtype it
+                was computed in (no quantization).
         """
         super().__init__(
             model_caches=[_PerDeviceModelCache(model) for model in models],
@@ -894,7 +898,7 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
         )
 
         self.keep_cache_on_device = keep_cache_on_device
-        self.maybe_quantize_kv_cache = maybe_quantize_kv_cache
+        self.kv_cache_dtype = kv_cache_dtype
         self.ensemble_preprocessor = ensemble_preprocessor
 
         # Place model copies on all devices before building caches
@@ -1007,7 +1011,7 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
             )
 
         assert cache is not None
-        if self.maybe_quantize_kv_cache and hasattr(cache, "quantize"):
+        if self.kv_cache_dtype == "int8" and hasattr(cache, "quantize"):
             cache = cache.quantize()
         if self.keep_cache_on_device:
             return cache

--- a/src/tabpfn/regressor.py
+++ b/src/tabpfn/regressor.py
@@ -732,7 +732,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
             memory_saving_mode=self.memory_saving_mode,
             use_autocast_=self.use_autocast_,
             keep_cache_on_device=self.keep_cache_on_device,
-            kv_cache_dtype=self.kv_cache_dtype,
+            kv_cache_dtype=getattr(self, "kv_cache_dtype", "int8"),
             inference_mode=inference_mode,
         )
 

--- a/src/tabpfn/regressor.py
+++ b/src/tabpfn/regressor.py
@@ -1068,7 +1068,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
 
         warn_if_kv_cache_dtype_overrides_inference_precision(
             fit_mode=self.fit_mode,
-            kv_cache_dtype=self.kv_cache_dtype,
+            kv_cache_dtype=getattr(self, "kv_cache_dtype", "int8"),
             inference_precision=self.inference_precision,
         )
 

--- a/src/tabpfn/regressor.py
+++ b/src/tabpfn/regressor.py
@@ -423,14 +423,11 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
                 memory but gives lower latency. If False, the cache is stored on CPU.
 
             kv_cache_dtype:
-                Only relevant when `fit_mode="fit_with_cache"`. Dtype the
-                key-value cache is stored in. `"int8"` (default) quantizes the
-                cache with per-tensor symmetric quantization to reduce memory
-                footprint (if supported by the architecture); `"auto"` keeps
-                the cache in the dtype it was computed in (no quantization).
-                Note that with the default `"int8"` the cache stays int8 even
-                when `inference_precision` forces another dtype; pass `"auto"`
-                to keep the KV cache in the forced dtype.
+                Only relevant when `fit_mode="fit_with_cache"`. `"int8"`
+                (default) quantizes the key-value cache to save memory; `"auto"`
+                keeps the computed dtype. With `"int8"` the cache stays int8
+                even when `inference_precision` forces another dtype — pass
+                `"auto"` to keep it in the forced dtype.
 
             random_state:
                 Controls the randomness of the model. Pass an int for reproducible

--- a/src/tabpfn/regressor.py
+++ b/src/tabpfn/regressor.py
@@ -47,7 +47,6 @@ from tabpfn.base import (
     get_embeddings,
     initialize_model_variables_helper,
     reject_categoricals_for_differentiable_input,
-    warn_if_kv_cache_dtype_overrides_inference_precision,
 )
 from tabpfn.constants import (
     REGRESSION_CONSTANT_TARGET_BORDER_EPSILON,
@@ -244,7 +243,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
         ] = "fit_preprocessors",
         memory_saving_mode: MemorySavingMode = "auto",
         keep_cache_on_device: bool = True,
-        kv_cache_dtype: Literal["auto", "int8"] = "int8",
+        kv_cache_precision: Literal["auto", "int8"] | None = None,
         random_state: int | np.random.RandomState | np.random.Generator | None = 0,
         n_jobs: Annotated[int | None, deprecated("Use n_preprocessing_jobs")] = None,
         n_preprocessing_jobs: int = 1,
@@ -422,12 +421,14 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
                 device (e.g. GPU). Uses more device
                 memory but gives lower latency. If False, the cache is stored on CPU.
 
-            kv_cache_dtype:
-                Only relevant when `fit_mode="fit_with_cache"`. `"int8"`
-                (default) quantizes the key-value cache to save memory; `"auto"`
-                keeps the computed dtype. With `"int8"` the cache stays int8
-                even when `inference_precision` forces another dtype — pass
-                `"auto"` to keep it in the forced dtype.
+            kv_cache_precision:
+                Only relevant when `fit_mode="fit_with_cache"`. Resolved against
+                what the model architecture supports. `None` (default) picks the
+                architecture default (`"int8"` when it can quantize, e.g. TabPFN-3,
+                else `"auto"`); `"int8"` quantizes the key-value cache to save
+                memory; `"auto"` keeps the computed dtype. Requesting `"int8"` on
+                an architecture that cannot quantize warns and falls back to
+                `"auto"`.
 
             random_state:
                 Controls the randomness of the model. Pass an int for reproducible
@@ -501,7 +502,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
         self.show_progress_bar = show_progress_bar
         self.memory_saving_mode: MemorySavingMode = memory_saving_mode
         self.keep_cache_on_device = keep_cache_on_device
-        self.kv_cache_dtype = kv_cache_dtype
+        self.kv_cache_precision = kv_cache_precision
         self.random_state = random_state
         self.inference_config = inference_config
         self.differentiable_input = differentiable_input
@@ -732,7 +733,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
             memory_saving_mode=self.memory_saving_mode,
             use_autocast_=self.use_autocast_,
             keep_cache_on_device=self.keep_cache_on_device,
-            kv_cache_dtype=getattr(self, "kv_cache_dtype", "int8"),
+            kv_cache_precision=self.kv_cache_precision,
             inference_mode=inference_mode,
         )
 
@@ -1065,12 +1066,6 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
                 "prediction. The model will be re-initialized."
             )
             self.fit_mode = "fit_preprocessors"
-
-        warn_if_kv_cache_dtype_overrides_inference_precision(
-            fit_mode=self.fit_mode,
-            kv_cache_dtype=getattr(self, "kv_cache_dtype", "int8"),
-            inference_precision=self.inference_precision,
-        )
 
         static_seed, _ = infer_random_state(self.random_state)
         byte_size = self._initialize_model_variables()

--- a/src/tabpfn/regressor.py
+++ b/src/tabpfn/regressor.py
@@ -47,6 +47,7 @@ from tabpfn.base import (
     get_embeddings,
     initialize_model_variables_helper,
     reject_categoricals_for_differentiable_input,
+    warn_if_kv_cache_dtype_overrides_inference_precision,
 )
 from tabpfn.constants import (
     REGRESSION_CONSTANT_TARGET_BORDER_EPSILON,
@@ -243,6 +244,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
         ] = "fit_preprocessors",
         memory_saving_mode: MemorySavingMode = "auto",
         keep_cache_on_device: bool = True,
+        kv_cache_dtype: Literal["auto", "int8"] = "int8",
         random_state: int | np.random.RandomState | np.random.Generator | None = 0,
         n_jobs: Annotated[int | None, deprecated("Use n_preprocessing_jobs")] = None,
         n_preprocessing_jobs: int = 1,
@@ -420,6 +422,16 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
                 device (e.g. GPU). Uses more device
                 memory but gives lower latency. If False, the cache is stored on CPU.
 
+            kv_cache_dtype:
+                Only relevant when `fit_mode="fit_with_cache"`. Dtype the
+                key-value cache is stored in. `"int8"` (default) quantizes the
+                cache with per-tensor symmetric quantization to reduce memory
+                footprint (if supported by the architecture); `"auto"` keeps
+                the cache in the dtype it was computed in (no quantization).
+                Note that with the default `"int8"` the cache stays int8 even
+                when `inference_precision` forces another dtype; pass `"auto"`
+                to keep the KV cache in the forced dtype.
+
             random_state:
                 Controls the randomness of the model. Pass an int for reproducible
                 results and see the scikit-learn glossary for more information.
@@ -492,6 +504,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
         self.show_progress_bar = show_progress_bar
         self.memory_saving_mode: MemorySavingMode = memory_saving_mode
         self.keep_cache_on_device = keep_cache_on_device
+        self.kv_cache_dtype = kv_cache_dtype
         self.random_state = random_state
         self.inference_config = inference_config
         self.differentiable_input = differentiable_input
@@ -722,6 +735,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
             memory_saving_mode=self.memory_saving_mode,
             use_autocast_=self.use_autocast_,
             keep_cache_on_device=self.keep_cache_on_device,
+            kv_cache_dtype=self.kv_cache_dtype,
             inference_mode=inference_mode,
         )
 
@@ -1054,6 +1068,12 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
                 "prediction. The model will be re-initialized."
             )
             self.fit_mode = "fit_preprocessors"
+
+        warn_if_kv_cache_dtype_overrides_inference_precision(
+            fit_mode=self.fit_mode,
+            kv_cache_dtype=self.kv_cache_dtype,
+            inference_precision=self.inference_precision,
+        )
 
         static_seed, _ = infer_random_state(self.random_state)
         byte_size = self._initialize_model_variables()

--- a/tests/test_architectures/test_tabpfn_v3.py
+++ b/tests/test_architectures/test_tabpfn_v3.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import dataclasses
 import sys
+from typing import Literal
 
 import pytest
 import torch
@@ -571,20 +572,20 @@ def _build_cache(
     x: torch.Tensor,
     y: torch.Tensor,
     *,
-    quantize_kv_cache: bool,
+    kv_cache_dtype: Literal["auto", "int8"],
 ) -> TabPFNV3Cache:
     """Build a cache the way the inference engine does: forward to populate it,
     then apply the ``kv_cache_dtype="int8"`` step (``cache.quantize()``).
     """
     _, cache = arch(x, y, return_kv_cache=True)
-    return cache.quantize() if quantize_kv_cache else cache
+    return cache.quantize() if kv_cache_dtype == "int8" else cache
 
 
 @torch.no_grad()
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
-@pytest.mark.parametrize("quantize_kv_cache", [True, False])
+@pytest.mark.parametrize("kv_cache_dtype", ["int8", "auto"])
 def test__calculate_cache_size__matches_whole_classifier_cache(
-    quantize_kv_cache: bool,
+    kv_cache_dtype: Literal["auto", "int8"],
     dtype: torch.dtype,
 ) -> None:
     """get_cache_size equals the exact byte size of every tensor in a real
@@ -606,14 +607,14 @@ def test__calculate_cache_size__matches_whole_classifier_cache(
     torch.manual_seed(0)
     x = (torch.randn(20, 1, n_features, dtype=torch.float32) * 0.1).to(dtype)
     y = torch.randint(0, 10, (n_train,), dtype=torch.float32).to(dtype)
-    cache = _build_cache(arch, x, y, quantize_kv_cache=quantize_kv_cache)
+    cache = _build_cache(arch, x, y, kv_cache_dtype=kv_cache_dtype)
 
     total = get_cache_size(
         n_train=n_train,
         n_features=n_features,
         model_config=cfg,
         base_dtype=dtype,
-        quantize_kv_cache=quantize_kv_cache,
+        kv_cache_dtype=kv_cache_dtype,
     )
     # Exact: accounts for every tensor the real cache holds.
     assert total == _sum_cache_tensors(cache)
@@ -625,9 +626,9 @@ def test__calculate_cache_size__matches_whole_classifier_cache(
     reason="Autocast inference is only enabled on CUDA (disabled on CPU/MPS), so "
     "the mixed-precision cache it produces can only be built on a GPU.",
 )
-@pytest.mark.parametrize("quantize_kv_cache", [True, False])
+@pytest.mark.parametrize("kv_cache_dtype", ["int8", "auto"])
 def test__calculate_cache_size__matches_whole_classifier_cache_autocast(
-    quantize_kv_cache: bool,
+    kv_cache_dtype: Literal["auto", "int8"],
 ) -> None:
     """get_cache_size matches the exact byte size of a real classifier cache built
     on the GPU autocast path (the default for ``inference_precision='auto'`` on a
@@ -652,7 +653,7 @@ def test__calculate_cache_size__matches_whole_classifier_cache_autocast(
     y = torch.randint(0, 10, (n_train,), dtype=torch.float32, device=device)
     with get_autocast_context(device, enabled=True):
         _, cache = arch(x, y, return_kv_cache=True)
-    if quantize_kv_cache:
+    if kv_cache_dtype == "int8":
         cache = cache.quantize()
 
     total = get_cache_size(
@@ -661,7 +662,7 @@ def test__calculate_cache_size__matches_whole_classifier_cache_autocast(
         model_config=cfg,
         # "autocast": KV/train_embeddings sized at fp16, inducing/scaler at fp32.
         base_dtype="autocast",
-        quantize_kv_cache=quantize_kv_cache,
+        kv_cache_dtype=kv_cache_dtype,
     )
     assert total == _sum_cache_tensors(cache)
 
@@ -687,7 +688,7 @@ def test__calculate_cache_size__matches_whole_regression_cache(
     torch.manual_seed(0)
     x = torch.randn(20, 1, n_features, dtype=torch.float32).to(dtype)
     y = torch.randn(n_train, dtype=torch.float32).to(dtype)
-    cache = _build_cache(arch, x, y, quantize_kv_cache=True)
+    cache = _build_cache(arch, x, y, kv_cache_dtype="int8")
 
     total = get_cache_size(
         n_train=n_train, n_features=n_features, model_config=cfg, base_dtype=dtype
@@ -709,7 +710,7 @@ def test__calculate_cache_size__mqa_smaller_than_mha() -> None:
     mha = tabpfn_v3.TabPFNV3Config(**common)  # H_kv = icl_num_heads = 4
     mqa = tabpfn_v3.TabPFNV3Config(**common, icl_num_kv_heads_test=1)  # H_kv = 1
     n_train = 50
-    # quantize_kv_cache defaults to True, so the KV cache is int8 (1 byte)
+    # kv_cache_dtype defaults to "int8", so the KV cache is int8 (1 byte)
     # regardless of base_dtype; base_dtype only sizes the (cancelling) non-KV terms.
     kw = {"n_train": n_train, "n_features": 5, "base_dtype": torch.float32}
     est_mha = get_cache_size(model_config=mha, **kw)
@@ -739,7 +740,7 @@ def test__calculate_cache_size__tabpfn3_classifier_1000_rows() -> None:
         "n_features": 1,
         "model_config": config,
         "base_dtype": torch.float16,
-        "quantize_kv_cache": True,
+        "kv_cache_dtype": "int8",
     }
     # get_cache_size always sums the full cache. Fixed terms (n_features = 1):
     #   KV int8:            nlayers*2*H_kv*head_dim * N = 24*2*1*64 * 1000 = 3,072,000

--- a/tests/test_architectures/test_tabpfn_v3.py
+++ b/tests/test_architectures/test_tabpfn_v3.py
@@ -572,20 +572,20 @@ def _build_cache(
     x: torch.Tensor,
     y: torch.Tensor,
     *,
-    kv_cache_dtype: Literal["auto", "int8"],
+    kv_cache_precision: Literal["auto", "int8"],
 ) -> TabPFNV3Cache:
     """Build a cache the way the inference engine does: forward to populate it,
-    then apply the ``kv_cache_dtype="int8"`` step (``cache.quantize()``).
+    then apply the ``kv_cache_precision="int8"`` step (``cache.quantize()``).
     """
     _, cache = arch(x, y, return_kv_cache=True)
-    return cache.quantize() if kv_cache_dtype == "int8" else cache
+    return cache.quantize() if kv_cache_precision == "int8" else cache
 
 
 @torch.no_grad()
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
-@pytest.mark.parametrize("kv_cache_dtype", ["int8", "auto"])
+@pytest.mark.parametrize("kv_cache_precision", ["int8", "auto"])
 def test__calculate_cache_size__matches_whole_classifier_cache(
-    kv_cache_dtype: Literal["auto", "int8"],
+    kv_cache_precision: Literal["auto", "int8"],
     dtype: torch.dtype,
 ) -> None:
     """get_cache_size equals the exact byte size of every tensor in a real
@@ -607,14 +607,14 @@ def test__calculate_cache_size__matches_whole_classifier_cache(
     torch.manual_seed(0)
     x = (torch.randn(20, 1, n_features, dtype=torch.float32) * 0.1).to(dtype)
     y = torch.randint(0, 10, (n_train,), dtype=torch.float32).to(dtype)
-    cache = _build_cache(arch, x, y, kv_cache_dtype=kv_cache_dtype)
+    cache = _build_cache(arch, x, y, kv_cache_precision=kv_cache_precision)
 
     total = get_cache_size(
         n_train=n_train,
         n_features=n_features,
         model_config=cfg,
         base_dtype=dtype,
-        kv_cache_dtype=kv_cache_dtype,
+        kv_cache_precision=kv_cache_precision,
     )
     # Exact: accounts for every tensor the real cache holds.
     assert total == _sum_cache_tensors(cache)
@@ -626,9 +626,9 @@ def test__calculate_cache_size__matches_whole_classifier_cache(
     reason="Autocast inference is only enabled on CUDA (disabled on CPU/MPS), so "
     "the mixed-precision cache it produces can only be built on a GPU.",
 )
-@pytest.mark.parametrize("kv_cache_dtype", ["int8", "auto"])
+@pytest.mark.parametrize("kv_cache_precision", ["int8", "auto"])
 def test__calculate_cache_size__matches_whole_classifier_cache_autocast(
-    kv_cache_dtype: Literal["auto", "int8"],
+    kv_cache_precision: Literal["auto", "int8"],
 ) -> None:
     """get_cache_size matches the exact byte size of a real classifier cache built
     on the GPU autocast path (the default for ``inference_precision='auto'`` on a
@@ -653,7 +653,7 @@ def test__calculate_cache_size__matches_whole_classifier_cache_autocast(
     y = torch.randint(0, 10, (n_train,), dtype=torch.float32, device=device)
     with get_autocast_context(device, enabled=True):
         _, cache = arch(x, y, return_kv_cache=True)
-    if kv_cache_dtype == "int8":
+    if kv_cache_precision == "int8":
         cache = cache.quantize()
 
     total = get_cache_size(
@@ -662,7 +662,7 @@ def test__calculate_cache_size__matches_whole_classifier_cache_autocast(
         model_config=cfg,
         # "autocast": KV/train_embeddings sized at fp16, inducing/scaler at fp32.
         base_dtype="autocast",
-        kv_cache_dtype=kv_cache_dtype,
+        kv_cache_precision=kv_cache_precision,
     )
     assert total == _sum_cache_tensors(cache)
 
@@ -688,7 +688,7 @@ def test__calculate_cache_size__matches_whole_regression_cache(
     torch.manual_seed(0)
     x = torch.randn(20, 1, n_features, dtype=torch.float32).to(dtype)
     y = torch.randn(n_train, dtype=torch.float32).to(dtype)
-    cache = _build_cache(arch, x, y, kv_cache_dtype="int8")
+    cache = _build_cache(arch, x, y, kv_cache_precision="int8")
 
     total = get_cache_size(
         n_train=n_train, n_features=n_features, model_config=cfg, base_dtype=dtype
@@ -710,7 +710,7 @@ def test__calculate_cache_size__mqa_smaller_than_mha() -> None:
     mha = tabpfn_v3.TabPFNV3Config(**common)  # H_kv = icl_num_heads = 4
     mqa = tabpfn_v3.TabPFNV3Config(**common, icl_num_kv_heads_test=1)  # H_kv = 1
     n_train = 50
-    # kv_cache_dtype defaults to "int8", so the KV cache is int8 (1 byte)
+    # kv_cache_precision defaults to "int8", so the KV cache is int8 (1 byte)
     # regardless of base_dtype; base_dtype only sizes the (cancelling) non-KV terms.
     kw = {"n_train": n_train, "n_features": 5, "base_dtype": torch.float32}
     est_mha = get_cache_size(model_config=mha, **kw)
@@ -740,7 +740,7 @@ def test__calculate_cache_size__tabpfn3_classifier_1000_rows() -> None:
         "n_features": 1,
         "model_config": config,
         "base_dtype": torch.float16,
-        "kv_cache_dtype": "int8",
+        "kv_cache_precision": "int8",
     }
     # get_cache_size always sums the full cache. Fixed terms (n_features = 1):
     #   KV int8:            nlayers*2*H_kv*head_dim * N = 24*2*1*64 * 1000 = 3,072,000

--- a/tests/test_architectures/test_tabpfn_v3.py
+++ b/tests/test_architectures/test_tabpfn_v3.py
@@ -574,7 +574,7 @@ def _build_cache(
     quantize_kv_cache: bool,
 ) -> TabPFNV3Cache:
     """Build a cache the way the inference engine does: forward to populate it,
-    then apply the ``maybe_quantize_kv_cache`` step (``cache.quantize()``).
+    then apply the ``kv_cache_dtype="int8"`` step (``cache.quantize()``).
     """
     _, cache = arch(x, y, return_kv_cache=True)
     return cache.quantize() if quantize_kv_cache else cache

--- a/tests/test_classifier_interface.py
+++ b/tests/test_classifier_interface.py
@@ -558,7 +558,7 @@ def test__fit_preprocessors_and_with_cache_produce_equal_results(
 
     torch.random.manual_seed(0)
     tabpfn = TabPFNClassifier.create_default_for_version(
-        fit_mode="fit_with_cache", kv_cache_dtype="auto", **kwargs
+        fit_mode="fit_with_cache", kv_cache_precision="auto", **kwargs
     )
     tabpfn.fit(X, y)
     np.testing.assert_array_almost_equal(probs, tabpfn.predict_proba(X))

--- a/tests/test_classifier_interface.py
+++ b/tests/test_classifier_interface.py
@@ -7,7 +7,7 @@ import itertools
 import os
 from collections.abc import Callable
 from itertools import product
-from typing import Any, Literal
+from typing import Literal
 
 import numpy as np
 import pandas as pd
@@ -26,7 +26,6 @@ from tabpfn import TabPFNClassifier
 from tabpfn.architectures import tabpfn_v2_5
 from tabpfn.base import ClassifierModelSpecs, initialize_tabpfn_model
 from tabpfn.constants import ModelVersion
-from tabpfn.inference import InferenceEngineExplicitKVCache
 from tabpfn.inference_config import InferenceConfig
 from tabpfn.inference_tuning import (
     MIN_NUM_SAMPLES_RECOMMENDED_FOR_TUNING,
@@ -539,7 +538,6 @@ def test__fit_preprocessors_and_with_cache_produce_equal_results(
     X_y: tuple[np.ndarray, np.ndarray],
     model_version: ModelVersion,
     device: str,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     kwargs = {
         "version": model_version,
@@ -558,21 +556,9 @@ def test__fit_preprocessors_and_with_cache_produce_equal_results(
     probs = tabpfn.predict_proba(X)
     preds = tabpfn.predict(X)
 
-    original_init = InferenceEngineExplicitKVCache.__init__
-
-    def _init_without_kv_quantization(
-        self: InferenceEngineExplicitKVCache, *args: Any, **kwargs: Any
-    ) -> None:
-        kwargs.setdefault("maybe_quantize_kv_cache", False)
-        original_init(self, *args, **kwargs)
-
-    monkeypatch.setattr(
-        InferenceEngineExplicitKVCache, "__init__", _init_without_kv_quantization
-    )
-
     torch.random.manual_seed(0)
     tabpfn = TabPFNClassifier.create_default_for_version(
-        fit_mode="fit_with_cache", **kwargs
+        fit_mode="fit_with_cache", kv_cache_dtype="auto", **kwargs
     )
     tabpfn.fit(X, y)
     np.testing.assert_array_almost_equal(probs, tabpfn.predict_proba(X))

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -15,6 +15,7 @@ from numpy.random import default_rng
 from torch import Tensor, nn
 
 from tabpfn import TabPFNClassifier, TabPFNRegressor
+from tabpfn.architectures import tabpfn_v2
 from tabpfn.architectures.interface import Architecture, PerformanceOptions
 from tabpfn.architectures.kv_cache import KVCacheEntry
 from tabpfn.architectures.shared import workaround_mps_linear_bug
@@ -26,6 +27,7 @@ from tabpfn.inference import (
     InferenceEngineExplicitKVCache,
     InferenceEngineOnDemand,
     MultiDeviceInferenceEngine,
+    resolve_kv_cache_precision,
 )
 from tabpfn.preprocessing import (
     ClassifierEnsembleConfig,
@@ -884,3 +886,22 @@ def test__kv_cache_chunking__train_embeddings_not_duplicated(
 
     assert train_emb.shape[-2] == n_train
     assert test_emb.shape[-2] == n_test
+
+
+def test__resolve_kv_cache_precision__warns_when_unsupported() -> None:
+    """int8 on a v2 architecture (which cannot quantize) warns and uses 'auto'."""
+    arch = tabpfn_v2.get_architecture(
+        tabpfn_v2.TabPFNV2Config(
+            max_num_classes=10,
+            num_buckets=5,
+            emsize=192,
+            nlayers=1,
+            nhead=6,
+            features_per_group=2,
+            seed=0,
+        ),
+        cache_trainset_representation=False,
+    )
+    with pytest.warns(UserWarning, match="not supported"):
+        resolved = resolve_kv_cache_precision("int8", architecture=arch)
+    assert resolved == "auto"

--- a/tests/test_regressor_interface.py
+++ b/tests/test_regressor_interface.py
@@ -311,11 +311,11 @@ def test__fit_preprocessors_and_with_cache_produce_equal_results(
     tabpfn.fit(X, y)
     preds = tabpfn.predict(X)
 
-    # kv_cache_dtype="auto" keeps the cache un-quantized, so the cached path
+    # kv_cache_precision="auto" keeps the cache un-quantized, so the cached path
     # matches the non-cached path (int8 quantization would perturb it).
     torch.random.manual_seed(0)
     tabpfn = TabPFNRegressor.create_default_for_version(
-        fit_mode="fit_with_cache", kv_cache_dtype="auto", **kwargs
+        fit_mode="fit_with_cache", kv_cache_precision="auto", **kwargs
     )
     tabpfn.fit(X, y)
     np.testing.assert_array_almost_equal(preds, tabpfn.predict(X), decimal=2)

--- a/tests/test_regressor_interface.py
+++ b/tests/test_regressor_interface.py
@@ -7,7 +7,7 @@ import itertools
 import os
 import typing
 from collections.abc import Callable
-from typing import Any, Literal
+from typing import Literal
 from unittest import mock
 
 import numpy as np
@@ -26,7 +26,6 @@ import tabpfn.regressor as regressor_module
 from tabpfn import TabPFNRegressor
 from tabpfn.base import RegressorModelSpecs, initialize_tabpfn_model
 from tabpfn.constants import ModelVersion
-from tabpfn.inference import InferenceEngineExplicitKVCache
 from tabpfn.model_loading import ModelSource, prepend_cache_path
 from tabpfn.preprocessing import PreprocessorConfig
 from tabpfn.settings import settings
@@ -295,7 +294,6 @@ def test__fit_preprocessors_and_with_cache_produce_equal_results(
     X_y: tuple[np.ndarray, np.ndarray],
     model_version: ModelVersion,
     device: str,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     kwargs = {
         "version": model_version,
@@ -313,21 +311,11 @@ def test__fit_preprocessors_and_with_cache_produce_equal_results(
     tabpfn.fit(X, y)
     preds = tabpfn.predict(X)
 
-    original_init = InferenceEngineExplicitKVCache.__init__
-
-    def _init_without_kv_quantization(
-        self: InferenceEngineExplicitKVCache, *args: Any, **kwargs: Any
-    ) -> None:
-        kwargs.setdefault("maybe_quantize_kv_cache", False)
-        original_init(self, *args, **kwargs)
-
-    monkeypatch.setattr(
-        InferenceEngineExplicitKVCache, "__init__", _init_without_kv_quantization
-    )
-
+    # kv_cache_dtype="auto" keeps the cache un-quantized, so the cached path
+    # matches the non-cached path (int8 quantization would perturb it).
     torch.random.manual_seed(0)
     tabpfn = TabPFNRegressor.create_default_for_version(
-        fit_mode="fit_with_cache", **kwargs
+        fit_mode="fit_with_cache", kv_cache_dtype="auto", **kwargs
     )
     tabpfn.fit(X, y)
     np.testing.assert_array_almost_equal(preds, tabpfn.predict(X), decimal=2)


### PR DESCRIPTION
## Issue

Fixes PriorLabs/TabPFN#1119 and PriorLabs/TabPFN#631.  <br>Also this is an alternative to PriorLabs/TabPFN#1099

## Motivation and Context

`kv_cache_dtype`is a tradeoff decision and should be possible to control explicitly

---

## Public API Changes

- [ ] No Public API changes
- [X] Yes, Public API changes (Details below)

---

## How Has This Been Tested?

I fixed the unit tests to not rely on Monkeypatching anymore.  <br>I also ran the script shared in [https://github.com/PriorLabs/TabPFN/issues/631](<https://github.com/PriorLabs/TabPFN/issues/631>)

```python
import random
from sklearn.datasets import load_diabetes
from sklearn.model_selection import train_test_split
import numpy as np
import torch

from tabpfn import TabPFNRegressor

X, y = load_diabetes(return_X_y=True)
X_train, X_test, y_train, y_test = train_test_split(
    X, y, test_size=0.33, random_state=42
)


def _set_seeds() -> None:
    torch.manual_seed(0)
    np.random.seed(0)
    random.seed(0)


_set_seeds()
reg = TabPFNRegressor(fit_mode="low_memory", inference_precision=torch.float64)
reg.fit(X_train, y_train)
preds_no_cache = reg.predict(X_test)

reg = TabPFNRegressor(fit_mode="low_memory", inference_precision=torch.float64)
reg.fit(X_train, y_train)
preds_no_cache_repeat = reg.predict(X_test)

_set_seeds()
reg = TabPFNRegressor(fit_mode="fit_preprocessors", inference_precision=torch.float64)
reg.fit(X_train, y_train)
preds_cache_preproc = reg.predict(X_test)

_set_seeds()
reg = TabPFNRegressor(fit_mode="fit_with_cache", inference_precision=torch.float64, kv_cache_dtype="auto")
reg.fit(X_train, y_train)
preds_kv_cache_auto = reg.predict(X_test)

_set_seeds()
reg = TabPFNRegressor(fit_mode="fit_with_cache", inference_precision=torch.float64, kv_cache_dtype="int8")
reg.fit(X_train, y_train)
preds_kv_cache_int8 = reg.predict(X_test)


def _max_diff(a: np.ndarray, b: np.ndarray) -> float:
    return np.max(np.abs(a - b) / np.abs(a))


print("max relative diffs")
print("no_cache vs no_cache_repeat:", _max_diff(preds_no_cache, preds_no_cache_repeat))
print("no_cache vs cache_preproc:", _max_diff(preds_no_cache, preds_cache_preproc))
print("no_cache vs kv_cache (auto):", _max_diff(preds_no_cache, preds_kv_cache_auto))
print("no_cache vs kv_cache int8:", _max_diff(preds_no_cache, preds_kv_cache_int8))
```

Using `kv_cache_dtype="auto"` fixes the issue. If `int8`is used we now throw a warning, when someone forces the inference dtype to sth else.

```
/usr/lib/python3.12/contextlib.py:81: UserWarning: inference_precision forces a dtype but kv_cache_dtype is 'int8', so the KV cache is still stored as int8 regardless of the forced dtype. Pass kv_cache_dtype='auto' to keep the KV cache in the forced dtype.
  return func(*args, **kwds)
max relative diffs
no_cache vs no_cache_repeat: 0.0
no_cache vs cache_preproc: 0.0
no_cache vs kv_cache (auto): 0.0
```

---

## Checklist

- [X] The changes have been tested locally.
- [ ] Documentation has been updated (if the public API or usage changes).
- [ ] A changelog entry has been added (see `changelog/README.md`), or "no changelog needed" label requested.
- [X] The code follows the project's style guidelines.
- [X] I have considered the impact of these changes on the public API.

---

```
```