### PR TITLE
Enable bf16 autocast on bf16-capable CPUs for inference_precision="auto"

### DIFF
--- a/changelog/1122.changed.md
+++ b/changelog/1122.changed.md
@@ -1,0 +1,1 @@
+`inference_precision="auto"` now uses bfloat16 autocast on CPUs with native bf16 support (Intel AMX / AVX512-BF16, AMD Zen 4+), giving ~2x faster CPU inference at unchanged accuracy. CPUs without fast bf16 keep running in float32.

--- a/src/tabpfn/base.py
+++ b/src/tabpfn/base.py
@@ -36,8 +36,8 @@ from tabpfn.model_loading import (
 from tabpfn.preprocessing.clean import fix_dtypes
 from tabpfn.utils import (
     DevicesSpecification,
+    infer_autocast_inference_mode,
     infer_devices,
-    infer_fp16_inference_mode,
 )
 from tabpfn.validation import ensure_compatible_predict_input_sklearn
 
@@ -251,7 +251,7 @@ def determine_precision(
             The byte size per element for the chosen precision.
     """
     if inference_precision in ["autocast", "auto"]:
-        use_autocast_ = infer_fp16_inference_mode(
+        use_autocast_ = infer_autocast_inference_mode(
             devices=devices_,
             enable=True if (inference_precision == "autocast") else None,
         )

--- a/src/tabpfn/classifier.py
+++ b/src/tabpfn/classifier.py
@@ -1725,6 +1725,10 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
             unit="estimator",
             disable=not self.show_progress_bar,
         ):
+            # Upcast from autocast's reduced precision so the post-processing
+            # (temperature scaling, softmax, estimator averaging) runs in
+            # float32, keeping predict_proba consistent with predict_logits.
+            output = output.float()  # noqa: PLW2901
             original_ndim = output.ndim
 
             # This block correctly handles both single configs and lists of configs

--- a/src/tabpfn/utils.py
+++ b/src/tabpfn/utils.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import contextlib
 import os
+import warnings
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Literal
 
@@ -227,16 +228,25 @@ def _cpu_supports_fast_bf16() -> bool:
 
     Requires a torch build with oneDNN, which provides the fast bf16 kernels
     (absent e.g. on macOS wheels, where CPU bf16 falls back to slow reference
-    kernels). Returns False when the capability checks are unavailable, so
-    autocast stays off rather than falling back to emulated, slower bf16.
+    kernels). AMX CPUs also enumerate AVX512-BF16, so this one check covers
+    both instruction sets.
     """
     if not torch.backends.mkldnn.is_available():
         return False
-    # The capability checks are private torch API with no public equivalent;
-    # guarded so a torch release removing them degrades to bf16-off, not a crash.
-    avx512_bf16 = getattr(torch.cpu, "_is_avx512_bf16_supported", lambda: False)
-    amx_tile = getattr(torch.cpu, "_is_amx_tile_supported", lambda: False)
-    return bool(avx512_bf16() or amx_tile())
+    # Private torch API with no public equivalent; if a torch release removes
+    # it, warn and stay on float32 rather than risk slow emulated bf16.
+    avx512_bf16 = getattr(torch.cpu, "_is_avx512_bf16_supported", None)
+    if avx512_bf16 is None:
+        warnings.warn(
+            "torch.cpu._is_avx512_bf16_supported() does not exist in this torch"
+            " version, so TabPFN cannot detect CPU bf16 support and disables"
+            " CPU bf16 autocast. Please report this at"
+            " https://github.com/PriorLabs/TabPFN/issues so detection can be"
+            " updated.",
+            stacklevel=2,
+        )
+        return False
+    return bool(avx512_bf16())
 
 
 def infer_autocast_inference_mode(

--- a/src/tabpfn/utils.py
+++ b/src/tabpfn/utils.py
@@ -226,26 +226,11 @@ def is_autocast_available(device_type: str) -> bool:
 
 @functools.lru_cache(maxsize=1)
 def cpu_supports_fast_bf16() -> bool:
-    """Whether the host CPU has native bfloat16 matmul acceleration.
+    """Whether the CPU accelerates bfloat16 (Intel AMX / AVX512-BF16, AMD Zen 4+).
 
-    ``torch.autocast("cpu")`` runs in bfloat16. That is a meaningful speed-up
-    (~2x on TabPFN inference) only when the CPU has hardware bf16 support
-    (Intel AMX or AVX512-BF16, AMD Zen 4+); on other CPUs bf16 is emulated and
-    can be *slower* than float32. We therefore only report support when such
-    hardware is positively detected, and otherwise stay in float32 so ``"auto"``
-    never regresses.
-
-    Returns:
-        True if the CPU is known to accelerate bfloat16, False when unsure.
+    Reads Linux CPU flags; returns False when they are unavailable (e.g. non-Linux)
+    so autocast stays off rather than falling back to emulated, slower bf16.
     """
-    # 1) PyTorch's own view of the usable CPU ISA. Portable across OSes and
-    #    catches Intel AMX (which reports as "AMX"). Probing must never hard-fail.
-    with contextlib.suppress(Exception):
-        capability = torch.backends.cpu.get_cpu_capability()
-        if isinstance(capability, str) and capability.upper() == "AMX":
-            return True
-    # 2) Linux CPU flags. Catches AVX512-BF16 (Cooper Lake, AMD Zen 4+), which
-    #    (1) only reports coarsely as "AVX512".
     with contextlib.suppress(OSError):
         flags = Path("/proc/cpuinfo").read_bytes()
         if b"amx_bf16" in flags or b"avx512_bf16" in flags:
@@ -277,11 +262,8 @@ def infer_fp16_inference_mode(
     """
     is_cpu = any(device.type.lower() == "cpu" for device in devices)
     if is_cpu:
-        # Historically CPU was excluded outright because fp16 autocast kills
-        # inference speed there. But CPU autocast uses *bfloat16*, which is
-        # hardware-accelerated on AMX/AVX512-BF16/Zen4+ for a ~2x speed-up at
-        # negligible accuracy cost. Enable it only when every device is a CPU
-        # with fast bf16; otherwise keep float32 (no regression).
+        # CPU autocast runs in bfloat16, which is only faster than float32 on CPUs
+        # with native bf16 support.
         fp16_available = (
             all(device.type.lower() == "cpu" for device in devices)
             and is_autocast_available("cpu")

--- a/src/tabpfn/utils.py
+++ b/src/tabpfn/utils.py
@@ -5,10 +5,8 @@
 from __future__ import annotations
 
 import contextlib
-import functools
 import os
 from collections.abc import Sequence
-from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 import numpy as np
@@ -224,21 +222,24 @@ def is_autocast_available(device_type: str) -> bool:
         )
 
 
-@functools.lru_cache(maxsize=1)
 def cpu_supports_fast_bf16() -> bool:
     """Whether the CPU accelerates bfloat16 (Intel AMX / AVX512-BF16, AMD Zen 4+).
 
-    Reads Linux CPU flags; returns False when they are unavailable (e.g. non-Linux)
-    so autocast stays off rather than falling back to emulated, slower bf16.
+    Requires a torch build with oneDNN, which provides the fast bf16 kernels
+    (absent e.g. on macOS wheels, where CPU bf16 falls back to slow reference
+    kernels). Returns False when the capability checks are unavailable, so
+    autocast stays off rather than falling back to emulated, slower bf16.
     """
-    with contextlib.suppress(OSError):
-        flags = Path("/proc/cpuinfo").read_bytes()
-        if b"amx_bf16" in flags or b"avx512_bf16" in flags:
-            return True
-    return False
+    if not torch.backends.mkldnn.is_available():
+        return False
+    # The capability checks are private torch API with no public equivalent;
+    # guarded so a torch release removing them degrades to bf16-off, not a crash.
+    avx512_bf16 = getattr(torch.cpu, "_is_avx512_bf16_supported", lambda: False)
+    amx_tile = getattr(torch.cpu, "_is_amx_tile_supported", lambda: False)
+    return bool(avx512_bf16() or amx_tile())
 
 
-def infer_fp16_inference_mode(
+def infer_autocast_inference_mode(
     devices: Sequence[torch.device], *, enable: bool | None
 ) -> bool:
     """Infer whether reduced-precision (autocast) inference should be enabled.
@@ -264,27 +265,28 @@ def infer_fp16_inference_mode(
     if is_cpu:
         # CPU autocast runs in bfloat16, which is only faster than float32 on CPUs
         # with native bf16 support.
-        fp16_available = (
+        autocast_available = (
             all(device.type.lower() == "cpu" for device in devices)
             and is_autocast_available("cpu")
             and cpu_supports_fast_bf16()
         )
     else:
-        fp16_available = any(is_autocast_available(device.type) for device in devices)
+        autocast_available = any(
+            is_autocast_available(device.type) for device in devices
+        )
 
     if enable is None:
-        return fp16_available
+        return autocast_available
 
     if enable is True:
-        if not fp16_available:
+        if not autocast_available:
             raise ValueError(
-                "You specified `fp16_inference=True`, however"
-                "`torch.amp.autocast_mode.is_autocast_available()`"
-                f" reported that one or more of the selected devices ({devices=})"
-                " does not support it."
-                "\nPlease ensure your version of torch and device type"
-                " are compatible with torch.autocast()`"
-                " or set `fp16_inference=False`.",
+                'You specified `inference_precision="autocast"`, however one or'
+                f" more of the selected devices ({devices=}) does not support it."
+                " On CPU, autocast requires hardware-accelerated bfloat16"
+                " (Intel AMX / AVX512-BF16, AMD Zen 4+)."
+                '\nSet `inference_precision="auto"` to fall back to full'
+                " precision automatically.",
             )
         return True
 

--- a/src/tabpfn/utils.py
+++ b/src/tabpfn/utils.py
@@ -241,6 +241,8 @@ def _cpu_supports_fast_bf16() -> bool:
     kernels). AMX CPUs also enumerate AVX512-BF16, so this one check covers
     both instruction sets.
     """
+    # bf16 without oneDNN's fast kernels is far slower than float32. Official
+    # wheels always ship oneDNN; this guards distro/self-built torch without it.
     if not torch.backends.mkldnn.is_available():
         return False
     # Private torch API with no public equivalent; if a torch release removes

--- a/src/tabpfn/utils.py
+++ b/src/tabpfn/utils.py
@@ -222,7 +222,7 @@ def is_autocast_available(device_type: str) -> bool:
         )
 
 
-def cpu_supports_fast_bf16() -> bool:
+def _cpu_supports_fast_bf16() -> bool:
     """Whether the CPU accelerates bfloat16 (Intel AMX / AVX512-BF16, AMD Zen 4+).
 
     Requires a torch build with oneDNN, which provides the fast bf16 kernels
@@ -246,7 +246,7 @@ def infer_autocast_inference_mode(
 
     On GPU this is fp16 autocast; on CPU ``torch.autocast`` runs in bfloat16,
     which is enabled only on CPUs with native bf16 support (see
-    :func:`cpu_supports_fast_bf16`).
+    :func:`_cpu_supports_fast_bf16`).
 
     Args:
         devices: The devices to validate against.
@@ -268,7 +268,7 @@ def infer_autocast_inference_mode(
         autocast_available = (
             all(device.type.lower() == "cpu" for device in devices)
             and is_autocast_available("cpu")
-            and cpu_supports_fast_bf16()
+            and _cpu_supports_fast_bf16()
         )
     else:
         autocast_available = any(

--- a/src/tabpfn/utils.py
+++ b/src/tabpfn/utils.py
@@ -5,8 +5,10 @@
 from __future__ import annotations
 
 import contextlib
+import functools
 import os
 from collections.abc import Sequence
+from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 import numpy as np
@@ -222,10 +224,43 @@ def is_autocast_available(device_type: str) -> bool:
         )
 
 
+@functools.lru_cache(maxsize=1)
+def cpu_supports_fast_bf16() -> bool:
+    """Whether the host CPU has native bfloat16 matmul acceleration.
+
+    ``torch.autocast("cpu")`` runs in bfloat16. That is a meaningful speed-up
+    (~2x on TabPFN inference) only when the CPU has hardware bf16 support
+    (Intel AMX or AVX512-BF16, AMD Zen 4+); on other CPUs bf16 is emulated and
+    can be *slower* than float32. We therefore only report support when such
+    hardware is positively detected, and otherwise stay in float32 so ``"auto"``
+    never regresses.
+
+    Returns:
+        True if the CPU is known to accelerate bfloat16, False when unsure.
+    """
+    # 1) PyTorch's own view of the usable CPU ISA. Portable across OSes and
+    #    catches Intel AMX (which reports as "AMX"). Probing must never hard-fail.
+    with contextlib.suppress(Exception):
+        capability = torch.backends.cpu.get_cpu_capability()
+        if isinstance(capability, str) and capability.upper() == "AMX":
+            return True
+    # 2) Linux CPU flags. Catches AVX512-BF16 (Cooper Lake, AMD Zen 4+), which
+    #    (1) only reports coarsely as "AVX512".
+    with contextlib.suppress(OSError):
+        flags = Path("/proc/cpuinfo").read_bytes()
+        if b"amx_bf16" in flags or b"avx512_bf16" in flags:
+            return True
+    return False
+
+
 def infer_fp16_inference_mode(
     devices: Sequence[torch.device], *, enable: bool | None
 ) -> bool:
-    """Infer whether fp16 inference should be enabled.
+    """Infer whether reduced-precision (autocast) inference should be enabled.
+
+    On GPU this is fp16 autocast; on CPU ``torch.autocast`` runs in bfloat16,
+    which is enabled only on CPUs with native bf16 support (see
+    :func:`cpu_supports_fast_bf16`).
 
     Args:
         devices: The devices to validate against.
@@ -234,17 +269,26 @@ def infer_fp16_inference_mode(
             detect if it's possible and use it if so.
 
     Returns:
-        Whether to use fp16 inference or not.
+        Whether to use autocast inference or not.
 
     Raises:
-        ValueError: If fp16 inference was enabled and any of the selected devices do
+        ValueError: If autocast was enabled and any of the selected devices do
             not support it.
     """
     is_cpu = any(device.type.lower() == "cpu" for device in devices)
-    fp16_available = (
-        not is_cpu  # CPU can show enabled, yet it kills inference speed
-        and any(is_autocast_available(device.type) for device in devices)
-    )
+    if is_cpu:
+        # Historically CPU was excluded outright because fp16 autocast kills
+        # inference speed there. But CPU autocast uses *bfloat16*, which is
+        # hardware-accelerated on AMX/AVX512-BF16/Zen4+ for a ~2x speed-up at
+        # negligible accuracy cost. Enable it only when every device is a CPU
+        # with fast bf16; otherwise keep float32 (no regression).
+        fp16_available = (
+            all(device.type.lower() == "cpu" for device in devices)
+            and is_autocast_available("cpu")
+            and cpu_supports_fast_bf16()
+        )
+    else:
+        fp16_available = any(is_autocast_available(device.type) for device in devices)
 
     if enable is None:
         return fp16_available

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -273,59 +273,71 @@ def test__translate_probs_across_borders__forces_chunking(
     assert torch.equal(out_chunked, out_unchunked)
 
 
-class TestCpuSupportsFastBf16:
-    """Detection of native CPU bfloat16 acceleration (AMX / AVX512-BF16)."""
-
-    def test__amx_bf16_flag__returns_true(self, mocker: MagicMock) -> None:
-        cpu_supports_fast_bf16.cache_clear()
-        mocker.patch(
-            "tabpfn.utils.Path.read_bytes",
-            return_value=b"flags\t: avx512f amx_tile amx_bf16",
-        )
-        assert cpu_supports_fast_bf16() is True
-
-    def test__avx512_bf16_flag__returns_true(self, mocker: MagicMock) -> None:
-        cpu_supports_fast_bf16.cache_clear()
-        mocker.patch(
-            "tabpfn.utils.Path.read_bytes",
-            return_value=b"flags\t: avx512f avx512_bf16",
-        )
-        assert cpu_supports_fast_bf16() is True
-
-    def test__no_bf16_flag__returns_false(self, mocker: MagicMock) -> None:
-        cpu_supports_fast_bf16.cache_clear()
-        mocker.patch(
-            "tabpfn.utils.Path.read_bytes", return_value=b"flags\t: avx2 sse4_2"
-        )
-        assert cpu_supports_fast_bf16() is False
-
-    def test__cpuinfo_unreadable__returns_false(self, mocker: MagicMock) -> None:
-        cpu_supports_fast_bf16.cache_clear()
-        mocker.patch("tabpfn.utils.Path.read_bytes", side_effect=OSError("no /proc"))
-        assert cpu_supports_fast_bf16() is False
+def test__cpu_supports_fast_bf16__amx_bf16_flag__returns_true(
+    mocker: MagicMock,
+) -> None:
+    cpu_supports_fast_bf16.cache_clear()
+    mocker.patch(
+        "tabpfn.utils.Path.read_bytes",
+        return_value=b"flags\t: avx512f amx_tile amx_bf16",
+    )
+    assert cpu_supports_fast_bf16() is True
 
 
-class TestInferFp16InferenceModeCpu:
-    """CPU branch: autocast (bf16) enabled only on fast-bf16 hardware."""
+def test__cpu_supports_fast_bf16__avx512_bf16_flag__returns_true(
+    mocker: MagicMock,
+) -> None:
+    cpu_supports_fast_bf16.cache_clear()
+    mocker.patch(
+        "tabpfn.utils.Path.read_bytes",
+        return_value=b"flags\t: avx512f avx512_bf16",
+    )
+    assert cpu_supports_fast_bf16() is True
 
-    def test__cpu_with_fast_bf16__auto__enabled(self, mocker: MagicMock) -> None:
-        mocker.patch("tabpfn.utils.cpu_supports_fast_bf16", return_value=True)
-        mocker.patch("tabpfn.utils.is_autocast_available", return_value=True)
-        assert infer_fp16_inference_mode([torch.device("cpu")], enable=None) is True
 
-    def test__cpu_without_fast_bf16__auto__disabled(self, mocker: MagicMock) -> None:
-        mocker.patch("tabpfn.utils.cpu_supports_fast_bf16", return_value=False)
-        mocker.patch("tabpfn.utils.is_autocast_available", return_value=True)
-        assert infer_fp16_inference_mode([torch.device("cpu")], enable=None) is False
+def test__cpu_supports_fast_bf16__no_bf16_flag__returns_false(
+    mocker: MagicMock,
+) -> None:
+    cpu_supports_fast_bf16.cache_clear()
+    mocker.patch("tabpfn.utils.Path.read_bytes", return_value=b"flags\t: avx2 sse4_2")
+    assert cpu_supports_fast_bf16() is False
 
-    def test__cpu_without_fast_bf16__explicit_enable__raises(
-        self, mocker: MagicMock
-    ) -> None:
-        mocker.patch("tabpfn.utils.cpu_supports_fast_bf16", return_value=False)
-        mocker.patch("tabpfn.utils.is_autocast_available", return_value=True)
-        with pytest.raises(ValueError, match="does not support it"):
-            infer_fp16_inference_mode([torch.device("cpu")], enable=True)
 
-    def test__cpu_explicit_disable__stays_false(self, mocker: MagicMock) -> None:
-        mocker.patch("tabpfn.utils.cpu_supports_fast_bf16", return_value=True)
-        assert infer_fp16_inference_mode([torch.device("cpu")], enable=False) is False
+def test__cpu_supports_fast_bf16__cpuinfo_unreadable__returns_false(
+    mocker: MagicMock,
+) -> None:
+    cpu_supports_fast_bf16.cache_clear()
+    mocker.patch("tabpfn.utils.Path.read_bytes", side_effect=OSError("no /proc"))
+    assert cpu_supports_fast_bf16() is False
+
+
+def test__infer_fp16_inference_mode__cpu_with_fast_bf16__enabled(
+    mocker: MagicMock,
+) -> None:
+    mocker.patch("tabpfn.utils.cpu_supports_fast_bf16", return_value=True)
+    mocker.patch("tabpfn.utils.is_autocast_available", return_value=True)
+    assert infer_fp16_inference_mode([torch.device("cpu")], enable=None) is True
+
+
+def test__infer_fp16_inference_mode__cpu_without_fast_bf16__disabled(
+    mocker: MagicMock,
+) -> None:
+    mocker.patch("tabpfn.utils.cpu_supports_fast_bf16", return_value=False)
+    mocker.patch("tabpfn.utils.is_autocast_available", return_value=True)
+    assert infer_fp16_inference_mode([torch.device("cpu")], enable=None) is False
+
+
+def test__infer_fp16_inference_mode__cpu_without_fast_bf16_and_enabled__raises(
+    mocker: MagicMock,
+) -> None:
+    mocker.patch("tabpfn.utils.cpu_supports_fast_bf16", return_value=False)
+    mocker.patch("tabpfn.utils.is_autocast_available", return_value=True)
+    with pytest.raises(ValueError, match="does not support it"):
+        infer_fp16_inference_mode([torch.device("cpu")], enable=True)
+
+
+def test__infer_fp16_inference_mode__cpu_explicitly_disabled__returns_false(
+    mocker: MagicMock,
+) -> None:
+    mocker.patch("tabpfn.utils.cpu_supports_fast_bf16", return_value=True)
+    assert infer_fp16_inference_mode([torch.device("cpu")], enable=False) is False

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,7 +13,9 @@ from torch.torch_version import TorchVersion
 from tabpfn.utils import (
     _translate_probs_across_borders_unchunked,
     balance_probas_by_class_counts,
+    cpu_supports_fast_bf16,
     infer_devices,
+    infer_fp16_inference_mode,
     translate_probs_across_borders,
 )
 
@@ -269,3 +271,64 @@ def test__translate_probs_across_borders__forces_chunking(
     assert call_counter["n"] == total_rows  # chunk_size == 1 row here
     assert out_chunked.shape == out_unchunked.shape
     assert torch.equal(out_chunked, out_unchunked)
+
+
+class TestCpuSupportsFastBf16:
+    """Detection of native CPU bfloat16 acceleration (AMX / AVX512-BF16)."""
+
+    def test__amx_reported_by_torch__returns_true(self, mocker: MagicMock) -> None:
+        cpu_supports_fast_bf16.cache_clear()
+        mocker.patch("torch.backends.cpu.get_cpu_capability", return_value="AMX")
+        assert cpu_supports_fast_bf16() is True
+
+    def test__avx512_bf16_in_cpuinfo__returns_true(self, mocker: MagicMock) -> None:
+        cpu_supports_fast_bf16.cache_clear()
+        mocker.patch("torch.backends.cpu.get_cpu_capability", return_value="AVX512")
+        mocker.patch(
+            "builtins.open",
+            mocker.mock_open(read_data=b"flags\t: avx512f avx512_bf16 amx_tile"),
+        )
+        assert cpu_supports_fast_bf16() is True
+
+    def test__no_bf16_hardware__returns_false(self, mocker: MagicMock) -> None:
+        cpu_supports_fast_bf16.cache_clear()
+        mocker.patch("torch.backends.cpu.get_cpu_capability", return_value="AVX2")
+        mocker.patch(
+            "builtins.open", mocker.mock_open(read_data=b"flags\t: avx2 sse4_2")
+        )
+        assert cpu_supports_fast_bf16() is False
+
+    def test__probing_raises__returns_false(self, mocker: MagicMock) -> None:
+        cpu_supports_fast_bf16.cache_clear()
+        mocker.patch(
+            "torch.backends.cpu.get_cpu_capability",
+            side_effect=RuntimeError("boom"),
+        )
+        mocker.patch("builtins.open", side_effect=OSError("no /proc"))
+        assert cpu_supports_fast_bf16() is False
+
+
+class TestInferFp16InferenceModeCpu:
+    """CPU branch: autocast (bf16) enabled only on fast-bf16 hardware."""
+
+    def test__cpu_with_fast_bf16__auto__enabled(self, mocker: MagicMock) -> None:
+        mocker.patch("tabpfn.utils.cpu_supports_fast_bf16", return_value=True)
+        mocker.patch("tabpfn.utils.is_autocast_available", return_value=True)
+        assert infer_fp16_inference_mode([torch.device("cpu")], enable=None) is True
+
+    def test__cpu_without_fast_bf16__auto__disabled(self, mocker: MagicMock) -> None:
+        mocker.patch("tabpfn.utils.cpu_supports_fast_bf16", return_value=False)
+        mocker.patch("tabpfn.utils.is_autocast_available", return_value=True)
+        assert infer_fp16_inference_mode([torch.device("cpu")], enable=None) is False
+
+    def test__cpu_without_fast_bf16__explicit_enable__raises(
+        self, mocker: MagicMock
+    ) -> None:
+        mocker.patch("tabpfn.utils.cpu_supports_fast_bf16", return_value=False)
+        mocker.patch("tabpfn.utils.is_autocast_available", return_value=True)
+        with pytest.raises(ValueError, match="does not support it"):
+            infer_fp16_inference_mode([torch.device("cpu")], enable=True)
+
+    def test__cpu_explicit_disable__stays_false(self, mocker: MagicMock) -> None:
+        mocker.patch("tabpfn.utils.cpu_supports_fast_bf16", return_value=True)
+        assert infer_fp16_inference_mode([torch.device("cpu")], enable=False) is False

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -276,34 +276,31 @@ def test__translate_probs_across_borders__forces_chunking(
 class TestCpuSupportsFastBf16:
     """Detection of native CPU bfloat16 acceleration (AMX / AVX512-BF16)."""
 
-    def test__amx_reported_by_torch__returns_true(self, mocker: MagicMock) -> None:
+    def test__amx_bf16_flag__returns_true(self, mocker: MagicMock) -> None:
         cpu_supports_fast_bf16.cache_clear()
-        mocker.patch("torch.backends.cpu.get_cpu_capability", return_value="AMX")
-        assert cpu_supports_fast_bf16() is True
-
-    def test__avx512_bf16_in_cpuinfo__returns_true(self, mocker: MagicMock) -> None:
-        cpu_supports_fast_bf16.cache_clear()
-        mocker.patch("torch.backends.cpu.get_cpu_capability", return_value="AVX512")
         mocker.patch(
             "tabpfn.utils.Path.read_bytes",
-            return_value=b"flags\t: avx512f avx512_bf16 amx_tile",
+            return_value=b"flags\t: avx512f amx_tile amx_bf16",
         )
         assert cpu_supports_fast_bf16() is True
 
-    def test__no_bf16_hardware__returns_false(self, mocker: MagicMock) -> None:
+    def test__avx512_bf16_flag__returns_true(self, mocker: MagicMock) -> None:
         cpu_supports_fast_bf16.cache_clear()
-        mocker.patch("torch.backends.cpu.get_cpu_capability", return_value="AVX2")
+        mocker.patch(
+            "tabpfn.utils.Path.read_bytes",
+            return_value=b"flags\t: avx512f avx512_bf16",
+        )
+        assert cpu_supports_fast_bf16() is True
+
+    def test__no_bf16_flag__returns_false(self, mocker: MagicMock) -> None:
+        cpu_supports_fast_bf16.cache_clear()
         mocker.patch(
             "tabpfn.utils.Path.read_bytes", return_value=b"flags\t: avx2 sse4_2"
         )
         assert cpu_supports_fast_bf16() is False
 
-    def test__probing_raises__returns_false(self, mocker: MagicMock) -> None:
+    def test__cpuinfo_unreadable__returns_false(self, mocker: MagicMock) -> None:
         cpu_supports_fast_bf16.cache_clear()
-        mocker.patch(
-            "torch.backends.cpu.get_cpu_capability",
-            side_effect=RuntimeError("boom"),
-        )
         mocker.patch("tabpfn.utils.Path.read_bytes", side_effect=OSError("no /proc"))
         assert cpu_supports_fast_bf16() is False
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,8 +14,8 @@ from tabpfn.utils import (
     _translate_probs_across_borders_unchunked,
     balance_probas_by_class_counts,
     cpu_supports_fast_bf16,
+    infer_autocast_inference_mode,
     infer_devices,
-    infer_fp16_inference_mode,
     translate_probs_across_borders,
 )
 
@@ -273,71 +273,62 @@ def test__translate_probs_across_borders__forces_chunking(
     assert torch.equal(out_chunked, out_unchunked)
 
 
-def test__cpu_supports_fast_bf16__amx_bf16_flag__returns_true(
+@pytest.mark.parametrize(
+    ("mkldnn", "avx512_bf16", "amx_tile", "expected"),
+    [
+        (True, True, False, True),
+        (True, False, True, True),
+        (True, False, False, False),
+        (False, True, True, False),
+    ],
+    ids=["avx512_bf16", "amx", "no_bf16_hardware", "no_onednn_build"],
+)
+def test__cpu_supports_fast_bf16(
     mocker: MagicMock,
+    mkldnn: bool,
+    avx512_bf16: bool,
+    amx_tile: bool,
+    expected: bool,
 ) -> None:
-    cpu_supports_fast_bf16.cache_clear()
-    mocker.patch(
-        "tabpfn.utils.Path.read_bytes",
-        return_value=b"flags\t: avx512f amx_tile amx_bf16",
+    mocker.patch.object(torch.backends.mkldnn, "is_available", return_value=mkldnn)
+    mocker.patch.object(
+        torch.cpu, "_is_avx512_bf16_supported", return_value=avx512_bf16
     )
-    assert cpu_supports_fast_bf16() is True
+    mocker.patch.object(torch.cpu, "_is_amx_tile_supported", return_value=amx_tile)
+    assert cpu_supports_fast_bf16() is expected
 
 
-def test__cpu_supports_fast_bf16__avx512_bf16_flag__returns_true(
-    mocker: MagicMock,
+def test__cpu_supports_fast_bf16__torch_helpers_missing__returns_false(
+    mocker: MagicMock, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    cpu_supports_fast_bf16.cache_clear()
-    mocker.patch(
-        "tabpfn.utils.Path.read_bytes",
-        return_value=b"flags\t: avx512f avx512_bf16",
-    )
-    assert cpu_supports_fast_bf16() is True
-
-
-def test__cpu_supports_fast_bf16__no_bf16_flag__returns_false(
-    mocker: MagicMock,
-) -> None:
-    cpu_supports_fast_bf16.cache_clear()
-    mocker.patch("tabpfn.utils.Path.read_bytes", return_value=b"flags\t: avx2 sse4_2")
+    mocker.patch.object(torch.backends.mkldnn, "is_available", return_value=True)
+    monkeypatch.delattr(torch.cpu, "_is_avx512_bf16_supported", raising=False)
+    monkeypatch.delattr(torch.cpu, "_is_amx_tile_supported", raising=False)
     assert cpu_supports_fast_bf16() is False
 
 
-def test__cpu_supports_fast_bf16__cpuinfo_unreadable__returns_false(
+@pytest.mark.parametrize(
+    ("supports_bf16", "enable", "expected"),
+    [(True, None, True), (False, None, False), (True, False, False)],
+    ids=["auto_with_bf16", "auto_without_bf16", "explicitly_disabled"],
+)
+def test__infer_autocast_inference_mode__cpu(
     mocker: MagicMock,
+    supports_bf16: bool,
+    enable: bool | None,
+    expected: bool,
 ) -> None:
-    cpu_supports_fast_bf16.cache_clear()
-    mocker.patch("tabpfn.utils.Path.read_bytes", side_effect=OSError("no /proc"))
-    assert cpu_supports_fast_bf16() is False
-
-
-def test__infer_fp16_inference_mode__cpu_with_fast_bf16__enabled(
-    mocker: MagicMock,
-) -> None:
-    mocker.patch("tabpfn.utils.cpu_supports_fast_bf16", return_value=True)
+    mocker.patch("tabpfn.utils.cpu_supports_fast_bf16", return_value=supports_bf16)
     mocker.patch("tabpfn.utils.is_autocast_available", return_value=True)
-    assert infer_fp16_inference_mode([torch.device("cpu")], enable=None) is True
+    assert (
+        infer_autocast_inference_mode([torch.device("cpu")], enable=enable) is expected
+    )
 
 
-def test__infer_fp16_inference_mode__cpu_without_fast_bf16__disabled(
-    mocker: MagicMock,
-) -> None:
-    mocker.patch("tabpfn.utils.cpu_supports_fast_bf16", return_value=False)
-    mocker.patch("tabpfn.utils.is_autocast_available", return_value=True)
-    assert infer_fp16_inference_mode([torch.device("cpu")], enable=None) is False
-
-
-def test__infer_fp16_inference_mode__cpu_without_fast_bf16_and_enabled__raises(
+def test__infer_autocast_inference_mode__cpu_without_fast_bf16_and_enabled__raises(
     mocker: MagicMock,
 ) -> None:
     mocker.patch("tabpfn.utils.cpu_supports_fast_bf16", return_value=False)
     mocker.patch("tabpfn.utils.is_autocast_available", return_value=True)
     with pytest.raises(ValueError, match="does not support it"):
-        infer_fp16_inference_mode([torch.device("cpu")], enable=True)
-
-
-def test__infer_fp16_inference_mode__cpu_explicitly_disabled__returns_false(
-    mocker: MagicMock,
-) -> None:
-    mocker.patch("tabpfn.utils.cpu_supports_fast_bf16", return_value=True)
-    assert infer_fp16_inference_mode([torch.device("cpu")], enable=False) is False
+        infer_autocast_inference_mode([torch.device("cpu")], enable=True)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -285,8 +285,8 @@ class TestCpuSupportsFastBf16:
         cpu_supports_fast_bf16.cache_clear()
         mocker.patch("torch.backends.cpu.get_cpu_capability", return_value="AVX512")
         mocker.patch(
-            "builtins.open",
-            mocker.mock_open(read_data=b"flags\t: avx512f avx512_bf16 amx_tile"),
+            "tabpfn.utils.Path.read_bytes",
+            return_value=b"flags\t: avx512f avx512_bf16 amx_tile",
         )
         assert cpu_supports_fast_bf16() is True
 
@@ -294,7 +294,7 @@ class TestCpuSupportsFastBf16:
         cpu_supports_fast_bf16.cache_clear()
         mocker.patch("torch.backends.cpu.get_cpu_capability", return_value="AVX2")
         mocker.patch(
-            "builtins.open", mocker.mock_open(read_data=b"flags\t: avx2 sse4_2")
+            "tabpfn.utils.Path.read_bytes", return_value=b"flags\t: avx2 sse4_2"
         )
         assert cpu_supports_fast_bf16() is False
 
@@ -304,7 +304,7 @@ class TestCpuSupportsFastBf16:
             "torch.backends.cpu.get_cpu_capability",
             side_effect=RuntimeError("boom"),
         )
-        mocker.patch("builtins.open", side_effect=OSError("no /proc"))
+        mocker.patch("tabpfn.utils.Path.read_bytes", side_effect=OSError("no /proc"))
         assert cpu_supports_fast_bf16() is False
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,9 +11,9 @@ import torch
 from torch.torch_version import TorchVersion
 
 from tabpfn.utils import (
+    _cpu_supports_fast_bf16,
     _translate_probs_across_borders_unchunked,
     balance_probas_by_class_counts,
-    cpu_supports_fast_bf16,
     infer_autocast_inference_mode,
     infer_devices,
     translate_probs_across_borders,
@@ -295,7 +295,7 @@ def test__cpu_supports_fast_bf16(
         torch.cpu, "_is_avx512_bf16_supported", return_value=avx512_bf16
     )
     mocker.patch.object(torch.cpu, "_is_amx_tile_supported", return_value=amx_tile)
-    assert cpu_supports_fast_bf16() is expected
+    assert _cpu_supports_fast_bf16() is expected
 
 
 def test__cpu_supports_fast_bf16__torch_helpers_missing__returns_false(
@@ -304,7 +304,7 @@ def test__cpu_supports_fast_bf16__torch_helpers_missing__returns_false(
     mocker.patch.object(torch.backends.mkldnn, "is_available", return_value=True)
     monkeypatch.delattr(torch.cpu, "_is_avx512_bf16_supported", raising=False)
     monkeypatch.delattr(torch.cpu, "_is_amx_tile_supported", raising=False)
-    assert cpu_supports_fast_bf16() is False
+    assert _cpu_supports_fast_bf16() is False
 
 
 @pytest.mark.parametrize(
@@ -318,7 +318,7 @@ def test__infer_autocast_inference_mode__cpu(
     enable: bool | None,
     expected: bool,
 ) -> None:
-    mocker.patch("tabpfn.utils.cpu_supports_fast_bf16", return_value=supports_bf16)
+    mocker.patch("tabpfn.utils._cpu_supports_fast_bf16", return_value=supports_bf16)
     mocker.patch("tabpfn.utils.is_autocast_available", return_value=True)
     assert (
         infer_autocast_inference_mode([torch.device("cpu")], enable=enable) is expected
@@ -328,7 +328,7 @@ def test__infer_autocast_inference_mode__cpu(
 def test__infer_autocast_inference_mode__cpu_without_fast_bf16_and_enabled__raises(
     mocker: MagicMock,
 ) -> None:
-    mocker.patch("tabpfn.utils.cpu_supports_fast_bf16", return_value=False)
+    mocker.patch("tabpfn.utils._cpu_supports_fast_bf16", return_value=False)
     mocker.patch("tabpfn.utils.is_autocast_available", return_value=True)
     with pytest.raises(ValueError, match="does not support it"):
         infer_autocast_inference_mode([torch.device("cpu")], enable=True)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -274,37 +274,34 @@ def test__translate_probs_across_borders__forces_chunking(
 
 
 @pytest.mark.parametrize(
-    ("mkldnn", "avx512_bf16", "amx_tile", "expected"),
+    ("mkldnn", "avx512_bf16", "expected"),
     [
-        (True, True, False, True),
-        (True, False, True, True),
-        (True, False, False, False),
-        (False, True, True, False),
+        (True, True, True),
+        (True, False, False),
+        (False, True, False),
     ],
-    ids=["avx512_bf16", "amx", "no_bf16_hardware", "no_onednn_build"],
+    ids=["bf16_hardware", "no_bf16_hardware", "no_onednn_build"],
 )
 def test__cpu_supports_fast_bf16(
     mocker: MagicMock,
     mkldnn: bool,
     avx512_bf16: bool,
-    amx_tile: bool,
     expected: bool,
 ) -> None:
     mocker.patch.object(torch.backends.mkldnn, "is_available", return_value=mkldnn)
     mocker.patch.object(
         torch.cpu, "_is_avx512_bf16_supported", return_value=avx512_bf16
     )
-    mocker.patch.object(torch.cpu, "_is_amx_tile_supported", return_value=amx_tile)
     assert _cpu_supports_fast_bf16() is expected
 
 
-def test__cpu_supports_fast_bf16__torch_helpers_missing__returns_false(
+def test__cpu_supports_fast_bf16__torch_helper_missing__warns_and_returns_false(
     mocker: MagicMock, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     mocker.patch.object(torch.backends.mkldnn, "is_available", return_value=True)
     monkeypatch.delattr(torch.cpu, "_is_avx512_bf16_supported", raising=False)
-    monkeypatch.delattr(torch.cpu, "_is_amx_tile_supported", raising=False)
-    assert _cpu_supports_fast_bf16() is False
+    with pytest.warns(UserWarning, match="cannot detect CPU bf16 support"):
+        assert _cpu_supports_fast_bf16() is False
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What
Make `inference_precision="auto"` (the default) use **bfloat16 autocast on CPUs with native bf16 acceleration** (Intel AMX / AVX512-BF16, AMD Zen 4+) instead of always running float32 on CPU.

## Why
CPU inference was never tuned for reduced precision — `"auto"` forces float32 on CPU (the code comment noted fp16 autocast "kills inference speed" there). But `torch.autocast("cpu")` runs in **bfloat16**, which modern Intel/AMD server CPUs accelerate in hardware. That's a free ~2× at essentially no accuracy cost.

Measured on a Sapphire Rapids Xeon 8481C (n_train=5000, 20 features, 4 threads, default `n_estimators=8`):

| precision | predict | accuracy | log-loss |
|---|--:|--:|--:|
| float32 (old CPU default) | 67.3s | 0.9940 | 0.0346 |
| **auto → bf16 (this PR)** | **32.4s** | 0.9940 | 0.0347 |

→ **2.08×**, accuracy identical.

## How
- New `_cpu_supports_fast_bf16()` — detects hardware bf16 via torch's CPU capability check (`torch.cpu._is_avx512_bf16_supported()`, the same check vLLM uses; AMX CPUs also enumerate AVX512-BF16, so this single check covers AMX machines too), and additionally requires `torch.backends.mkldnn.is_available()` so torch builds without oneDNN's fast bf16 kernels (e.g. macOS wheels, where CPU bf16 is dramatically *slower* than fp32; Fedora-packaged torch) stay in float32. The capability helper is private torch API, so it is accessed via `getattr` — if a future torch removes it, TabPFN emits a `UserWarning` and stays on float32, so the lost speedup is visible and reportable rather than a silent regression or a crash. Conservative overall: returns `False` when unsure, so `"auto"` **never regresses** on CPUs without fast bf16 (Skylake/Cascade/Ice Lake, AVX2 laptops, macOS). Unlike the earlier `/proc/cpuinfo` approach, this also covers Windows x86 (Zen 4+ / Sapphire Rapids).
- `infer_fp16_inference_mode` → renamed to `infer_autocast_inference_mode` (CPU autocast runs bf16, not fp16), with a CPU branch that enables autocast only when every selected device is a CPU with fast bf16. No deprecation alias: GitHub-wide code search finds no external importer of the old name (only vendored copies of TabPFN). The `enable=True` error message now references `inference_precision="autocast"` (the actual API) instead of a nonexistent `fp16_inference` parameter.
- Uses **autocast** (not a forced dtype), so inputs and numpy preprocessing stay float32 — no interaction with e.g. the fingerprint preprocessing step.

## Notes
- GPU behavior unchanged.
- Escape hatch: pass `inference_precision=torch.float32` to force float32, or a specific `torch.dtype` to force it.
- ARM64 is a potential follow-up: Graviton 3/4 expose a `bf16` cpuinfo flag and aarch64 Linux wheels ship ACL bf16 kernels, but the hardware flag alone doesn't guarantee the installed wheel has fast kernels, so enabling it should be preceded by a Graviton benchmark.

## Tests
- Parametrized unit tests in `tests/test_utils.py`: detection (bf16 hardware / no bf16 hardware / no-oneDNN build / torch helper missing warns) and the CPU autocast branches (auto with/without fast bf16, explicit disable, explicit enable raising on unsupported CPUs).
- Validated end-to-end on-hardware: `auto` → `use_autocast_=True`, no crash with fingerprint on, 2.08×, accuracy unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
