### PR TITLE
enable torch autocast for mps [PRI-341]

### DIFF
--- a/changelog/1124.changed.md
+++ b/changelog/1124.changed.md
@@ -1,0 +1,1 @@
+Enabled autocast also for mps.

--- a/src/tabpfn/utils.py
+++ b/src/tabpfn/utils.py
@@ -29,7 +29,7 @@ MAXINT_RANDOM_SEED = int(np.iinfo(np.int32).max)
 def get_autocast_context(
     device: torch.device, *, enabled: bool
 ) -> contextlib.AbstractContextManager:
-    """Returns a torch.autocast context manager, disabling it for MPS devices.
+    """Returns a torch.autocast context manager.
 
     Args:
         device: The torch device being used.

--- a/src/tabpfn/utils.py
+++ b/src/tabpfn/utils.py
@@ -38,8 +38,6 @@ def get_autocast_context(
     Returns:
         A context manager for autocasting.
     """
-    if device.type == "mps":
-        return contextlib.nullcontext()
     return torch.autocast(device.type, enabled=enabled)
 
 


### PR DESCRIPTION
## Issue

Partially adresses PriorLabs/TabPFN#1102

## Motivation and Context

We currently disable autocast on MPS. However, enabling it gives drastic speeupds on Apple Silikon. We are not aware of any accuracy concerns specific to MPS.

By now it seems that bfloat16 is supported by torch for MPS, since `torch==2.6.0` [https://github.com/pytorch/pytorch/pull/139390#issuecomment-2666900556](<https://github.com/pytorch/pytorch/pull/139390#issuecomment-2666900556>).

It reduces the runtime of below code snippet from around 8.3s to 5s on my macbook

```python
from tabpfn import TabPFNClassifier, TabPFNRegressor
from sklearn.datasets import make_classification, make_regression
import torch

from time import time

X_train, y_train = make_classification(
            n_samples=1000,
            n_features=100,
            n_classes=2,
        )

X_test = X_train

start = time()
clf = TabPFNClassifier()
clf.fit(X_train, y_train)  # downloads checkpoint on first use
predictions = clf.predict(X_test)
print(predictions[0])
print("time to fit and predict", time()-start)
```

---

## Public API Changes

- [ ] No Public API changes
- [X] Yes, Public API changes (Details below)

---

## How Has This Been Tested?

## Yes, all pytests pass on my mac and run significantly faster

## Checklist

- [X] The changes have been tested locally.
- [ ] Documentation has been updated (if the public API or usage changes).
- [ ] A changelog entry has been added (see `changelog/README.md`), or "no changelog needed" label requested.
- [X] The code follows the project's style guidelines.
- [X] I have considered the impact of these changes on the public API.

---