### PR TITLE
Fix _repair_borders widening the top border downwards for negative targets

### DIFF
--- a/changelog/1127.fixed.md
+++ b/changelog/1127.fixed.md
@@ -1,0 +1,1 @@
+Fix `_repair_borders` widening the top bar-distribution border downwards for negative targets, which left the borders non-ascending when a quantile target transform collapsed the top gap.

--- a/src/tabpfn/utils.py
+++ b/src/tabpfn/utils.py
@@ -60,10 +60,10 @@ def _repair_borders(borders: np.ndarray, *, inplace: Literal[True]) -> None:
         nans = np.isnan(borders)
         largest = borders[~nans].max()
         borders[nans] = largest
-        borders[-1] = borders[-1] * 2
+        borders[-1] += np.abs(borders[-1])
 
     if borders[-1] - borders[-2] < 1e-6:
-        borders[-1] = borders[-1] * 1.1
+        borders[-1] += np.abs(borders[-1] * 0.1)
 
     if borders[0] == borders[1]:
         borders[0] -= np.abs(borders[0] * 0.1)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,6 +11,7 @@ import torch
 from torch.torch_version import TorchVersion
 
 from tabpfn.utils import (
+    _repair_borders,
     _translate_probs_across_borders_unchunked,
     balance_probas_by_class_counts,
     infer_devices,
@@ -269,3 +270,36 @@ def test__translate_probs_across_borders__forces_chunking(
     assert call_counter["n"] == total_rows  # chunk_size == 1 row here
     assert out_chunked.shape == out_unchunked.shape
     assert torch.equal(out_chunked, out_unchunked)
+
+
+@pytest.mark.parametrize(
+    ("borders", "expected_last"),
+    [
+        # Widening must move the top border up regardless of sign. Multiplying by
+        # 1.1 moves a negative border further down, past borders[-2].
+        ([-10.0, -5.0, -4.9999999], -4.5),
+        ([1.0, 5.0, 5.0000001], 5.5),
+        ([-2.0, 3.0, 3.0000001], 3.3),
+    ],
+)
+def test__repair_borders__collapsed_top_gap__widens_upwards(borders, expected_last):
+    repaired = np.array(borders)
+    _repair_borders(repaired, inplace=True)
+
+    assert repaired[-1] == pytest.approx(expected_last)
+    assert np.all(np.diff(repaired) > 0)
+
+
+@pytest.mark.parametrize(
+    ("borders", "expected_last"),
+    [
+        ([-10.0, -5.0, np.nan], 0.0),
+        ([1.0, 5.0, np.nan], 10.0),
+    ],
+)
+def test__repair_borders__nan_top__widens_upwards(borders, expected_last):
+    repaired = np.array(borders)
+    _repair_borders(repaired, inplace=True)
+
+    assert repaired[-1] == pytest.approx(expected_last)
+    assert np.all(np.diff(repaired) > 0)


### PR DESCRIPTION
## Issue

No existing issue — the template asks for one first, so flagging that I skipped it. In practice
most merged PRs here don't link one (11 recent external merges, 2 with an issue), so I read this
as a preference rather than a hard gate; happy to open one and reopen against it if you'd rather.

## Motivation and Context

`_repair_borders` widens the outermost borders so the bar distribution has a non-degenerate top bucket, but it does so by **multiplying**:

```python
if borders[-1] - borders[-2] < 1e-6:
    borders[-1] = borders[-1] * 1.1
```

Multiplying only widens *upwards* when the border is positive. For a **negative** border it moves further *down*, past `borders[-2]`, leaving the borders no longer ascending:

```python
_repair_borders([-10., -5., -4.9999999])  # -> [-10., -5., -5.5]   ascending: False
_repair_borders([  1.,   5.,  5.0000001])  # -> [  1.,   5.,   5.5]   ascending: True
```

The lower border a few lines below already gets this right, using an additive form whose direction does not depend on the sign:

```python
if borders[0] == borders[1]:
    borders[0] -= np.abs(borders[0] * 0.1)
```

**Fix**

Mirror that idiom for the top border. The NaN branch above has the same flaw (`borders[-1] * 2` after the NaN fill), so it gets the same treatment.

**Behaviour on positive targets is unchanged** — for a positive border, `x += np.abs(x)` is exactly the previous `x * 2`, and `x += np.abs(x * 0.1)` is exactly `x * 1.1`. Only the negative case changes, and only from "broken" to "widened outward".

I want to be precise about this rather than overstate it. The default `REGRESSION_Y_PREPROCESS_TRANSFORMS` is `(None, "safepower")`, which does not produce a collapsed top gap, so **the default path never triggers this**.

It is reachable through a documented user option: `inference_config.py` states the transform may be *"One of the options from `tabpfn.preprocessing.get_all_reshape_feature_distribution_preprocessors()`"*. With a quantile transform, `QuantileTransformer`'s inverse saturates at `y.max()`, producing a zero-width top gap that sends `_repair_borders` down this branch; when the target is all-negative, the border is then driven backwards:

```python
tf = get_all_reshape_feature_distribution_preprocessors(num_examples=1000, random_state=0)["quantile_uni"]
tf.fit(y.reshape(-1, 1))              # y = all-negative target
_, _, bt = transform_borders_one(np.linspace(-5, 5, 20), target_transform=tf,
                                 repair_nan_borders_after_transform=True)
bt[-2], bt[-1]   # -0.149655, -0.164621   -> descending
```

`_repair_borders` itself is called unconditionally from `transform_borders_one` (`utils.py:450`), which is live in the predict path at `regressor.py:1372` whenever `config_for_ensemble.target_transform is not None`.

---

## Public API Changes

-   [x] No Public API changes

---

## How Has This Been Tested?

`tests/test_utils.py` previously had no coverage of `_repair_borders` (it covers `infer_devices` and `translate_probs_across_borders` only), which is why the sign flaw survived. Added parametrized cases for the collapsed-gap and NaN branches, each asserting both the expected border and that the result is strictly ascending. The two negative cases fail on `main` and pass here; the positive/straddling-zero cases pass both ways, pinning the unchanged behaviour.

`pytest tests/test_utils.py` — **21 passed** (16 existing + 5 new), no regressions. `ruff check` / `ruff format --check` clean (with the pinned 0.15.12).

---

AI disclosure: drafted with Claude Code (Opus 4.8), including the root-cause trace and the tests. I ran the repro and the test file locally and reviewed the diff before opening.

---

## Checklist

-   [x] The changes have been tested locally.
-   [x] Documentation has been updated (if the public API or usage changes). — n/a, no public API change
-   [x] A changelog entry has been added (`changelog/1127.fixed.md`).
-   [x] The code follows the project's style guidelines.
-   [x] I have considered the impact of these changes on the public API.

---

---

AI disclosure: drafted with Claude Code (Opus 4.8), including the root-cause trace and the tests. I ran the repro and the test file locally and reviewed the diff before opening.
