### PR TITLE
allow MPS only with torch>=2.6

### DIFF
--- a/changelog/1129.changed.md
+++ b/changelog/1129.changed.md
@@ -1,0 +1,1 @@
+Changed the minimal required version of torch to use MPS to 2.6

--- a/src/tabpfn/utils.py
+++ b/src/tabpfn/utils.py
@@ -142,7 +142,7 @@ def infer_devices(devices: DevicesSpecification) -> tuple[torch.device, ...]:
             )
 
         if "mps" not in exclude_devices and torch.backends.mps.is_available():
-            if _is_mps_supported():
+            if _is_torch_mps_supported():
                 return (torch.device("mps"),)
             warnings.warn(
                 "An MPS device is available, but TabPFN disables MPS for "
@@ -165,12 +165,17 @@ def infer_devices(devices: DevicesSpecification) -> tuple[torch.device, ...]:
             f"than once. It contained: {devices}"
         )
 
-    if not _is_mps_supported() and any(d.type == "mps" for d in devices):
-        raise ValueError(
-            "The MPS device was selected, "
-            "but TabPFN requires PyTorch >= 2.6 for MPS. "
-            'Upgrade PyTorch, or set `device="cpu"` instead.'
-        )
+    if any(d.type == "mps" for d in devices):
+        if not torch.backends.mps.is_available():
+            raise ValueError(
+                "The MPS device was selected, but MPS is not available on this system."
+            )
+        if not _is_torch_mps_supported():
+            raise ValueError(
+                "The MPS device was selected, "
+                "but TabPFN requires PyTorch >= 2.6 for MPS. "
+                "Upgrade PyTorch, or set device='cpu' instead."
+            )
 
     return devices
 
@@ -189,12 +194,12 @@ def _parse_device(device: str | torch.device) -> torch.device:
     return device
 
 
-def _is_mps_supported() -> bool:
+def _is_torch_mps_supported() -> bool:
     """Return True if the MPS device is supported, otherwise False.
 
     We require PyTorch >= 2.6 for MPS to support all used operations.
     """
-    return torch.__version__ >= "2.6" and torch.backends.mps.is_available()
+    return torch.__version__ >= "2.6"
 
 
 def is_autocast_available(device_type: str) -> bool:

--- a/src/tabpfn/utils.py
+++ b/src/tabpfn/utils.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import contextlib
 import os
+import warnings
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Literal
 
@@ -140,8 +141,16 @@ def infer_devices(devices: DevicesSpecification) -> tuple[torch.device, ...]:
                 torch.device(f"cuda:{i}") for i in range(torch.cuda.device_count())
             )
 
-        if _is_mps_supported() and "mps" not in exclude_devices:
-            return (torch.device("mps"),)
+        if "mps" not in exclude_devices and torch.backends.mps.is_available():
+            if _is_mps_supported():
+                return (torch.device("mps"),)
+            warnings.warn(
+                "An MPS device is available, but TabPFN disables MPS for "
+                "PyTorch < 2.6 (earlier versions can give poor accuracy and "
+                "lack bfloat16 autocast support on the MPS backend). Falling "
+                "back to CPU. Install torch>=2.6 to use MPS.",
+                stacklevel=2,
+            )
 
         return (torch.device("cpu"),)
 
@@ -159,8 +168,8 @@ def infer_devices(devices: DevicesSpecification) -> tuple[torch.device, ...]:
     if not _is_mps_supported() and any(d.type == "mps" for d in devices):
         raise ValueError(
             "The MPS device was selected, "
-            "but this is not supported by TabPFN before PyTorch 2.5. "
-            'Set `device="cpu"` instead.'
+            "but TabPFN requires PyTorch >= 2.6 for MPS. "
+            'Upgrade PyTorch, or set `device="cpu"` instead.'
         )
 
     return devices
@@ -183,10 +192,9 @@ def _parse_device(device: str | torch.device) -> torch.device:
 def _is_mps_supported() -> bool:
     """Return True if the MPS device is supported, otherwise False.
 
-    We have found that using MPS can lead to poor accuracy on PyTorch <2.5. See
-    https://github.com/PriorLabs/TabPFN/pull/619
+    We require PyTorch >= 2.6 for MPS to support all used operations.
     """
-    return torch.__version__ >= "2.5" and torch.backends.mps.is_available()
+    return torch.__version__ >= "2.6" and torch.backends.mps.is_available()
 
 
 def is_autocast_available(device_type: str) -> bool:


### PR DESCRIPTION
## Issue
resolves #1126 by avoiding to bump torch for all users.

## Motivation and Context
The  package does not run anymore on torch 2.5 with MPS, because we are using operations that were not implemented back then. Thus the tests are also failing. Allowing only torch>=2.6 for MPS resolves this.


---

## Public API Changes

-   [x] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?
test pass on torch 2.6 on the mac, but fail on torch 2.5 with clear error message of unsupported operations.

---

## Checklist

-   [x] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [x] A changelog entry has been added (see `changelog/README.md`), or "no changelog needed" label requested.
-   [x] The code follows the project's style guidelines.
-   [x] I have considered the impact of these changes on the public API.

---
