### PR TITLE
parallelization and datatype dependent preprocessing [RES-2237]

### DIFF
--- a/src/tabpfn/preprocessing/modality_detection.py
+++ b/src/tabpfn/preprocessing/modality_detection.py
@@ -4,9 +4,11 @@
 
 from __future__ import annotations
 
+import os
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from concurrent.futures import ThreadPoolExecutor
 
+import numpy as np
 import pandas as pd
 
 from tabpfn.errors import TabPFNUserError
@@ -17,8 +19,9 @@ from tabpfn.preprocessing.datamodel import (
     build_input_feature_names,
 )
 
-if TYPE_CHECKING:
-    import numpy as np
+_NUMERIC_NUMPY_DTYPE_KINDS = "fiub"
+"""Numpy dtype kinds whose columns are counted with the GIL-releasing
+``np.unique`` kernel; other dtypes use the pandas kernel."""
 
 
 def detect_feature_modalities(
@@ -58,22 +61,89 @@ def detect_feature_modalities(
         A dictionary with the feature modalities as keys and the column as
         values.
     """
-    features: list[Feature] = []
     big_enough_n_to_infer_cat = len(X) > min_samples_for_inference
     unique_feature_names = build_input_feature_names(feature_names, X.shape[1])
-    for i, index in enumerate(range(X.shape[1])):
-        X_slice: np.ndarray = X[:, index]
+    # Numeric arrays use a count-based kernel built on np.unique, which
+    # releases the GIL while sorting -- the thread pool then scales across
+    # cores. Other dtypes run the pandas kernel, which holds the GIL (the
+    # loop still works, it just does not parallelise).
+    use_numeric_kernel = X.dtype.kind in _NUMERIC_NUMPY_DTYPE_KINDS
+
+    def detect_one(index: int) -> FeatureModality:
         reported_categorical = index in (provided_categorical_indices or ())
-        feature_name = unique_feature_names[i]
-        feat_modality = _detect_feature_modality(
-            s=pd.Series(X_slice, name=feature_name),
+        if use_numeric_kernel:
+            return _modality_from_exact_count(
+                n_unique=_nunique_numeric(X[:, index]),
+                reported_categorical=reported_categorical,
+                max_unique_for_category=max_unique_for_category,
+                min_unique_for_numerical=min_unique_for_numerical,
+                big_enough_n_to_infer_cat=big_enough_n_to_infer_cat,
+            )
+        return _detect_feature_modality(
+            s=pd.Series(X[:, index], name=unique_feature_names[index]),
             reported_categorical=reported_categorical,
             max_unique_for_category=max_unique_for_category,
             min_unique_for_numerical=min_unique_for_numerical,
             big_enough_n_to_infer_cat=big_enough_n_to_infer_cat,
         )
-        features.append(Feature(name=feature_name, modality=feat_modality))
+
+    with ThreadPoolExecutor(max_workers=_usable_cpu_count()) as executor:
+        modalities = list(executor.map(detect_one, range(X.shape[1])))
+
+    features = [
+        Feature(name=unique_feature_names[i], modality=modality)
+        for i, modality in enumerate(modalities)
+    ]
     return FeatureSchema(features=features)
+
+
+def _usable_cpu_count() -> int:
+    """CPUs available to this process (cgroup/affinity-aware where possible)."""
+    if hasattr(os, "sched_getaffinity"):
+        return len(os.sched_getaffinity(0))
+    return os.cpu_count() or 1
+
+
+def _nunique_numeric(column: np.ndarray) -> int:
+    """Exact distinct count of a numeric column, NaN counted as one category.
+
+    Equals ``pd.Series(column).nunique(dropna=False)``: NaN is one category
+    (handled explicitly, since ``np.unique`` collapses NaNs only from numpy
+    1.24 on), ``+/-inf`` are ordinary values, and ``0.0 == -0.0`` collapses
+    under both implementations.
+    """
+    if column.dtype.kind == "f":
+        non_nan = column[~np.isnan(column)]
+        return len(np.unique(non_nan)) + (non_nan.shape[0] < column.shape[0])
+    return len(np.unique(column))
+
+
+def _modality_from_exact_count(
+    n_unique: int,
+    *,
+    reported_categorical: bool,
+    max_unique_for_category: int,
+    min_unique_for_numerical: int,
+    big_enough_n_to_infer_cat: bool,
+) -> FeatureModality:
+    """Modality of a numeric-dtype column from its exact distinct count.
+
+    Mirrors :func:`_detect_feature_modality` for numeric-dtype columns: there
+    the series is always numeric (``_is_numeric_pandas_series`` is True by
+    dtype), so the decision depends only on the distinct count. Any change to
+    the decision logic must be made in both places.
+    """
+    if n_unique <= 1 and not reported_categorical:
+        return FeatureModality.CONSTANT
+    if _detect_numeric_as_categorical(
+        n_unique=n_unique,
+        reported_categorical=reported_categorical,
+        max_unique_for_category=max_unique_for_category,
+        min_unique_for_numerical=min_unique_for_numerical,
+        big_enough_n_to_infer_cat=big_enough_n_to_infer_cat,
+    ):
+        return FeatureModality.CATEGORICAL
+    return FeatureModality.NUMERICAL
 
 
 def _detect_feature_modality(

--- a/tests/test_preprocessing/test_modality_detection.py
+++ b/tests/test_preprocessing/test_modality_detection.py
@@ -13,6 +13,7 @@ import pytest
 from tabpfn.preprocessing.datamodel import FeatureModality
 from tabpfn.preprocessing.modality_detection import (
     _detect_feature_modality,
+    _nunique_numeric,
     detect_feature_modalities,
 )
 from tabpfn.preprocessing.type_detection import infer_categorical_features
@@ -400,3 +401,102 @@ def test_infer_categorical_with_dict_raises_error():
             max_unique_for_category=2,
             min_unique_for_numerical=2,
         )
+
+
+# ---------------------------------------------------------------------------
+# Parallel numeric kernel: equivalence with the pandas kernel
+# ---------------------------------------------------------------------------
+
+
+def _numeric_test_matrix(rng: np.random.Generator, n: int = 500) -> np.ndarray:
+    """Matrix mixing every numeric column kind the kernel must handle."""
+    cols = [
+        rng.standard_normal(n),  # continuous
+        rng.integers(0, 3, n).astype(np.float64),  # low-cardinality
+        rng.integers(0, 50, n).astype(np.float64),  # mid-cardinality
+        np.full(n, 7.0),  # constant
+        np.full(n, np.nan),  # all-NaN
+        np.where(rng.random(n) < 0.1, np.nan, rng.standard_normal(n)),  # NaN mix
+        np.where(rng.random(n) < 0.1, np.inf, rng.standard_normal(n)),  # +inf mix
+        np.where(rng.random(n) < 0.1, -np.inf, rng.integers(0, 2, n)),  # -inf mix
+        np.where(rng.random(n) < 0.5, np.nan, 1.0),  # constant + NaN
+        np.where(rng.random(n) < 0.5, 0.0, -0.0),  # signed zeros collapse
+    ]
+    return np.stack(cols, axis=1)
+
+
+@pytest.mark.parametrize("dtype", [np.float64, np.float32])
+@pytest.mark.parametrize("provided_categorical_indices", [None, [1, 2, 3]])
+def test__numeric_kernel_matches_pandas_kernel(
+    dtype: type,
+    provided_categorical_indices: list[int] | None,
+) -> None:
+    """The threaded numeric kernel must reproduce the pandas kernel exactly."""
+    X = _numeric_test_matrix(np.random.default_rng(0)).astype(dtype)
+    schema = detect_feature_modalities(
+        X=X,
+        feature_names=None,
+        min_samples_for_inference=100,
+        max_unique_for_category=30,
+        min_unique_for_numerical=4,
+        provided_categorical_indices=provided_categorical_indices,
+    )
+    for j, feature in enumerate(schema.features):
+        expected = _detect_feature_modality(
+            pd.Series(X[:, j]),
+            reported_categorical=j in (provided_categorical_indices or ()),
+            max_unique_for_category=30,
+            min_unique_for_numerical=4,
+            big_enough_n_to_infer_cat=True,
+        )
+        assert feature.modality == expected, f"column {j}"
+
+
+@pytest.mark.parametrize("dtype", [np.int64, np.int32, np.uint8, np.bool_])
+def test__numeric_kernel_matches_pandas_kernel_int_bool(dtype: type) -> None:
+    rng = np.random.default_rng(1)
+    X = np.stack(
+        [
+            rng.integers(0, 2, 500),  # binary
+            rng.integers(0, 2, 500),  # binary
+            np.ones(500, dtype=np.int64),  # constant
+            rng.integers(0, 100, 500) % (2 if dtype == np.bool_ else 100),
+        ],
+        axis=1,
+    ).astype(dtype)
+    schema = detect_feature_modalities(
+        X=X,
+        feature_names=None,
+        min_samples_for_inference=100,
+        max_unique_for_category=30,
+        min_unique_for_numerical=4,
+    )
+    for j, feature in enumerate(schema.features):
+        expected = _detect_feature_modality(
+            pd.Series(X[:, j]),
+            reported_categorical=False,
+            max_unique_for_category=30,
+            min_unique_for_numerical=4,
+            big_enough_n_to_infer_cat=True,
+        )
+        assert feature.modality == expected, f"column {j}"
+
+
+def test__nunique_numeric_matches_pandas() -> None:
+    X = _numeric_test_matrix(np.random.default_rng(2))
+    for j in range(X.shape[1]):
+        assert _nunique_numeric(X[:, j]) == pd.Series(X[:, j]).nunique(dropna=False), (
+            f"column {j}"
+        )
+
+
+def test__numeric_kernel_zero_rows() -> None:
+    X = np.empty((0, 3), dtype=np.float64)
+    schema = detect_feature_modalities(
+        X=X,
+        feature_names=None,
+        min_samples_for_inference=100,
+        max_unique_for_category=30,
+        min_unique_for_numerical=4,
+    )
+    assert [f.modality for f in schema.features] == [FeatureModality.CONSTANT] * 3


### PR DESCRIPTION
## Issue
[RES-2237: Parallelize per-column modality detection (nunique) in fit() across CPU cores](https://linear.app/priorlabs/issue/RES-2237/parallelize-per-column-modality-detection-nunique-in-fit-across-cpu)

## Motivation and Context

---

## Public API Changes

-   [ ] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?

---

## Checklist

-   [ ] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [ ] A changelog entry has been added (see `changelog/README.md`), or "no changelog needed" label requested.
-   [ ] The code follows the project's style guidelines.
-   [ ] I have considered the impact of these changes on the public API.

---
