### PR TITLE
only consider max_features_per_estimator when finding max input features [RES-2236]

### DIFF
--- a/changelog/1136.changed.md
+++ b/changelog/1136.changed.md
@@ -1,1 +1,1 @@
-improved performance of _find_max_input_features
+Speed up preprocessing for large number of features

--- a/changelog/1136.changed.md
+++ b/changelog/1136.changed.md
@@ -1,0 +1,1 @@
+improved performance of _find_max_input_features

--- a/src/tabpfn/preprocessing/ensemble.py
+++ b/src/tabpfn/preprocessing/ensemble.py
@@ -622,9 +622,6 @@ def _find_max_input_features(
     """
     n_total = feature_schema.num_columns
 
-    # Steps only ever add features (num_added_features >= 0), so any
-    # k > max_features_per_estimator can never fit the budget. Starting the
-    # scan at the budget keeps this O(budget^2) instead of O(n_total^2).
     for k in range(min(n_total, max_features_per_estimator), -1, -1):
         if k == n_total:
             sliced_schema = feature_schema

--- a/src/tabpfn/preprocessing/ensemble.py
+++ b/src/tabpfn/preprocessing/ensemble.py
@@ -613,7 +613,7 @@ def _find_max_input_features(
 ) -> int:
     """Find the largest number of input features that fits within the budget.
 
-    Decrements from n_total until k + pipeline.num_added_features(...) <= max.
+    Decrements k until k + pipeline.num_added_features(...) <= max.
 
     TODO: The search always slices the *first* k features, so the budget
     estimate can be biased when transforms add features depending on feature
@@ -622,7 +622,10 @@ def _find_max_input_features(
     """
     n_total = feature_schema.num_columns
 
-    for k in range(n_total, -1, -1):
+    # Steps only ever add features (num_added_features >= 0), so any
+    # k > max_features_per_estimator can never fit the budget. Starting the
+    # scan at the budget keeps this O(budget^2) instead of O(n_total^2).
+    for k in range(min(n_total, max_features_per_estimator), -1, -1):
         if k == n_total:
             sliced_schema = feature_schema
         else:


### PR DESCRIPTION
## Issue
[RES-2236: O(n_features²) feature-budget scan in TabPFNEnsemblePreprocessor.__init__ dominates fit() setup on wide tables](https://linear.app/priorlabs/issue/RES-2236/on-features-feature-budget-scan-in-tabpfnensemblepreprocessor-init)

## Motivation and Context
`_find_max_input_features` scanned `k` downward from `n_total`, rebuilding an
O(k) sliced schema per iteration → O(n_features²) on wide tables, all inside
`__init__`.

Since every `num_added_features` implementation returns ≥ 0, any
`k > max_features_per_estimator` can never fit the budget, so the scan now
starts at `min(n_total, budget)` instead of `n_total`. Behavior-identical:
returns the same `k` for all inputs.

Timing of `_find_max_input_features` (L4 node, n_samples=30k, budget=500, best of 3:

```
n_features   before      after    k (both)
       500    21.8 ms    21.8 ms    399
      1000   196.5 ms    22.0 ms    399
      2000   934.2 ms    21.9 ms    399
      4000  3984.7 ms    22.0 ms    399
      8000 17324.3 ms    21.9 ms    399
```

Brute-force equivalence check vs. the original full scan passes for widths
around the budget boundary (1–1000 features).
---

## Public API Changes

-   [x] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?
pytests pass, and performance has been verified locally.
---

## Checklist

-   [x] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [x] A changelog entry has been added (see `changelog/README.md`), or "no changelog needed" label requested.
-   [x] The code follows the project's style guidelines.
-   [x] I have considered the impact of these changes on the public API.

---
