### PR TITLE
add early exit for modality detection [RES-2237]

### DIFF
--- a/changelog/1137.changed.md
+++ b/changelog/1137.changed.md
@@ -1,0 +1,1 @@
+Speedup preprocessing for large numeric columns.

--- a/src/tabpfn/preprocessing/modality_detection.py
+++ b/src/tabpfn/preprocessing/modality_detection.py
@@ -84,7 +84,20 @@ def _detect_feature_modality(
     min_unique_for_numerical: int,
     big_enough_n_to_infer_cat: bool,
 ) -> FeatureModality:
-    n_unique = _get_unique_with_sklearn_compatible_error(s)
+    # Early exit for the distinct count: counts only grow with the number of
+    # rows scanned, and every comparison below is against a threshold of at
+    # most max(max_unique_for_category, min_unique_for_numerical). So once a
+    # small prefix of the column already exceeds all of them, every decision
+    # equals the full-column one and scanning the remaining rows is skipped —
+    # the common case for continuous columns. Low-cardinality columns fall
+    # through to the exact full count, paying one extra prefix pass.
+    PREFIX_ROWS = 1024
+    decided_at = max(max_unique_for_category, min_unique_for_numerical, 1) + 1
+    n_unique = 0
+    if len(s) > PREFIX_ROWS:
+        n_unique = _get_unique_with_sklearn_compatible_error(s.iloc[:PREFIX_ROWS])
+    if n_unique < decided_at:
+        n_unique = _get_unique_with_sklearn_compatible_error(s)
 
     if n_unique <= 1 and not reported_categorical:
         # Either all values are missing, or all values are the same.

--- a/src/tabpfn/preprocessing/modality_detection.py
+++ b/src/tabpfn/preprocessing/modality_detection.py
@@ -20,6 +20,8 @@ from tabpfn.preprocessing.datamodel import (
 if TYPE_CHECKING:
     import numpy as np
 
+_EARLY_EXIT_PREFIX_ROWS = 1024
+
 
 def detect_feature_modalities(
     X: np.ndarray,
@@ -91,11 +93,12 @@ def _detect_feature_modality(
     # equals the full-column one and scanning the remaining rows is skipped —
     # the common case for continuous columns. Low-cardinality columns fall
     # through to the exact full count, paying one extra prefix pass.
-    PREFIX_ROWS = 1024
     decided_at = max(max_unique_for_category, min_unique_for_numerical, 1) + 1
     n_unique = 0
-    if len(s) > PREFIX_ROWS:
-        n_unique = _get_unique_with_sklearn_compatible_error(s.iloc[:PREFIX_ROWS])
+    if len(s) > _EARLY_EXIT_PREFIX_ROWS:
+        n_unique = _get_unique_with_sklearn_compatible_error(
+            s.iloc[:_EARLY_EXIT_PREFIX_ROWS]
+        )
     if n_unique < decided_at:
         n_unique = _get_unique_with_sklearn_compatible_error(s)
 

--- a/tests/test_preprocessing/test_modality_detection.py
+++ b/tests/test_preprocessing/test_modality_detection.py
@@ -12,6 +12,7 @@ import pytest
 
 from tabpfn.preprocessing.datamodel import FeatureModality
 from tabpfn.preprocessing.modality_detection import (
+    _EARLY_EXIT_PREFIX_ROWS,
     _detect_feature_modality,
     detect_feature_modalities,
 )
@@ -420,7 +421,9 @@ def test__long_columns_early_exit_decisions(
 
 
 def test__early_exit_not_fooled_by_uninformative_prefix():
-    # The first 1024 rows are constant; only the tail is distinct. The prefix
-    # must not decide anything -- the full scan has to run.
-    s = pd.Series(np.concatenate([np.zeros(1024), np.arange(1.0, 4000.0)]))
+    # The prefix is constant; only the tail is distinct. The prefix must not
+    # decide anything -- the full scan has to run.
+    s = pd.Series(
+        np.concatenate([np.zeros(_EARLY_EXIT_PREFIX_ROWS), np.arange(1.0, 4000.0)])
+    )
     assert _for_test_detect_with_defaults(s) == FeatureModality.NUMERICAL

--- a/tests/test_preprocessing/test_modality_detection.py
+++ b/tests/test_preprocessing/test_modality_detection.py
@@ -400,3 +400,27 @@ def test_infer_categorical_with_dict_raises_error():
             max_unique_for_category=2,
             min_unique_for_numerical=2,
         )
+
+
+@pytest.mark.parametrize(
+    ("series_data", "expected"),
+    [
+        # Prefix (1024 rows) already shows > 10 distinct -> decided early.
+        (np.arange(5000, dtype=float), FeatureModality.NUMERICAL),
+        # Prefix stays below the threshold -> exact full scan must run.
+        (np.tile([1.0, 2.0, 3.0], 2000), FeatureModality.CATEGORICAL),
+        (np.zeros(5000), FeatureModality.CONSTANT),
+    ],
+)
+def test__long_columns_early_exit_decisions(
+    series_data: np.ndarray, expected: FeatureModality
+) -> None:
+    """Columns longer than the early-exit prefix get the exact-count modality."""
+    assert _for_test_detect_with_defaults(pd.Series(series_data)) == expected
+
+
+def test__early_exit_not_fooled_by_uninformative_prefix():
+    # The first 1024 rows are constant; only the tail is distinct. The prefix
+    # must not decide anything -- the full scan has to run.
+    s = pd.Series(np.concatenate([np.zeros(1024), np.arange(1.0, 4000.0)]))
+    assert _for_test_detect_with_defaults(s) == FeatureModality.NUMERICAL


### PR DESCRIPTION
## Issue, Motivation and Context

https://linear.app/priorlabs/issue/RES-2237/parallelize-per-column-modality-detection-nunique-in-fit-across-cpu#comment-2522b6fd

---

## Public API Changes

-   [x] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?

---

## Checklist

-   [x] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [x] A changelog entry has been added (see `changelog/README.md`), or "no changelog needed" label requested.
-   [x] The code follows the project's style guidelines.
-   [x] I have considered the impact of these changes on the public API.

---
