### PR TITLE
Fix v2.x activation checkpointing regression from #1070

### DIFF
--- a/changelog/1138.fixed.md
+++ b/changelog/1138.fixed.md
@@ -1,0 +1,1 @@
+Fix activation checkpointing during v2, v2.5, and v2.6 fine-tuning after the state-container memory optimization.

--- a/src/tabpfn/architectures/tabpfn_v2.py
+++ b/src/tabpfn/architectures/tabpfn_v2.py
@@ -319,7 +319,7 @@ class TabPFNBlock(nn.Module):
 
     def forward(
         self,
-        x_BRCE_container: list[torch.Tensor],
+        x_BRCE: torch.Tensor,
         single_eval_pos: int,
         save_peak_memory_factor: int | None,
         *,
@@ -336,9 +336,9 @@ class TabPFNBlock(nn.Module):
         E: The embedding size of each cell.
 
         Args:
-            x_BRCE_container:
-                A length-1 list containing the transformer state passed as input to the
-                layer of shape (batch_size, num_items, num_feature_blocks, d_model).
+            x_BRCE:
+                The transformer state passed as input to the layer of shape
+                (batch_size, num_items, num_feature_blocks, d_model).
             single_eval_pos:
                 The position from which on everything is treated as test set.
             save_peak_memory_factor:
@@ -360,7 +360,6 @@ class TabPFNBlock(nn.Module):
         """
         # -- First Block: Attention between features.
         # The row attention has no train/test distinction and is not cached.
-        x_BRCE = x_BRCE_container.pop(0)
         x_BRCE = chunked_evaluate_maybe_inplace(
             self.per_sample_attention_between_features,
             x_BRCE,
@@ -926,13 +925,9 @@ class TabPFNV2(Architecture):
             {} if (return_kv_cache and not using_cache) else None
         )
         for layer_idx, block in enumerate(self.blocks):
-            # Note: Using x_BRCD._set() instead of the container approach here leads
-            # to memory issues on some mac hardware.
-            x_BRCD_container = [x_BRCD]
-            del x_BRCD
             if return_kv_cache and not using_cache:
                 x_BRCD, kv_entry = block(
-                    x_BRCD_container,
+                    x_BRCD,
                     block_single_eval_pos,
                     save_peak_memory_factor,
                     return_kv=True,
@@ -940,7 +935,7 @@ class TabPFNV2(Architecture):
                 kv_out[layer_idx] = kv_entry
             elif using_cache:
                 x_BRCD, _ = block(
-                    x_BRCD_container,
+                    x_BRCD,
                     block_single_eval_pos,
                     save_peak_memory_factor,
                     cached_kv=kv_cache.kv[layer_idx],
@@ -948,13 +943,14 @@ class TabPFNV2(Architecture):
             elif force_recompute_layer:
                 x_BRCD = torch.utils.checkpoint.checkpoint(
                     block,
-                    x_BRCD_container,
+                    x_BRCD,
                     block_single_eval_pos,
                     save_peak_memory_factor,
+                    use_reentrant=False,
                 )[0]
             else:
                 x_BRCD, _ = block(
-                    x_BRCD_container, block_single_eval_pos, save_peak_memory_factor
+                    x_BRCD, block_single_eval_pos, save_peak_memory_factor
                 )
 
         # In the cache path every row is a test row; otherwise test rows start after the

--- a/src/tabpfn/architectures/tabpfn_v2.py
+++ b/src/tabpfn/architectures/tabpfn_v2.py
@@ -319,7 +319,7 @@ class TabPFNBlock(nn.Module):
 
     def forward(
         self,
-        x_BRCE: torch.Tensor,
+        x_BRCE_container: list[torch.Tensor] | torch.Tensor,
         single_eval_pos: int,
         save_peak_memory_factor: int | None,
         *,
@@ -336,9 +336,11 @@ class TabPFNBlock(nn.Module):
         E: The embedding size of each cell.
 
         Args:
-            x_BRCE:
-                The transformer state passed as input to the layer of shape
-                (batch_size, num_items, num_feature_blocks, d_model).
+            x_BRCE_container:
+                Either the transformer state Tensor or a length-1 list containing
+                the transformer state. The list form is consumed with ``pop(0)``
+                so non-checkpointed callers can release their reference before
+                allocating the next activation.
             single_eval_pos:
                 The position from which on everything is treated as test set.
             save_peak_memory_factor:
@@ -360,6 +362,10 @@ class TabPFNBlock(nn.Module):
         """
         # -- First Block: Attention between features.
         # The row attention has no train/test distinction and is not cached.
+        if isinstance(x_BRCE_container, torch.Tensor):
+            x_BRCE = x_BRCE_container
+        else:
+            x_BRCE = x_BRCE_container.pop(0)
         x_BRCE = chunked_evaluate_maybe_inplace(
             self.per_sample_attention_between_features,
             x_BRCE,
@@ -926,16 +932,20 @@ class TabPFNV2(Architecture):
         )
         for layer_idx, block in enumerate(self.blocks):
             if return_kv_cache and not using_cache:
+                x_BRCD_container = [x_BRCD]
+                del x_BRCD
                 x_BRCD, kv_entry = block(
-                    x_BRCD,
+                    x_BRCD_container,
                     block_single_eval_pos,
                     save_peak_memory_factor,
                     return_kv=True,
                 )
                 kv_out[layer_idx] = kv_entry
             elif using_cache:
+                x_BRCD_container = [x_BRCD]
+                del x_BRCD
                 x_BRCD, _ = block(
-                    x_BRCD,
+                    x_BRCD_container,
                     block_single_eval_pos,
                     save_peak_memory_factor,
                     cached_kv=kv_cache.kv[layer_idx],
@@ -949,8 +959,10 @@ class TabPFNV2(Architecture):
                     use_reentrant=False,
                 )[0]
             else:
+                x_BRCD_container = [x_BRCD]
+                del x_BRCD
                 x_BRCD, _ = block(
-                    x_BRCD, block_single_eval_pos, save_peak_memory_factor
+                    x_BRCD_container, block_single_eval_pos, save_peak_memory_factor
                 )
 
         # In the cache path every row is a test row; otherwise test rows start after the

--- a/src/tabpfn/architectures/tabpfn_v2_5.py
+++ b/src/tabpfn/architectures/tabpfn_v2_5.py
@@ -382,7 +382,7 @@ class TabPFNBlock(nn.Module):
     @override
     def forward(
         self,
-        x_BRCE_container: list[torch.Tensor],
+        x_BRCE: torch.Tensor,
         single_eval_pos: int,
         save_peak_memory_factor: int | None,
         *,
@@ -399,9 +399,9 @@ class TabPFNBlock(nn.Module):
         E: The embedding size of each cell.
 
         Args:
-            x_BRCE_container:
-                A length-1 list containing the transformer state passed as input to the
-                layer of shape (batch_size, num_items, num_feature_blocks, d_model).
+            x_BRCE:
+                The transformer state passed as input to the layer of shape
+                (batch_size, num_items, num_feature_blocks, d_model).
             single_eval_pos:
                 The position from which on everything is treated as test set.
             save_peak_memory_factor:
@@ -423,7 +423,6 @@ class TabPFNBlock(nn.Module):
         """
         # -- First Block: Attention between features.
         # The row attention has no train/test distinction and is not cached.
-        x_BRCE = x_BRCE_container.pop(0)
         x_BRCE = chunked_evaluate_maybe_inplace(
             self.per_sample_attention_between_features,
             x_BRCE,
@@ -830,13 +829,9 @@ class TabPFNV2p5(Architecture):
 
         kv_out: dict[int, KVCacheEntry] = {}
         for layer_idx, block in enumerate(self.blocks):
-            # Note: Using x_BRCD._set() instead of the container approach here leads
-            # to memory issues on some mac hardware.
-            x_BRCD_container = [x_BRCD]
-            del x_BRCD
             if return_kv_cache and not using_cache:
                 x_BRCD, kv_entry = block(
-                    x_BRCD_container,
+                    x_BRCD,
                     block_single_eval_pos,
                     save_peak_memory_factor,
                     return_kv=True,
@@ -844,7 +839,7 @@ class TabPFNV2p5(Architecture):
                 kv_out[layer_idx] = kv_entry
             elif using_cache:
                 x_BRCD, _ = block(
-                    x_BRCD_container,
+                    x_BRCD,
                     block_single_eval_pos,
                     save_peak_memory_factor,
                     cached_kv=kv_cache.kv[layer_idx],
@@ -852,14 +847,14 @@ class TabPFNV2p5(Architecture):
             elif force_recompute_layer:
                 x_BRCD = torch.utils.checkpoint.checkpoint(
                     block,
-                    x_BRCD_container,
+                    x_BRCD,
                     block_single_eval_pos,
                     save_peak_memory_factor,
                     use_reentrant=False,
                 )[0]
             else:
                 x_BRCD, _ = block(
-                    x_BRCD_container, block_single_eval_pos, save_peak_memory_factor
+                    x_BRCD, block_single_eval_pos, save_peak_memory_factor
                 )
 
         # In the cache path every row is a test row; otherwise the test rows start

--- a/src/tabpfn/architectures/tabpfn_v2_5.py
+++ b/src/tabpfn/architectures/tabpfn_v2_5.py
@@ -382,7 +382,7 @@ class TabPFNBlock(nn.Module):
     @override
     def forward(
         self,
-        x_BRCE: torch.Tensor,
+        x_BRCE_container: list[torch.Tensor] | torch.Tensor,
         single_eval_pos: int,
         save_peak_memory_factor: int | None,
         *,
@@ -399,9 +399,11 @@ class TabPFNBlock(nn.Module):
         E: The embedding size of each cell.
 
         Args:
-            x_BRCE:
-                The transformer state passed as input to the layer of shape
-                (batch_size, num_items, num_feature_blocks, d_model).
+            x_BRCE_container:
+                Either the transformer state Tensor or a length-1 list containing
+                the transformer state. The list form is consumed with ``pop(0)``
+                so non-checkpointed callers can release their reference before
+                allocating the next activation.
             single_eval_pos:
                 The position from which on everything is treated as test set.
             save_peak_memory_factor:
@@ -423,6 +425,10 @@ class TabPFNBlock(nn.Module):
         """
         # -- First Block: Attention between features.
         # The row attention has no train/test distinction and is not cached.
+        if isinstance(x_BRCE_container, torch.Tensor):
+            x_BRCE = x_BRCE_container
+        else:
+            x_BRCE = x_BRCE_container.pop(0)
         x_BRCE = chunked_evaluate_maybe_inplace(
             self.per_sample_attention_between_features,
             x_BRCE,
@@ -830,16 +836,20 @@ class TabPFNV2p5(Architecture):
         kv_out: dict[int, KVCacheEntry] = {}
         for layer_idx, block in enumerate(self.blocks):
             if return_kv_cache and not using_cache:
+                x_BRCD_container = [x_BRCD]
+                del x_BRCD
                 x_BRCD, kv_entry = block(
-                    x_BRCD,
+                    x_BRCD_container,
                     block_single_eval_pos,
                     save_peak_memory_factor,
                     return_kv=True,
                 )
                 kv_out[layer_idx] = kv_entry
             elif using_cache:
+                x_BRCD_container = [x_BRCD]
+                del x_BRCD
                 x_BRCD, _ = block(
-                    x_BRCD,
+                    x_BRCD_container,
                     block_single_eval_pos,
                     save_peak_memory_factor,
                     cached_kv=kv_cache.kv[layer_idx],
@@ -853,8 +863,10 @@ class TabPFNV2p5(Architecture):
                     use_reentrant=False,
                 )[0]
             else:
+                x_BRCD_container = [x_BRCD]
+                del x_BRCD
                 x_BRCD, _ = block(
-                    x_BRCD, block_single_eval_pos, save_peak_memory_factor
+                    x_BRCD_container, block_single_eval_pos, save_peak_memory_factor
                 )
 
         # In the cache path every row is a test row; otherwise the test rows start

--- a/src/tabpfn/architectures/tabpfn_v2_6.py
+++ b/src/tabpfn/architectures/tabpfn_v2_6.py
@@ -380,7 +380,7 @@ class TabPFNBlock(nn.Module):
     @override
     def forward(
         self,
-        x_BRCE: torch.Tensor,
+        x_BRCE_container: list[torch.Tensor] | torch.Tensor,
         single_eval_pos: int,
         save_peak_memory_factor: int | None,
         *,
@@ -397,9 +397,11 @@ class TabPFNBlock(nn.Module):
         E: The embedding size of each cell.
 
         Args:
-            x_BRCE:
-                The transformer state passed as input to the layer of shape
-                (batch_size, num_items, num_feature_blocks, d_model).
+            x_BRCE_container:
+                Either the transformer state Tensor or a length-1 list containing
+                the transformer state. The list form is consumed with ``pop(0)``
+                so non-checkpointed callers can release their reference before
+                allocating the next activation.
             single_eval_pos:
                 The position from which on everything is treated as test set.
             save_peak_memory_factor:
@@ -421,6 +423,10 @@ class TabPFNBlock(nn.Module):
         """
         # -- First Block: Attention between features.
         # The row attention has no train/test distinction and is not cached.
+        if isinstance(x_BRCE_container, torch.Tensor):
+            x_BRCE = x_BRCE_container
+        else:
+            x_BRCE = x_BRCE_container.pop(0)
         x_BRCE = chunked_evaluate_maybe_inplace(
             self.per_sample_attention_between_features,
             x_BRCE,
@@ -827,16 +833,20 @@ class TabPFNV2p6(Architecture):
         kv_out: dict[int, KVCacheEntry] = {}
         for layer_idx, block in enumerate(self.blocks):
             if return_kv_cache and not using_cache:
+                x_BRCD_container = [x_BRCD]
+                del x_BRCD
                 x_BRCD, kv_entry = block(
-                    x_BRCD,
+                    x_BRCD_container,
                     block_single_eval_pos,
                     save_peak_memory_factor,
                     return_kv=True,
                 )
                 kv_out[layer_idx] = kv_entry
             elif using_cache:
+                x_BRCD_container = [x_BRCD]
+                del x_BRCD
                 x_BRCD, _ = block(
-                    x_BRCD,
+                    x_BRCD_container,
                     block_single_eval_pos,
                     save_peak_memory_factor,
                     cached_kv=kv_cache.kv[layer_idx],
@@ -850,8 +860,10 @@ class TabPFNV2p6(Architecture):
                     use_reentrant=False,
                 )[0]
             else:
+                x_BRCD_container = [x_BRCD]
+                del x_BRCD
                 x_BRCD, _ = block(
-                    x_BRCD, block_single_eval_pos, save_peak_memory_factor
+                    x_BRCD_container, block_single_eval_pos, save_peak_memory_factor
                 )
 
         # In the cache path every row is a test row; otherwise the test rows start

--- a/src/tabpfn/architectures/tabpfn_v2_6.py
+++ b/src/tabpfn/architectures/tabpfn_v2_6.py
@@ -380,7 +380,7 @@ class TabPFNBlock(nn.Module):
     @override
     def forward(
         self,
-        x_BRCE_container: list[torch.Tensor],
+        x_BRCE: torch.Tensor,
         single_eval_pos: int,
         save_peak_memory_factor: int | None,
         *,
@@ -397,9 +397,9 @@ class TabPFNBlock(nn.Module):
         E: The embedding size of each cell.
 
         Args:
-            x_BRCE_container:
-                A length-1 list containing the transformer state passed as input to the
-                layer of shape (batch_size, num_items, num_feature_blocks, d_model).
+            x_BRCE:
+                The transformer state passed as input to the layer of shape
+                (batch_size, num_items, num_feature_blocks, d_model).
             single_eval_pos:
                 The position from which on everything is treated as test set.
             save_peak_memory_factor:
@@ -421,7 +421,6 @@ class TabPFNBlock(nn.Module):
         """
         # -- First Block: Attention between features.
         # The row attention has no train/test distinction and is not cached.
-        x_BRCE = x_BRCE_container.pop(0)
         x_BRCE = chunked_evaluate_maybe_inplace(
             self.per_sample_attention_between_features,
             x_BRCE,
@@ -827,13 +826,9 @@ class TabPFNV2p6(Architecture):
 
         kv_out: dict[int, KVCacheEntry] = {}
         for layer_idx, block in enumerate(self.blocks):
-            # Note: Using x_BRCD._set() instead of the container approach here leads
-            # to memory issues on some mac hardware.
-            x_BRCD_container = [x_BRCD]
-            del x_BRCD
             if return_kv_cache and not using_cache:
                 x_BRCD, kv_entry = block(
-                    x_BRCD_container,
+                    x_BRCD,
                     block_single_eval_pos,
                     save_peak_memory_factor,
                     return_kv=True,
@@ -841,7 +836,7 @@ class TabPFNV2p6(Architecture):
                 kv_out[layer_idx] = kv_entry
             elif using_cache:
                 x_BRCD, _ = block(
-                    x_BRCD_container,
+                    x_BRCD,
                     block_single_eval_pos,
                     save_peak_memory_factor,
                     cached_kv=kv_cache.kv[layer_idx],
@@ -849,14 +844,14 @@ class TabPFNV2p6(Architecture):
             elif force_recompute_layer:
                 x_BRCD = torch.utils.checkpoint.checkpoint(
                     block,
-                    x_BRCD_container,
+                    x_BRCD,
                     block_single_eval_pos,
                     save_peak_memory_factor,
                     use_reentrant=False,
                 )[0]
             else:
                 x_BRCD, _ = block(
-                    x_BRCD_container, block_single_eval_pos, save_peak_memory_factor
+                    x_BRCD, block_single_eval_pos, save_peak_memory_factor
                 )
 
         # In the cache path every row is a test row; otherwise the test rows start

--- a/tests/test_architectures/test_tabpfn_v2.py
+++ b/tests/test_architectures/test_tabpfn_v2.py
@@ -77,7 +77,6 @@ def test__forward_pass_equal_with_save_peak_memory_enabled_and_disabled(
 
 
 @pytest.mark.parametrize("task_type", TASK_TYPES)
-@torch.no_grad()
 def test__forward_pass_equal_with_checkpointing_enabled_and_disabled(
     task_type: str,
 ) -> None:
@@ -100,6 +99,9 @@ def test__forward_pass_equal_with_checkpointing_enabled_and_disabled(
         assert torch.allclose(
             output_with_recomputation[key], output_without_recomputation[key], atol=1e-5
         ), f"Outputs for {key} do not match between implementations."
+
+    output_with_recomputation["standard"].sum().backward()
+    assert arch.blocks[0].mlp[0].weight.grad is not None
 
 
 def _make_kv_cache_data(task_type: str) -> tuple[torch.Tensor, torch.Tensor, int]:

--- a/tests/test_architectures/test_tabpfn_v2_5.py
+++ b/tests/test_architectures/test_tabpfn_v2_5.py
@@ -84,7 +84,6 @@ def test__forward_pass_equal_with_save_peak_memory_enabled_and_disabled(
 
 
 @pytest.mark.parametrize("task_type", TASK_TYPES)
-@torch.no_grad()
 @pytest.mark.skipif(sys.platform == "win32", reason="float64 tests fail on Windows")
 def test__forward_pass_equal_with_checkpointing_enabled_and_disabled(
     task_type: str,
@@ -108,6 +107,9 @@ def test__forward_pass_equal_with_checkpointing_enabled_and_disabled(
         assert torch.allclose(
             output_with_recomputation[key], output_without_recomputation[key]
         ), f"Outputs for {key} do not match between implementations."
+
+    output_with_recomputation["standard"].sum().backward()
+    assert arch.blocks[0].mlp[0].weight.grad is not None
 
 
 def test__thinking_rows__output_has_correct_shape() -> None:

--- a/tests/test_architectures/test_tabpfn_v2_6.py
+++ b/tests/test_architectures/test_tabpfn_v2_6.py
@@ -54,7 +54,6 @@ def test__forward_pass_equal_with_save_peak_memory_enabled_and_disabled() -> Non
         ), f"Outputs for {key} do not match between implementations."
 
 
-@torch.no_grad()
 @pytest.mark.skipif(sys.platform == "win32", reason="float64 tests fail on Windows")
 def test__forward_pass_equal_with_checkpointing_enabled_and_disabled() -> None:
     arch = _get_model()
@@ -76,6 +75,9 @@ def test__forward_pass_equal_with_checkpointing_enabled_and_disabled() -> None:
         assert torch.allclose(
             output_with_recomputation[key], output_without_recomputation[key]
         ), f"Outputs for {key} do not match between implementations."
+
+    output_with_recomputation["standard"].sum().backward()
+    assert arch.blocks[0].mlp[0].weight.grad is not None
 
 
 @torch.no_grad()


### PR DESCRIPTION
## Summary

PR #1070 changed the v2.x transformer block input from a `Tensor` to a
single-element mutable list. Each block consumes the activation using `pop(0)`,
allowing the caller to release its reference before the block creates another
large activation.

This optimization is incompatible with activation checkpointing during
fine-tuning, with different symptoms across the v2.x architectures.

### Failure modes

- **v2 silently loses transformer gradients.**

  After #1070, v2 passes the mutable list to `checkpoint` without explicitly
  setting `use_reentrant`. Under the currently supported PyTorch runtime, this
  selects the legacy reentrant checkpoint implementation.

  Reentrant checkpointing does not treat tensors nested inside Python
  containers as autograd inputs. Backward can therefore complete without an
  exception while parameters inside the checkpointed transformer blocks receive
  no gradients.

- **v2.5 and v2.6 fail during backward recomputation.**

  These architectures explicitly use non-reentrant checkpointing. During
  backward, checkpointing recomputes the checkpointed block. The mutable list is
  retained as a non-Tensor argument, but the original forward has already
  emptied it with `pop(0)`. Recalculation therefore raises:

  `IndexError: pop from empty list`

## Fix

Restore the transformer activation as a direct, top-level `Tensor` input for
v2, v2.5, and v2.6 blocks and pass that Tensor directly across checkpoint
boundaries.

This restores the checkpoint input contract and fixes both failure modes:

- the activation is again exposed to checkpointing and autograd as a top-level
  Tensor input;
- backward recomputation no longer depends on destructively consumed mutable
  state.

Separately, v2 now explicitly selects `use_reentrant=False`. Restoring the
top-level Tensor is the actual regression fix; selecting non-reentrant
checkpointing is not required once the Tensor input has been restored. It is an
intentional additional change that follows PyTorch's recommended checkpoint
implementation and matches v2.5 and v2.6.

## Changes

- Restore `torch.Tensor` as the transformer block input in v2, v2.5, and v2.6.
- Remove the single-element activation containers and destructive `pop(0)`
  calls.
- Pass activation tensors directly in normal, KV-cache, and checkpointed block
  calls.
- Explicitly use `use_reentrant=False` for the v2 checkpoint path.
- Extend the checkpoint tests to run `backward()`.
- Assert that a parameter in the first transformer block receives a gradient.

## User impact

Before this fix:

- v2 fine-tuning with activation checkpointing could complete backward while
  silently leaving checkpointed transformer-block parameters without gradients;
- v2.5 and v2.6 fine-tuning with activation checkpointing could fail during
  backward recomputation with `IndexError: pop from empty list`.

After this fix, all three architectures complete backward and propagate
gradients through their transformer blocks.

## Trade-off

This change removes the activation-reference release optimization introduced by
the state-container portion of #1070. Because direct Tensor inputs are restored
for every block call, this also affects non-checkpointed inference and KV-cache
paths, whose peak activation memory may return toward the behavior before
#1070.

The unrelated improvements from #1070 remain intact, including:

- contiguous-input handling in chunked evaluation;
- the non-contiguous-input regression test;
- the shared scaled-dot-product-attention implementation;
- Flash Attention and MPS-related changes.

This PR prioritizes correct fine-tuning and a stable checkpoint input contract.
A checkpoint-safe version of the inference reference-release optimization can
be considered separately.

## Validation

- `pytest tests/test_architectures/test_tabpfn_v2.py tests/test_architectures/test_tabpfn_v2_5.py tests/test_architectures/test_tabpfn_v2_6.py -q`
  - 34 passed
- Checkpointed and non-checkpointed forward outputs remain equivalent.
- Backward completes for v2, v2.5, and v2.6.
- Transformer-block gradient propagation is covered by regression tests.
- `ruff check` on all six changed Python files passed.
- `ruff format --check` on all six changed Python files passed.
