### PR TITLE
docs: correct n_estimators_final_inference default in FinetunedTabPFNBase docstring

### DIFF
--- a/src/tabpfn/finetuning/finetuned_base.py
+++ b/src/tabpfn/finetuning/finetuned_base.py
@@ -313,7 +313,7 @@ class FinetunedTabPFNBase(BaseEstimator, ABC):
         n_estimators_final_inference: If set, overrides `n_estimators` only for
             the final fitted inference model that is used after fine-tuning. If
             None, the value from `kwargs` or the estimator default is used.
-            Defaults to 8.
+            Defaults to 2.
         use_activation_checkpointing: Whether to use activation checkpointing to
             reduce memory usage. Defaults to True.
         save_checkpoint_interval: Number of epochs between checkpoint saves. This


### PR DESCRIPTION
## Issue

None. One-line docstring correction, no behaviour change.

## Motivation and Context

`FinetunedTabPFNBase.__init__` documents `n_estimators_final_inference` as `Defaults to 8`, but the signature is `= 2`.

Both subclasses (`FinetunedTabPFNClassifier`, `FinetunedTabPFNRegressor`) pass `8` explicitly, so the base default is unreachable in practice and only the docstring is wrong. I fixed the docstring rather than the default; happy to flip it if `8` was intended.

## Public API Changes

-   [x] No Public API changes
-   [ ] Yes, Public API changes (Details below)

## How Has This Been Tested?

Docstring only, no code path touched. `ruff check` and `ruff format --check` pass.

## Checklist

-   [ ] The changes have been tested locally (lint only)
-   [x] Documentation has been updated (if the public API or usage changes).
-   [ ] A changelog entry has been added. Requesting `no changelog needed` for a docs typo.
-   [x] The code follows the project's style guidelines.
-   [x] I have considered the impact of these changes on the public API.
