### PR TITLE
Fix fit() crashes in tuning: rare class missing from holdout, Generator random_state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `fit()` crashing during temperature calibration or threshold tuning (`tuning_config`) when a rare class is absent from the tuning holdout: `log_loss` is now given the full label set explicitly.
+- Fix `fit()` crashing when `random_state` is a `np.random.Generator` and tuning is enabled: the generator is now converted to a static seed before being passed to `StratifiedKFold`.
+
 ## [8.1.0] - 2026-07-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- Fix `fit()` crashing during temperature calibration or threshold tuning (`tuning_config`) when a rare class is absent from the tuning holdout: `log_loss` is now given the full label set explicitly.
-- Fix `fit()` crashing when `random_state` is a `np.random.Generator` and tuning is enabled: the generator is now converted to a static seed before being passed to `StratifiedKFold`.
-
 ## [8.1.0] - 2026-07-13
 
 ### Added

--- a/changelog/1140.fixed.md
+++ b/changelog/1140.fixed.md
@@ -1,0 +1,6 @@
+- Fixed `fit()` crashing during temperature calibration or threshold tuning
+  (`tuning_config`) when a rare class is absent from the tuning holdout, by
+  passing the full label set to `log_loss` explicitly.
+- Fixed `fit()` crashing when `random_state` is a `np.random.Generator` and
+  tuning is enabled, by converting the generator to a static seed before it
+  reaches `StratifiedKFold`.

--- a/src/tabpfn/inference_tuning.py
+++ b/src/tabpfn/inference_tuning.py
@@ -21,6 +21,8 @@ from sklearn.metrics import (
 )
 from sklearn.model_selection import StratifiedKFold
 
+from tabpfn.utils import infer_random_state
+
 if TYPE_CHECKING:
     import torch
 
@@ -119,7 +121,8 @@ METRIC_NAME_TO_OBJECTIVE = {
             y_pred,
         )
     ),
-    "log_loss": log_loss,
+    # y_true is binarized one-vs-rest and may contain a single label.
+    "log_loss": lambda y_true, y_pred: log_loss(y_true, y_pred, labels=[0, 1]),
 }
 
 
@@ -168,6 +171,10 @@ def get_tuning_splits(
     # more than 100 folds
     rounded_holdout_frac = round(holdout_frac, 2)
     n_folds = max(2, round(1 / rounded_holdout_frac))
+
+    if isinstance(random_state, np.random.Generator):
+        # StratifiedKFold does not accept np.random.Generator.
+        random_state, _ = infer_random_state(random_state)
 
     splitter = StratifiedKFold(
         n_splits=n_folds,
@@ -329,7 +336,12 @@ def find_optimal_temperature(
     # TODO: think about vectorizing this loop.
     for temperature in temperatures:
         probas = logits_to_probabilities_fn(raw_logits, temperature)
-        current_log_loss = log_loss(y_true=y_true, y_pred=probas)
+        # The holdout may lack a rare class, so labels cannot be inferred from y_true.
+        current_log_loss = log_loss(
+            y_true=y_true,
+            y_pred=probas,
+            labels=np.arange(probas.shape[-1]),
+        )
 
         if current_log_loss < best_log_loss:
             best_log_loss = current_log_loss

--- a/src/tabpfn/inference_tuning.py
+++ b/src/tabpfn/inference_tuning.py
@@ -94,7 +94,11 @@ class ClassifierEvalMetrics(str, Enum):
     LOG_LOSS = "log_loss"
 
 
-METRIC_NAME_TO_OBJECTIVE = {
+# Objectives for the one-vs-rest threshold search, so the inputs are always
+# binary: callers binarize y_true as ``(y_true == i)`` and pass thresholded 0/1
+# predictions. ``f1`` (average="binary") and ``roc_auc`` (1-D scores) rely on
+# this too, and raise on multiclass input.
+BINARY_METRIC_NAME_TO_OBJECTIVE = {
     "f1": lambda y_true, y_pred: (
         -f1_score(
             y_true,
@@ -131,17 +135,17 @@ def compute_metric_to_minimize(
     y_true: np.ndarray,
     y_pred: np.ndarray,
 ) -> float:
-    """Computes the metric.
+    """Computes the metric for binary one-vs-rest inputs.
 
     Adjusts the sign of the metric to frame the problem as a minimization
     problem.
     """
-    if metric_name not in METRIC_NAME_TO_OBJECTIVE:
+    if metric_name not in BINARY_METRIC_NAME_TO_OBJECTIVE:
         raise ValueError(
             f"Metric '{metric_name}' is not supported. "
-            f"Supported metrics are: {list(METRIC_NAME_TO_OBJECTIVE.keys())}"
+            f"Supported metrics are: {list(BINARY_METRIC_NAME_TO_OBJECTIVE.keys())}"
         )
-    return METRIC_NAME_TO_OBJECTIVE[metric_name](y_true, y_pred)
+    return BINARY_METRIC_NAME_TO_OBJECTIVE[metric_name](y_true, y_pred)
 
 
 def get_tuning_splits(

--- a/tests/test_inference_tuning.py
+++ b/tests/test_inference_tuning.py
@@ -10,6 +10,8 @@ from tabpfn.inference_tuning import (
     ClassifierTuningConfig,
     find_optimal_classification_threshold_single_class,
     find_optimal_classification_thresholds,
+    find_optimal_temperature,
+    get_tuning_splits,
     resolve_tuning_config,
     select_robust_optimal_threshold,
 )
@@ -195,3 +197,61 @@ def test__resolve_tuning_config__provides_expected_values_for_auto_config(
     assert resolved_tuning_config.tune_decision_thresholds == tune_decision_thresholds
     assert resolved_tuning_config.tuning_holdout_frac == expected_tuning_holdout_pct
     assert resolved_tuning_config.tuning_n_folds == expected_tuning_holdout_n_splits
+
+
+def test__find_optimal_temperature__works_when_class_missing_from_holdout() -> None:
+    rng = np.random.default_rng(0)
+    n_estimators, n_samples, n_classes = 2, 50, 3
+    raw_logits = rng.normal(size=(n_estimators, n_samples, n_classes))
+    # Class 2 never appears in the holdout labels.
+    y_true = rng.integers(0, 2, size=n_samples)
+
+    def logits_to_probabilities_fn(
+        raw_logits: np.ndarray,
+        softmax_temperature: float,
+    ) -> np.ndarray:
+        scaled = raw_logits / softmax_temperature
+        exp = np.exp(scaled - scaled.max(axis=-1, keepdims=True))
+        probas = exp / exp.sum(axis=-1, keepdims=True)
+        return probas.mean(axis=0)
+
+    temperature = find_optimal_temperature(
+        raw_logits=raw_logits,
+        y_true=y_true,
+        logits_to_probabilities_fn=logits_to_probabilities_fn,
+        current_default_temperature=1.0,
+    )
+
+    assert 0.6 <= temperature <= 1.4
+
+
+def test__find_optimal_classification_threshold_single_class__all_negative() -> None:
+    # One-vs-rest labels are all-negative when the class is absent from the holdout.
+    y_true = np.zeros(20, dtype=int)
+    y_pred_probas = np.linspace(0.05, 0.95, 20)
+
+    threshold = find_optimal_classification_threshold_single_class(
+        metric_name=ClassifierEvalMetrics.LOG_LOSS,
+        y_true=y_true,
+        y_pred_probas=y_pred_probas,
+    )
+
+    assert 0.0 < threshold < 1.0
+
+
+def test__get_tuning_splits__accepts_numpy_generator_random_state() -> None:
+    X = np.arange(100, dtype=np.float64).reshape(50, 2)
+    y = np.array([0, 1] * 25)
+
+    splits = get_tuning_splits(
+        X=X,
+        y=y,
+        holdout_frac=0.2,
+        n_splits=1,
+        random_state=np.random.default_rng(0),
+    )
+
+    assert len(splits) == 1
+    X_train, X_holdout, y_train, y_holdout = splits[0]
+    assert len(X_train) + len(X_holdout) == len(X)
+    assert len(y_train) + len(y_holdout) == len(y)


### PR DESCRIPTION
## Summary

Two crashes in the `tuning_config` path of `TabPFNClassifier.fit()`, both found by auditing `main`:

**1. Temperature calibration / threshold tuning crashes when a rare class is absent from the tuning holdout.**
`find_optimal_temperature` called `log_loss(y_true, probas)` without `labels=`. `probas` always has `n_classes` columns, but the holdout labels come from only the first `tuning_n_folds` folds of the `StratifiedKFold`, so a rare class can be entirely absent and sklearn raises `ValueError: y_true and y_prob contain different number of classes`. Repro: 25,002 samples with a 2-sample class and `tuning_config={'calibrate_temperature': True}` (auto-resolves to 1 of 3 folds).

Notably the failure is **deterministic**, not seed-dependent: `StratifiedKFold`'s per-fold class allocation depends only on the class counts, `shuffle`/`random_state` only permute which samples fill each fold's quota. A scheduled retrain can start crashing because two rows of a new rare class were added.

The `log_loss` entry of `METRIC_NAME_TO_OBJECTIVE` (used by threshold tuning on binarized one-vs-rest labels) had the same missing-`labels` pattern and failed with `y_true contains only one label`; fixed with `labels=[0, 1]`.

**2. `fit()` crashes when `random_state` is a `np.random.Generator` and tuning is enabled.**
`get_tuning_splits` forwarded `random_state` raw to `StratifiedKFold`, whose `check_random_state` rejects `np.random.Generator` — even though `Generator` is a documented `random_state` type and works everywhere else in `fit()`. Now converted to a static seed via `infer_random_state`, matching what `fit()` itself does.

## Behavior impact

None where the code previously worked:
- With every class present in the holdout, sklearn infers `labels = np.unique(y_true) = np.arange(n_classes)` (y is label-encoded before the tuning call), so the explicit `labels=` is bit-for-bit identical — verified, including the chosen temperature.
- The `Generator` conversion only touches the `isinstance(random_state, np.random.Generator)` case, which previously always crashed; `int`/`RandomState`/`None` are passed through unchanged.

## Tests

Three regression tests in `tests/test_inference_tuning.py`, matching the file's unit-test style (no model needed). All three fail on `main` and pass with this change; the 24 existing tests in the file still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)