### PR TITLE
Fix importance-based feature subsampling never sharing pools across estimators

### DIFF
--- a/changelog/1141.fixed.md
+++ b/changelog/1141.fixed.md
@@ -1,0 +1,5 @@
+- Fixed importance-based feature subsampling drawing every estimator's non-top
+  features independently instead of from a shared round-robin pool, which could
+  leave features unseen by any ensemble member even when the combined feature
+  budget covered them all. Results change for fits using
+  `gini_feature_importance` (directly or via `"auto"` on large, wide datasets).

--- a/src/tabpfn/preprocessing/ensemble.py
+++ b/src/tabpfn/preprocessing/ensemble.py
@@ -658,8 +658,9 @@ def _get_subsample_feature_indices(
             "balanced", "random", or "constant_and_balanced".
         constant_feature_count: Number of leading features to always include
             when using the "constant_and_balanced" method.
-        importance_feature_orders: Per-estimator feature indices sorted most->least
-            important. Produced by ``_compute_feature_importance_order``.
+        importance_feature_orders: Unique feature orderings sorted most->least
+            important, cycled across estimators. Produced by
+            ``_compute_feature_importance_order``.
         importance_top_k_count: Number of top features always included per estimator.
             Only used when feature_subsampling_method is "feature_importance".
     """
@@ -878,8 +879,9 @@ def _subsample_features_importance_based(
     Args:
         subsample_sizes: Number of input features to select per estimator.
         n_total_features: Total number of features in the dataset.
-        importance_feature_orders: Per-estimator feature indices sorted most->least
-            important. Produced by ``_compute_feature_importance_order``.
+        importance_feature_orders: Unique feature orderings sorted most->least
+            important, cycled across estimators. Produced by
+            ``_compute_feature_importance_order``.
         top_k_count: Number of top features always included per estimator.
         rng: Random number generator.
     """
@@ -934,20 +936,19 @@ def _collect_importance_orderings(
     fit_ordering_fn: Callable[[np.ndarray, np.ndarray], np.ndarray],
     rng: np.random.Generator,
 ) -> list[np.ndarray]:
-    """Run ``fit_ordering_fn`` and return one ordering per estimator.
+    """Run ``fit_ordering_fn`` once per unique subsample and return the orderings.
 
-    For datasets that fit within ``max_samples`` a single call is made and its
-    result is repeated.  For larger datasets ``n_subsamples`` independent
-    subsamples of size ``max_samples`` are drawn and cycled to fill
-    ``n_estimators``.
+    Datasets within ``max_samples`` yield a single ordering; larger datasets
+    yield up to ``n_estimators`` orderings fit on independent subsamples.
+    Consumers cycle through the list, so estimators sharing an entry share one
+    subsampling pool.
     """
     n_samples = len(X)
 
     if n_samples <= max_samples:
         # The importance model bins each feature from the values it is handed,
         # but `clean_data` no longer casts: not a no-op
-        ordering = fit_ordering_fn(np.asarray(X, dtype=np.float64), y)
-        return [ordering] * n_estimators
+        return [fit_ordering_fn(np.asarray(X, dtype=np.float64), y)]
 
     from sklearn.model_selection import train_test_split  # noqa: PLC0415
 
@@ -964,7 +965,7 @@ def _collect_importance_orderings(
         # The importance model bins each feature from the values it is handed,
         # but `clean_data` no longer casts: not a no-op
         orderings.append(fit_ordering_fn(np.asarray(X[idx], dtype=np.float64), y[idx]))
-    return [orderings[i % n_subsamples] for i in range(n_estimators)]
+    return orderings
 
 
 def _compute_feature_importance_order(
@@ -978,18 +979,13 @@ def _compute_feature_importance_order(
     categorical_feature_indices: list[int] | None = None,
     rng: np.random.Generator,
 ) -> list[np.ndarray]:
-    """Rank features by LightGBM gain importance, returning one ordering per estimator.
-
-    The returned list always has length ``n_estimators``.  When fewer distinct
-    orderings are computed than there are estimators the list is filled by
-    cycling through the available orderings.
+    """Rank features by LightGBM gain importance.
 
     Args:
         X: Training features, shape (n_samples, n_features).
         y: Training targets, shape (n_samples,).
         task_type: ``"classifier"`` or ``"regressor"`` (matches TabPFN estimator_type).
-        n_estimators: Number of TabPFN ensemble estimators.  The returned list
-            has exactly this length.
+        n_estimators: Upper bound on the number of orderings computed.
         max_samples: Row budget per importance model fit.
         n_tree_estimators: Number of trees in LightGBM models.
         categorical_feature_indices: Column indices of categorical features
@@ -997,8 +993,9 @@ def _compute_feature_importance_order(
         rng: Random number generator.
 
     Returns:
-        List of length ``n_estimators``, each element an array of feature indices
-        sorted from most to least important.
+        The unique orderings, each an array of feature indices sorted from most
+        to least important. Estimators are assigned orderings by cycling
+        through the list.
     """
     model_cls = _get_lightgbm_model_cls(task_type)
     cat_feature: list[int] | str = categorical_feature_indices or "auto"

--- a/src/tabpfn/preprocessing/ensemble.py
+++ b/src/tabpfn/preprocessing/ensemble.py
@@ -658,8 +658,9 @@ def _get_subsample_feature_indices(
             "balanced", "random", or "constant_and_balanced".
         constant_feature_count: Number of leading features to always include
             when using the "constant_and_balanced" method.
-        importance_feature_orders: Per-estimator feature indices sorted most->least
-            important. Produced by ``_compute_feature_importance_order``.
+        importance_feature_orders: Unique feature orderings sorted most->least
+            important, cycled across estimators. Produced by
+            ``_compute_feature_importance_order``.
         importance_top_k_count: Number of top features always included per estimator.
             Only used when feature_subsampling_method is "feature_importance".
     """
@@ -878,8 +879,9 @@ def _subsample_features_importance_based(
     Args:
         subsample_sizes: Number of input features to select per estimator.
         n_total_features: Total number of features in the dataset.
-        importance_feature_orders: Per-estimator feature indices sorted most->least
-            important. Produced by ``_compute_feature_importance_order``.
+        importance_feature_orders: Unique feature orderings sorted most->least
+            important, cycled across estimators. Produced by
+            ``_compute_feature_importance_order``.
         top_k_count: Number of top features always included per estimator.
         rng: Random number generator.
     """
@@ -934,18 +936,17 @@ def _collect_importance_orderings(
     fit_ordering_fn: Callable[[np.ndarray, np.ndarray], np.ndarray],
     rng: np.random.Generator,
 ) -> list[np.ndarray]:
-    """Run ``fit_ordering_fn`` and return one ordering per estimator.
+    """Run ``fit_ordering_fn`` once per unique subsample and return the orderings.
 
-    For datasets that fit within ``max_samples`` a single call is made and its
-    result is repeated.  For larger datasets ``n_subsamples`` independent
-    subsamples of size ``max_samples`` are drawn and cycled to fill
-    ``n_estimators``.
+    Datasets within ``max_samples`` yield a single ordering; larger datasets
+    yield up to ``n_estimators`` orderings fit on independent subsamples.
+    Consumers cycle through the list, so estimators sharing an entry share one
+    subsampling pool.
     """
     n_samples = len(X)
 
     if n_samples <= max_samples:
-        ordering = fit_ordering_fn(X, y)
-        return [ordering] * n_estimators
+        return [fit_ordering_fn(X, y)]
 
     from sklearn.model_selection import train_test_split  # noqa: PLC0415
 
@@ -960,7 +961,7 @@ def _collect_importance_orderings(
             random_state=int(rng.integers(0, np.iinfo(np.int32).max)),
         )
         orderings.append(fit_ordering_fn(X[idx], y[idx]))
-    return [orderings[i % n_subsamples] for i in range(n_estimators)]
+    return orderings
 
 
 def _compute_feature_importance_order(
@@ -974,18 +975,13 @@ def _compute_feature_importance_order(
     categorical_feature_indices: list[int] | None = None,
     rng: np.random.Generator,
 ) -> list[np.ndarray]:
-    """Rank features by LightGBM gain importance, returning one ordering per estimator.
-
-    The returned list always has length ``n_estimators``.  When fewer distinct
-    orderings are computed than there are estimators the list is filled by
-    cycling through the available orderings.
+    """Rank features by LightGBM gain importance.
 
     Args:
         X: Training features, shape (n_samples, n_features).
         y: Training targets, shape (n_samples,).
         task_type: ``"classifier"`` or ``"regressor"`` (matches TabPFN estimator_type).
-        n_estimators: Number of TabPFN ensemble estimators.  The returned list
-            has exactly this length.
+        n_estimators: Upper bound on the number of orderings computed.
         max_samples: Row budget per importance model fit.
         n_tree_estimators: Number of trees in LightGBM models.
         categorical_feature_indices: Column indices of categorical features
@@ -993,8 +989,9 @@ def _compute_feature_importance_order(
         rng: Random number generator.
 
     Returns:
-        List of length ``n_estimators``, each element an array of feature indices
-        sorted from most to least important.
+        The unique orderings, each an array of feature indices sorted from most
+        to least important. Estimators are assigned orderings by cycling
+        through the list.
     """
     model_cls = _get_lightgbm_model_cls(task_type)
     cat_feature: list[int] | str = categorical_feature_indices or "auto"

--- a/tests/test_preprocessing/test_ensemble.py
+++ b/tests/test_preprocessing/test_ensemble.py
@@ -21,6 +21,7 @@ from tabpfn.preprocessing.configs import (
 from tabpfn.preprocessing.datamodel import Feature, FeatureModality
 from tabpfn.preprocessing.ensemble import (
     TabPFNEnsemblePreprocessor,
+    _collect_importance_orderings,
     _compute_feature_importance_order,
     _draw_balanced_from_pool,
     _get_subsample_feature_indices,
@@ -1044,24 +1045,22 @@ def test_scale_n_estimators_for_feature_coverage__uses_min_max_features_across_c
 
 @skip_on_macos
 def test___compute_feature_importance_order__classification():
-    """_compute_feature_importance_order returns one valid feature ranking per tree."""
+    """Small datasets yield a single valid feature ranking."""
     rng = np.random.default_rng(0)
     n_samples, n_features = 100, 10
     X = rng.standard_normal((n_samples, n_features))
     # Make feature 0 highly predictive
     y = (X[:, 0] > 0).astype(int)
 
-    n_estimators = 4
     orders = _compute_feature_importance_order(
-        X=X, y=y, task_type="classifier", n_estimators=n_estimators, rng=rng
+        X=X, y=y, task_type="classifier", n_estimators=4, rng=rng
     )
 
-    assert len(orders) == n_estimators
+    assert len(orders) == 1
     for order in orders:
         assert order.shape == (n_features,)
         assert set(order) == set(range(n_features)), "All feature indices must appear"
-    # Feature 0 should rank first (most important) in the majority of orderings
-    assert sum(order[0] == 0 for order in orders) > len(orders) // 2
+    assert orders[0][0] == 0
 
 
 @skip_on_macos
@@ -1072,16 +1071,15 @@ def test___compute_feature_importance_order__regression():
     X = rng.standard_normal((n_samples, n_features))
     y = X[:, 2] * 3.0 + rng.standard_normal(n_samples) * 0.1
 
-    n_estimators = 4
     orders = _compute_feature_importance_order(
-        X=X, y=y, task_type="regressor", n_estimators=n_estimators, rng=rng
+        X=X, y=y, task_type="regressor", n_estimators=4, rng=rng
     )
 
-    assert len(orders) == n_estimators
+    assert len(orders) == 1
     for order in orders:
         assert order.shape == (n_features,)
         assert set(order) == set(range(n_features))
-    assert sum(order[0] == 2 for order in orders) > len(orders) // 2
+    assert orders[0][0] == 2
 
 
 @skip_on_macos
@@ -1092,19 +1090,58 @@ def test___compute_feature_importance_order__subsamples_large_datasets():
     X = rng.standard_normal((n_samples, n_features))
     y = rng.integers(0, 2, n_samples)
 
-    n_estimators = 4
     orders = _compute_feature_importance_order(
         X=X,
         y=y,
         task_type="classifier",
-        n_estimators=n_estimators,
+        n_estimators=8,
         max_samples=50,
         rng=rng,
     )
-    assert len(orders) == n_estimators
+    # min(n_estimators, n_samples // max_samples + 1) unique orderings
+    assert len(orders) == 5
     for order in orders:
         assert order.shape == (n_features,)
         assert set(order) == set(range(n_features))
+
+
+def test___collect_importance_orderings__small_data_returns_single_ordering():
+    orders = _collect_importance_orderings(
+        X=np.zeros((100, 6)),
+        y=np.zeros(100),
+        task_type="regressor",
+        n_estimators=4,
+        max_samples=200,
+        fit_ordering_fn=lambda _X, _y: np.arange(6),
+        rng=np.random.default_rng(0),
+    )
+
+    assert len(orders) == 1
+
+
+def test__subsample_features_importance_based__collected_orderings_cover_all_features():
+    """Estimators sharing a collected ordering draw from one shared pool."""
+    n_features, top_k, size, n_estimators = 12, 4, 8, 2
+
+    for seed in range(20):
+        rng = np.random.default_rng(seed)
+        orders = _collect_importance_orderings(
+            X=np.zeros((50, n_features)),
+            y=np.zeros(50),
+            task_type="regressor",
+            n_estimators=n_estimators,
+            max_samples=100,
+            fit_ordering_fn=lambda _X, _y: np.arange(n_features),
+            rng=rng,
+        )
+        subsampled = _subsample_features_importance_based(
+            [size] * n_estimators, n_features, orders, top_k, rng
+        )
+
+        # Combined budget covers all features: 2 * (8 - 4) top-up draws == the
+        # 8 non-top features, so a shared pool guarantees full coverage.
+        covered = set(np.concatenate(subsampled))
+        assert covered == set(range(n_features))
 
 
 def test__end_to_end__feature_importance_skipped_when_no_subsampling_needed():
@@ -1351,7 +1388,7 @@ def test___compute_feature_importance_order__lightgbm():
         rng=rng,
     )
 
-    assert len(orderings) == 3
+    assert len(orderings) == 1
     for order in orderings:
         assert len(order) == n_features
         assert order[0] == 5
@@ -1365,7 +1402,7 @@ def test___compute_feature_importance_order__lightgbm():
         categorical_feature_indices=[0, 1],
         rng=rng,
     )
-    assert len(orderings_cat) == 2
+    assert len(orderings_cat) == 1
     assert len(orderings_cat[0]) == n_features
 
 
@@ -1389,7 +1426,7 @@ def test___compute_feature_importance_order__handles_nan():
         rng=rng,
     )
 
-    assert len(orderings) == 2
+    assert len(orderings) == 1
     for order in orderings:
         assert len(order) > 0
         assert not np.isnan(order).any()

--- a/tests/test_preprocessing/test_ensemble.py
+++ b/tests/test_preprocessing/test_ensemble.py
@@ -23,6 +23,7 @@ from tabpfn.preprocessing.datamodel import Feature, FeatureModality
 from tabpfn.preprocessing.ensemble import (
     DEFAULT_N_ESTIMATORS,
     TabPFNEnsemblePreprocessor,
+    _collect_importance_orderings,
     _compute_feature_importance_order,
     _draw_balanced_from_pool,
     _get_subsample_feature_indices,
@@ -1129,24 +1130,22 @@ def test_scale_n_estimators_for_feature_coverage__auto_scaling_enabled_does_not_
 
 @skip_on_macos
 def test___compute_feature_importance_order__classification():
-    """_compute_feature_importance_order returns one valid feature ranking per tree."""
+    """Small datasets yield a single valid feature ranking."""
     rng = np.random.default_rng(0)
     n_samples, n_features = 100, 10
     X = rng.standard_normal((n_samples, n_features))
     # Make feature 0 highly predictive
     y = (X[:, 0] > 0).astype(int)
 
-    n_estimators = 4
     orders = _compute_feature_importance_order(
-        X=X, y=y, task_type="classifier", n_estimators=n_estimators, rng=rng
+        X=X, y=y, task_type="classifier", n_estimators=4, rng=rng
     )
 
-    assert len(orders) == n_estimators
+    assert len(orders) == 1
     for order in orders:
         assert order.shape == (n_features,)
         assert set(order) == set(range(n_features)), "All feature indices must appear"
-    # Feature 0 should rank first (most important) in the majority of orderings
-    assert sum(order[0] == 0 for order in orders) > len(orders) // 2
+    assert orders[0][0] == 0
 
 
 @skip_on_macos
@@ -1157,16 +1156,15 @@ def test___compute_feature_importance_order__regression():
     X = rng.standard_normal((n_samples, n_features))
     y = X[:, 2] * 3.0 + rng.standard_normal(n_samples) * 0.1
 
-    n_estimators = 4
     orders = _compute_feature_importance_order(
-        X=X, y=y, task_type="regressor", n_estimators=n_estimators, rng=rng
+        X=X, y=y, task_type="regressor", n_estimators=4, rng=rng
     )
 
-    assert len(orders) == n_estimators
+    assert len(orders) == 1
     for order in orders:
         assert order.shape == (n_features,)
         assert set(order) == set(range(n_features))
-    assert sum(order[0] == 2 for order in orders) > len(orders) // 2
+    assert orders[0][0] == 2
 
 
 @skip_on_macos
@@ -1177,19 +1175,58 @@ def test___compute_feature_importance_order__subsamples_large_datasets():
     X = rng.standard_normal((n_samples, n_features))
     y = rng.integers(0, 2, n_samples)
 
-    n_estimators = 4
     orders = _compute_feature_importance_order(
         X=X,
         y=y,
         task_type="classifier",
-        n_estimators=n_estimators,
+        n_estimators=8,
         max_samples=50,
         rng=rng,
     )
-    assert len(orders) == n_estimators
+    # min(n_estimators, n_samples // max_samples + 1) unique orderings
+    assert len(orders) == 5
     for order in orders:
         assert order.shape == (n_features,)
         assert set(order) == set(range(n_features))
+
+
+def test___collect_importance_orderings__small_data_returns_single_ordering():
+    orders = _collect_importance_orderings(
+        X=np.zeros((100, 6)),
+        y=np.zeros(100),
+        task_type="regressor",
+        n_estimators=4,
+        max_samples=200,
+        fit_ordering_fn=lambda _X, _y: np.arange(6),
+        rng=np.random.default_rng(0),
+    )
+
+    assert len(orders) == 1
+
+
+def test__subsample_features_importance_based__collected_orderings_cover_all_features():
+    """Estimators sharing a collected ordering draw from one shared pool."""
+    n_features, top_k, size, n_estimators = 12, 4, 8, 2
+
+    for seed in range(20):
+        rng = np.random.default_rng(seed)
+        orders = _collect_importance_orderings(
+            X=np.zeros((50, n_features)),
+            y=np.zeros(50),
+            task_type="regressor",
+            n_estimators=n_estimators,
+            max_samples=100,
+            fit_ordering_fn=lambda _X, _y: np.arange(n_features),
+            rng=rng,
+        )
+        subsampled = _subsample_features_importance_based(
+            [size] * n_estimators, n_features, orders, top_k, rng
+        )
+
+        # Combined budget covers all features: 2 * (8 - 4) top-up draws == the
+        # 8 non-top features, so a shared pool guarantees full coverage.
+        covered = set(np.concatenate(subsampled))
+        assert covered == set(range(n_features))
 
 
 def test__end_to_end__feature_importance_skipped_when_no_subsampling_needed():
@@ -1436,7 +1473,7 @@ def test___compute_feature_importance_order__lightgbm():
         rng=rng,
     )
 
-    assert len(orderings) == 3
+    assert len(orderings) == 1
     for order in orderings:
         assert len(order) == n_features
         assert order[0] == 5
@@ -1450,7 +1487,7 @@ def test___compute_feature_importance_order__lightgbm():
         categorical_feature_indices=[0, 1],
         rng=rng,
     )
-    assert len(orderings_cat) == 2
+    assert len(orderings_cat) == 1
     assert len(orderings_cat[0]) == n_features
 
 
@@ -1474,7 +1511,7 @@ def test___compute_feature_importance_order__handles_nan():
         rng=rng,
     )
 
-    assert len(orderings) == 2
+    assert len(orderings) == 1
     for order in orderings:
         assert len(order) > 0
         assert not np.isnan(order).any()


### PR DESCRIPTION
Didn't check performance on actual datasets with this change, but can look into it if we're not confident in the fix!

## Summary

With `FEATURE_SUBSAMPLING_METHOD="gini_feature_importance"` (or `"auto"` on >100k-sample datasets needing subsampling), each estimator keeps the top-K most important features and fills the rest of its budget from the remaining features. Since #913 that fill is documented — and unit-tested — as balanced round-robin from a pool shared by estimators using the same importance ordering, guaranteeing every feature lands in at least one estimator when the combined budget allows.

That sharing never happened in production. `_collect_importance_orderings` expanded its result to one entry per estimator (`[ordering] * n_estimators`, or cyclic expansion of the subsample orderings), so in `_subsample_features_importance_based` the position-keyed pools (`ordering_idx = i % n_orderings` with `n_orderings == n_estimators`) were always private and initially empty: every draw degenerated to an independent uniform sample — the pre-#913 behavior. The unit tests passed because they feed short orderings lists (1–2 entries for many estimators), a shape the production caller never produces.

Measured on the minimal case (12 features, top-4, budget 8, 2 estimators — combined budget exactly covers the tail): the production shape misses at least one feature in 20/20 seeds; the fixed shape covers all features in 20/20. At production scale the auto-scaler raises `n_estimators` to the exact minimum where round-robin would barely cover everything — the point where independent sampling misses the most (~30–50% of non-top features), directly contradicting the scaler's "every feature is included in at least one ensemble member" warning.

## Fix

`_collect_importance_orderings` now returns only the unique orderings (one for small datasets, up to `n_subsamples` for large). The consumer's existing `i % n_orderings` cycling assigns orderings to estimators *identically* to the old expansion, so the estimator→ordering mapping is unchanged — the only behavioral difference is that estimators sharing an ordering now genuinely share its pool, which is what #913's docstrings, comments, and tests already describe.

Not addressed here (separate issue): `scale_n_estimators_for_feature_coverage` computes the required estimator count from the raw budget, ignoring that the importance method re-includes top-K in every member; it can under-provision for gini even with this fix.

## Behavior impact

Results change (deterministically, given a seed) only for fits where the gini path is active: `FEATURE_SUBSAMPLING_METHOD="gini_feature_importance"`, or `"auto"` with >100k training samples and more features than `max_features_per_estimator`. All other configurations are unaffected.

## Tests

- Production-shaped regression test: orderings from `_collect_importance_orderings` fed to `_subsample_features_importance_based` must cover all features across 20 seeds when the combined budget suffices (fails 20/20 on main).
- `_collect_importance_orderings` small-data shape test.
- Existing length assertions updated to the compact contract; the large-dataset test now pins `min(n_estimators, n_samples // max_samples + 1)` distinct orderings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)