### PR TITLE
Expose ManyClassDecoder.attention_weights for decoder-head readout

### DIFF
--- a/changelog/1142.added.md
+++ b/changelog/1142.added.md
@@ -1,0 +1,1 @@
+Add `ManyClassDecoder.attention_weights`, the canonical per-training-row attention distribution of the multiclass decoder head, so interpretability tooling can read out which training rows drive a prediction without reimplementing the head's internal forward pass. The method exists only on multiclass models that use this decoder.

--- a/src/tabpfn/architectures/tabpfn_v3.py
+++ b/src/tabpfn/architectures/tabpfn_v3.py
@@ -557,6 +557,43 @@ class ManyClassDecoder(nn.Module):
         # convert to logits:
         return torch.log(torch.clamp(test_output_MBT, min=1e-5) + 3e-5)
 
+    def attention_weights(
+        self,
+        train_embeddings: torch.Tensor,  # (B, N, E)
+        test_embeddings: torch.Tensor,  # (B, M, E)
+    ) -> torch.Tensor:
+        """Per-train-row attention weights, averaged over heads: ``(B, M, N)``.
+
+        Runs the same query/key projection, optional query scaling and
+        scaled-dot-product softmax over the training rows as ``forward``, but
+        returns the attention distribution itself rather than the label-weighted
+        average. ``weights[..., n]`` is the vote mass this decoder places on
+        train row ``n`` for a test row; the weights are non-negative and sum to 1
+        over the training axis.
+
+        ``forward`` produces the same distribution implicitly inside a fused
+        attention kernel that never materializes it, so this recomputes the
+        scores explicitly. Collapsing the weights by training label recovers the
+        pre-log class average that ``forward`` turns into logits. Provided for
+        interpretability read-out of the decoder head; not used on the inference
+        path.
+        """
+        B, M, _ = test_embeddings.shape
+        N = train_embeddings.shape[1]
+        q_BMHD = self.q_projection(test_embeddings).view(
+            B, M, self.num_heads, self.head_dim
+        )
+        if train_embeddings.dtype != q_BMHD.dtype:
+            train_embeddings = train_embeddings.to(q_BMHD.dtype)
+        k_BNHD = self.k_projection(train_embeddings).view(
+            B, N, self.num_heads, self.head_dim
+        )
+        if self.softmax_scaling_layer is not None:
+            q_BMHD = self.softmax_scaling_layer(q_BMHD, N)
+        scores_BHMN = torch.einsum("bmhd,bnhd->bhmn", q_BMHD, k_BNHD).float()
+        scores_BHMN /= math.sqrt(self.head_dim)
+        return torch.softmax(scores_BHMN, dim=-1).mean(dim=1)  # over heads -> (B, M, N)
+
 
 def _chunked_class_attention(
     q_BSHD: torch.Tensor,

--- a/src/tabpfn/architectures/tabpfn_v3.py
+++ b/src/tabpfn/architectures/tabpfn_v3.py
@@ -568,14 +568,14 @@ class ManyClassDecoder(nn.Module):
         train_embeddings: torch.Tensor,  # (B, N, E)
         test_embeddings: torch.Tensor,  # (B, M, E)
     ) -> torch.Tensor:
-        """Per-train-row attention weights, averaged over heads: ``(B, M, N)``.
+        """Per-train-row attention weights, averaged over heads: `(B, M, N)`.
 
-        ``weights[..., n]`` is the vote mass placed on train row ``n`` for a
+        `weights[..., n]` is the vote mass placed on train row `n` for a
         test row; non-negative and summing to 1 over the training axis.
         Collapsing by training label recovers the pre-log class average that
-        ``forward`` turns into logits.
+        `forward` turns into logits.
 
-        ``forward`` fuses this into a single attention kernel to avoid
+        `forward` fuses this into a single attention kernel to avoid
         materializing an O(N*M) tensor.
         """
         q_BMHD, k_BNHD = self._project_qk(train_embeddings, test_embeddings)

--- a/src/tabpfn/architectures/tabpfn_v3.py
+++ b/src/tabpfn/architectures/tabpfn_v3.py
@@ -509,6 +509,22 @@ class ManyClassDecoder(nn.Module):
         self.k_projection = nn.Linear(self.input_size, self.attention_size)
         self.softmax_scaling_layer = softmax_scaling_layer
 
+    def _project_qk(
+        self,
+        train_embeddings: torch.Tensor,  # (B, N, E)
+        test_embeddings: torch.Tensor,  # (B, M, E)
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Project inputs to per-head queries/keys: (B, M, H, D), (B, N, H, D)."""
+        q_BME = self.q_projection(test_embeddings)
+        # Mirrors the dtype guard in ICLAttention's cached path.
+        if train_embeddings.dtype != q_BME.dtype:
+            train_embeddings = train_embeddings.to(q_BME.dtype)
+        k_BNE = self.k_projection(train_embeddings)
+        h, d = self.num_heads, self.head_dim
+        q_BMHD = q_BME.view(*q_BME.shape[:2], h, d).contiguous()
+        k_BNHD = k_BNE.view(*k_BNE.shape[:2], h, d).contiguous()
+        return q_BMHD, k_BNHD
+
     @override
     def forward(
         self,
@@ -518,11 +534,7 @@ class ManyClassDecoder(nn.Module):
     ) -> torch.Tensor:
         """Perform a forward pass."""
         B, M, _ = test_embeddings.shape
-        q_BME = self.q_projection(test_embeddings)
-        # Mirrors the dtype guard in ICLAttention's cached path.
-        if train_embeddings.dtype != q_BME.dtype:
-            train_embeddings = train_embeddings.to(q_BME.dtype)
-        k_BNE = self.k_projection(train_embeddings)
+        q_BMHD, k_BNHD = self._project_qk(train_embeddings, test_embeddings)
 
         if M == 0:
             # OOM checks at training start run with no test rows. Flash attention
@@ -530,18 +542,12 @@ class ManyClassDecoder(nn.Module):
             # Both dummy terms keep the output in the computation graph so that
             # gradients flow through both projections during memory estimation.
             empty = test_embeddings.new_empty((0, B, self.max_num_classes))
-            return empty + (q_BME.sum() + k_BNE.sum()) * 0.0
+            return empty + (q_BMHD.sum() + k_BNHD.sum()) * 0.0
 
-        one_hot_targets_BNT = (
-            F.one_hot(targets.long(), num_classes=self.max_num_classes)
-            .to(dtype=q_BME.dtype)
-            .contiguous()
-        )
-
-        q_BMHD = q_BME.view(B, M, self.num_heads, self.head_dim).contiguous()
-        k_BNHD = k_BNE.view(B, -1, self.num_heads, self.head_dim).contiguous()
         one_hot_targets_BNHT = (
-            one_hot_targets_BNT.unsqueeze(2)
+            F.one_hot(targets.long(), num_classes=self.max_num_classes)
+            .to(dtype=q_BMHD.dtype)
+            .unsqueeze(2)
             .expand(-1, -1, self.num_heads, -1)
             .contiguous()
         )
@@ -564,32 +570,21 @@ class ManyClassDecoder(nn.Module):
     ) -> torch.Tensor:
         """Per-train-row attention weights, averaged over heads: ``(B, M, N)``.
 
-        Runs the same query/key projection, optional query scaling and
-        scaled-dot-product softmax over the training rows as ``forward``, but
-        returns the attention distribution itself rather than the label-weighted
-        average. ``weights[..., n]`` is the vote mass this decoder places on
-        train row ``n`` for a test row; the weights are non-negative and sum to 1
-        over the training axis.
+        ``weights[..., n]`` is the vote mass this decoder places on train row
+        ``n`` for a test row; the weights are non-negative and sum to 1 over the
+        training axis. Collapsing them by training label recovers the pre-log
+        class average that ``forward`` turns into logits.
 
-        ``forward`` produces the same distribution implicitly inside a fused
-        attention kernel that never materializes it, so this recomputes the
-        scores explicitly. Collapsing the weights by training label recovers the
-        pre-log class average that ``forward`` turns into logits. Provided for
-        interpretability read-out of the decoder head; not used on the inference
-        path.
+        ``forward`` computes the same distribution inside a fused attention kernel
+        that never materializes it (to avoid the O(N*M) memory cost). This is the
+        interpretability read-out, so it materializes the scores explicitly: the
+        query scaling and ``1/sqrt(head_dim)`` factor below mirror what
+        ``_batched_scaled_dot_product_attention`` applies on the inference path.
+        Not used on the inference path.
         """
-        B, M, _ = test_embeddings.shape
-        N = train_embeddings.shape[1]
-        q_BMHD = self.q_projection(test_embeddings).view(
-            B, M, self.num_heads, self.head_dim
-        )
-        if train_embeddings.dtype != q_BMHD.dtype:
-            train_embeddings = train_embeddings.to(q_BMHD.dtype)
-        k_BNHD = self.k_projection(train_embeddings).view(
-            B, N, self.num_heads, self.head_dim
-        )
+        q_BMHD, k_BNHD = self._project_qk(train_embeddings, test_embeddings)
         if self.softmax_scaling_layer is not None:
-            q_BMHD = self.softmax_scaling_layer(q_BMHD, N)
+            q_BMHD = self.softmax_scaling_layer(q_BMHD, k_BNHD.shape[1])
         scores_BHMN = torch.einsum("bmhd,bnhd->bhmn", q_BMHD, k_BNHD).float()
         scores_BHMN /= math.sqrt(self.head_dim)
         return torch.softmax(scores_BHMN, dim=-1).mean(dim=1)  # over heads -> (B, M, N)

--- a/src/tabpfn/architectures/tabpfn_v3.py
+++ b/src/tabpfn/architectures/tabpfn_v3.py
@@ -570,17 +570,13 @@ class ManyClassDecoder(nn.Module):
     ) -> torch.Tensor:
         """Per-train-row attention weights, averaged over heads: ``(B, M, N)``.
 
-        ``weights[..., n]`` is the vote mass this decoder places on train row
-        ``n`` for a test row; the weights are non-negative and sum to 1 over the
-        training axis. Collapsing them by training label recovers the pre-log
-        class average that ``forward`` turns into logits.
+        ``weights[..., n]`` is the vote mass placed on train row ``n`` for a
+        test row; non-negative and summing to 1 over the training axis.
+        Collapsing by training label recovers the pre-log class average that
+        ``forward`` turns into logits.
 
-        ``forward`` computes the same distribution inside a fused attention kernel
-        that never materializes it (to avoid the O(N*M) memory cost). This is the
-        interpretability read-out, so it materializes the scores explicitly: the
-        query scaling and ``1/sqrt(head_dim)`` factor below mirror what
-        ``_batched_scaled_dot_product_attention`` applies on the inference path.
-        Not used on the inference path.
+        ``forward`` fuses this into a single attention kernel to avoid
+        materializing an O(N*M) tensor.
         """
         q_BMHD, k_BNHD = self._project_qk(train_embeddings, test_embeddings)
         if self.softmax_scaling_layer is not None:

--- a/tests/test_architectures/test_tabpfn_v3.py
+++ b/tests/test_architectures/test_tabpfn_v3.py
@@ -112,6 +112,48 @@ def test__forward__no_test_set_works_batch_size_one() -> None:
     assert out["standard"].shape == (0, 1, 10)
 
 
+@pytest.mark.parametrize("use_softmax_scaling", [False, True])
+@torch.no_grad()
+def test__many_class_decoder_attention_weights_matches_forward(
+    use_softmax_scaling: bool,
+) -> None:
+    """attention_weights is a proper distribution and matches the fused forward.
+
+    Collapsing the per-train-row weights by class label must reproduce, up to the
+    head's log-clamping, the logits the fused decoder returns.
+    """
+    torch.manual_seed(0)
+    B, N, M, E, max_num_classes = 2, 40, 7, 48, 10
+    head_dim, num_heads = 16, 3
+    scaling = (
+        tabpfn_v3.SoftmaxScalingMLP(num_heads=num_heads, head_dim=head_dim)
+        if use_softmax_scaling
+        else None
+    )
+    decoder = tabpfn_v3.ManyClassDecoder(
+        max_num_classes=max_num_classes,
+        input_size=E,
+        head_dim=head_dim,
+        num_heads=num_heads,
+        softmax_scaling_layer=scaling,
+    )
+    train_emb = torch.randn(B, N, E)
+    test_emb = torch.randn(B, M, E)
+    targets = torch.randint(0, max_num_classes, (B, N))
+
+    weights = decoder.attention_weights(train_emb, test_emb)
+    assert weights.shape == (B, M, N)
+    assert torch.all(weights >= 0)
+    torch.testing.assert_close(weights.sum(-1), torch.ones(B, M))
+
+    one_hot = torch.nn.functional.one_hot(targets, max_num_classes).float()
+    class_avg = torch.einsum("bmn,bnt->bmt", weights, one_hot)
+    logits = torch.log(torch.clamp(class_avg, min=1e-5) + 3e-5).transpose(0, 1)
+
+    expected = decoder(train_emb, test_emb, targets)
+    torch.testing.assert_close(logits, expected, atol=1e-4, rtol=1e-4)
+
+
 @torch.no_grad()
 def test__mem_eff_forward_matches_standard_forward() -> None:
     """Memory-efficient inference path must be numerically identical to standard."""


### PR DESCRIPTION
## What

Adds `ManyClassDecoder.attention_weights(train_embeddings, test_embeddings)` to the v3 architecture: the canonical per-training-row attention distribution of the multiclass decoder head, shape `(B, M, N)`, averaged over heads and summing to 1 over the training axis.

## Why

The multiclass head classifies by attending each test row over the training rows and averaging their one-hot labels weighted by that attention. The prediction is therefore a weighted vote, and reading out *which* training rows drive a prediction (and by how much) is a natural interpretability primitive.

Today that read-out can only be obtained by **reimplementing the head's forward pass externally** (q/k projections, optional `softmax_scaling_layer`, `scores / sqrt(head_dim)`, softmax over train rows, mean over heads). `forward` itself computes this distribution implicitly inside a fused flash-attention kernel that never materializes it ([tabpfn_v3.py](https://github.com/PriorLabs/TabPFN/blob/main/src/tabpfn/architectures/tabpfn_v3.py)), so downstream code has to duplicate internal math that can silently drift out of sync.

This method makes the decoder own that computation, so tooling reads the weights from the canonical source instead of re-deriving them.

## Design

- One method on `ManyClassDecoder`; nothing on the hot inference path changes.
- Naturally optional: it exists only on multiclass models that have this decoder. Regression and other heads simply don't expose it, so callers gate on its presence.
- Mirrors `forward`'s scoring exactly. Collapsing the returned weights by training label reproduces `forward`'s pre-log class average, and hence its logits up to the head's log-clamping.

## Tests

`test__many_class_decoder_attention_weights_matches_forward` (with and without `SoftmaxScalingMLP`) asserts the weights form a proper distribution and that collapsing them by class label, then applying the head's log transform, reproduces `forward`'s logits. Verified separately on a fitted `TabPFNClassifier` that it matches the existing external reimplementation bit-for-bit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)