### PR TITLE
Re-enable macos tests with minimum dependency versions.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
         if: ${{ matrix.dependency-set != 'lowest-direct' && (github.event_name == 'pull_request' || github.event_name == 'merge_group') }}
         run: uv run --no-sync pytest -m "not slow" tests/
 
-      # We don't support MPS below PyTorch 2.5 (see tabpfn.utils.infer_devices()), thus
+      # We don't support MPS below PyTorch 2.6 (see tabpfn.utils.infer_devices()), thus
       # disable MPS for the lowest-direct dependency set.
 
       - name: Run Tests (all tests, MPS disabled)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,12 +44,9 @@ jobs:
           - os: ubuntu-latest
             python-version: "3.10"
             dependency-set: lowest-direct
-          # Note that new pytorch versions >= 2.5 don't support x86 on mac anymore,
-          # and macos-latest (ARM) is python >= 3.11 only, so we disable this runner.
-          # https://github.com/actions/setup-python/issues/855
-          # - os: macos-15-intel # We need x86 as ARM is python>= 3.11 only.
-          #  python-version: "3.10"
-          #  dependency-set: lowest-direct
+          - os: macos-latest
+            python-version: "3.10"
+            dependency-set: lowest-direct
           - os: windows-latest
             python-version: "3.10"
             dependency-set: lowest-direct

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
   "joblib>=1.2.0",
   "tqdm>=4.66.0",
   "filelock>=3.11.0",
-  "lightgbm>=3.0",
+  "lightgbm>=4.4",
   "mlx>=0.29.3; sys_platform == 'darwin' and platform_machine == 'arm64'",
 ]
 requires-python = ">=3.10"

--- a/tests/test_preprocessing/test_pipeline_consistency.py
+++ b/tests/test_preprocessing/test_pipeline_consistency.py
@@ -26,6 +26,7 @@ from typing import Literal
 
 import numpy as np
 import pytest
+import torch
 
 from tabpfn.preprocessing.configs import EnsembleConfig, PreprocessorConfig
 from tabpfn.preprocessing.datamodel import Feature, FeatureModality, FeatureSchema
@@ -357,11 +358,22 @@ def _save_reference(
     logger.info(f"Reference data saved for {test_name} at {path}")
 
 
+def _get_filtered_test_cases() -> list:
+    skip_svd = pytest.mark.skipif(
+        not torch.__version__ >= "2.13",
+        reason="ARPACK and LAPACK SVD only agree on recent dependencies",
+    )
+    return [
+        pytest.param(name, case, marks=[skip_svd] if "svd" in name else [])
+        for name, case in test_cases.items()
+    ]
+
+
 @pytest.mark.skipif(
     _get_current_platform_string() not in ENABLED_PLATFORMS,
     reason="Current platform does not have consistency tests enabled.",
 )
-@pytest.mark.parametrize(("test_case_name", "test_case"), test_cases.items())
+@pytest.mark.parametrize(("test_case_name", "test_case"), _get_filtered_test_cases())
 def test__pipeline__output_matches_reference(
     test_case_name: str, test_case: _PipelineConsistencyCase
 ) -> None:

--- a/tests/test_torch_preprocessing/test_gpu_preprocessing_consistency.py
+++ b/tests/test_torch_preprocessing/test_gpu_preprocessing_consistency.py
@@ -285,9 +285,9 @@ class TestGpuQuantileEligibility:
 # macOS with recent dependencies the CPU-only (sklearn ARPACK) and GPU
 # (torch full-SVD via Accelerate) paths happen to agree, so we test SVD
 # configs there.
-_IS_MACOS = sys.platform == "darwin"
-_SVD_MACOS = pytest.mark.skipif(
-    not (_IS_MACOS and torch.__version__ >= "2.13"),
+_GPU_AND_CPU_SVD_CONSISTENT = sys.platform == "darwin" and torch.__version__ >= "2.13"
+_SKIP_IF_GPU_CPU_SVD_NOT_CONSISTENT = pytest.mark.skipif(
+    not _GPU_AND_CPU_SVD_CONSISTENT,
     reason="ARPACK and LAPACK SVD only agree on macOS with recent dependencies",
 )
 
@@ -374,8 +374,8 @@ class TestPipelineConsistency:
             V26_QUANTILE_NUMERIC_APPEND_ORIGINAL,
             V26_QUANTILE_ONEHOT,
             V26_QUANTILE_EXTRAPOLATE,
-            pytest.param(V26_QUANTILE_SVD, marks=_SVD_MACOS),
-            pytest.param(V25_SQUASHING_SVD, marks=_SVD_MACOS),
+            pytest.param(V26_QUANTILE_SVD, marks=_SKIP_IF_GPU_CPU_SVD_NOT_CONSISTENT),
+            pytest.param(V25_SQUASHING_SVD, marks=_SKIP_IF_GPU_CPU_SVD_NOT_CONSISTENT),
             V25_SQUASHING_NO_SVD,
             V25_NONE,
         ],
@@ -405,7 +405,8 @@ class TestPipelineConsistency:
         [
             _make_config(V26_QUANTILE_NUMERIC, fingerprint=False),
             pytest.param(
-                _make_config(V26_QUANTILE_SVD, fingerprint=False), marks=_SVD_MACOS
+                _make_config(V26_QUANTILE_SVD, fingerprint=False),
+                marks=_SKIP_IF_GPU_CPU_SVD_NOT_CONSISTENT,
             ),
             _make_config(
                 V26_QUANTILE_NUMERIC,
@@ -413,7 +414,10 @@ class TestPipelineConsistency:
                 feature_shift_count=5,
             ),
             _make_config(V26_QUANTILE_NUMERIC, outlier_removal_std=None),
-            pytest.param(_make_config(V26_QUANTILE_SVD_APPEND), marks=_SVD_MACOS),
+            pytest.param(
+                _make_config(V26_QUANTILE_SVD_APPEND),
+                marks=_SKIP_IF_GPU_CPU_SVD_NOT_CONSISTENT,
+            ),
             _make_config(V26_QUANTILE_APPEND_NO_SVD),
         ],
         ids=[
@@ -432,7 +436,7 @@ class TestPipelineConsistency:
         X, schema = sample_data
         _assert_paths_match(X, schema, config)
 
-    @_SVD_MACOS
+    @_SKIP_IF_GPU_CPU_SVD_NOT_CONSISTENT
     def test_feature_subsampling_matches(
         self, large_feature_data: _DataWithSchema
     ) -> None:
@@ -465,7 +469,7 @@ class TestSmallFeatureCounts:
         if (
             pconfig is TestPipelineConsistency.V26_QUANTILE_SVD
             and n_features >= 2
-            and not _IS_MACOS
+            and not _GPU_AND_CPU_SVD_CONSISTENT
         ):
             pytest.skip("torch SVD is non-deterministic across LAPACK backends")
 
@@ -527,7 +531,7 @@ class TestTestBatchSizeInvariance:
 class TestTestDataConsistency:
     """Verify that test-time transform also matches between paths."""
 
-    @_SVD_MACOS
+    @_SKIP_IF_GPU_CPU_SVD_NOT_CONSISTENT
     def test_transform_X_test(self, sample_data: _DataWithSchema) -> None:
         """Test data transform with SVD (macOS only)."""
         X, schema = sample_data

--- a/tests/test_torch_preprocessing/test_gpu_preprocessing_consistency.py
+++ b/tests/test_torch_preprocessing/test_gpu_preprocessing_consistency.py
@@ -282,13 +282,13 @@ class TestGpuQuantileEligibility:
 # Linux, Accelerate on macOS, OpenBLAS on some Windows builds) that can
 # produce different singular vectors for near-degenerate singular values.
 # This makes the GPU SVD output non-deterministic across platforms.  On
-# macOS the CPU-only (sklearn ARPACK) and GPU (torch full-SVD via
-# Accelerate) paths happen to agree, so we test SVD configs there.  On
-# other platforms we use configs without SVD to keep the consistency tests
-# deterministic.
+# macOS with recent dependencies the CPU-only (sklearn ARPACK) and GPU
+# (torch full-SVD via Accelerate) paths happen to agree, so we test SVD
+# configs there.
 _IS_MACOS = sys.platform == "darwin"
 _SVD_MACOS = pytest.mark.skipif(
-    not _IS_MACOS, reason="torch SVD is non-deterministic across LAPACK backends"
+    not (_IS_MACOS and torch.__version__ >= "2.13"),
+    reason="ARPACK and LAPACK SVD only agree on macOS with recent dependencies",
 )
 
 
@@ -527,9 +527,7 @@ class TestTestBatchSizeInvariance:
 class TestTestDataConsistency:
     """Verify that test-time transform also matches between paths."""
 
-    @pytest.mark.skipif(
-        not _IS_MACOS, reason="torch SVD non-deterministic across LAPACK backends"
-    )
+    @_SVD_MACOS
     def test_transform_X_test(self, sample_data: _DataWithSchema) -> None:
         """Test data transform with SVD (macOS only)."""
         X, schema = sample_data


### PR DESCRIPTION
This requires:
- Bumping lightgbm to >=4.4.0, the first version with a macos arm64 wheel, so the lowest-direct resolution works. This was [released](https://pypi.org/project/lightgbm/4.4.0/#history) in June 2024, which is newer than our usual aim of at least 3 years ago. There are no effects on the torch, pandas, numpy, or sklearn versions, which are often the main issues.
- Disabling some preprocessing consistency tests in the case of minimum dependency versions