### PR TITLE
Remove Tuana from external PR reviewers list.

### DIFF
--- a/.github/pr-reviewers.txt
+++ b/.github/pr-reviewers.txt
@@ -1,5 +1,4 @@
 oscarkey
-TuanaCelik
 bejaeger
 anuragg1209
 klemens-floege


### PR DESCRIPTION
cc @TuanaCelik @anuragg1209 

This will apply to both tabpfn and tabpfn-extensions.