### PR TITLE
Try to deflake windows.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,24 +125,34 @@ jobs:
           key: model-cache-${{ hashFiles('model_cache/**') }}
           enableCrossOsArchive: true
 
-      # Diagnostics for the intermittent Windows abort
-      # `Windows fatal exception: code 0xc000001d` (STATUS_ILLEGAL_INSTRUCTION),
-      # which kills roughly 1 in 10 Windows jobs. Every occurrence dies at the
-      # same test -- the suite's first fit/predict on real weights -- under both
-      # dependency sets, and a retry clears it. faulthandler cannot walk the
-      # native stack on Windows ("cannot get C stack on this system"), so the
-      # log never names the faulting DLL; record the CPU and the ISA torch
-      # picks for it instead.
+      # Works around `Windows fatal exception: code 0xc000001d`
+      # (STATUS_ILLEGAL_INSTRUCTION), which aborted roughly 1 in 10 Windows jobs
+      # at the suite's first fit/predict on real weights.
       #
-      # Run 30531520172 caught the split: the job on an Intel Xeon Platinum
-      # 8573C (Emerald Rapids, cpu_capability AVX512) aborted, while the job on
-      # an AMD EPYC 7763 (AVX2, no AVX-512) in the same run passed. So the
-      # abort happens on the runner with MORE ISA available, not less -- the
-      # opposite of a wheel built for an ISA the CPU lacks. The prime suspect
-      # is AMX, which Emerald Rapids advertises in CPUID but which Windows
-      # leaves off until a process opts into the tile XSTATE; an AMX kernel
-      # dispatched without that opt-in raises exactly this exception code.
-      # Remove all of this once the flake is understood.
+      # It is not a wheel built for an ISA the runner lacks -- it is the
+      # opposite. The abort only happens on the newer Intel runners (Xeon
+      # Platinum 8573C, Emerald Rapids); the AMD EPYC 7763 runners, with no
+      # AVX-512 at all, never hit it. Emerald Rapids advertises AMX in CPUID,
+      # but Windows leaves the tile XSTATE off until a process opts in, so
+      # oneDNN's AMX kernels take an illegal-instruction fault on their first
+      # tile instruction.
+      #
+      # Established by re-running the crashing test under each dispatcher cap in
+      # turn on an affected runner (run 30532900721): every oneDNN cap survived,
+      # while capping MKL (MKL_ENABLE_INSTRUCTIONS) or torch's own vectorized
+      # kernels (ATEN_CPU_CAPABILITY) still aborted. AVX512_CORE_FP16 is the
+      # highest oneDNN tier below AMX, so this keeps every AVX-512 kernel and
+      # drops only the AMX ones; capping to AVX2 also works but costs ~3x
+      # runtime. Both torch 2.5.0 (oneDNN v3.5.3) and 2.13.0 (v3.12.0) are
+      # affected, so this is not a regression that ages out on its own -- drop
+      # it once torch ships a oneDNN that honours the Windows AMX opt-in.
+      - name: Cap oneDNN below AMX (Windows only)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: echo "ONEDNN_MAX_CPU_ISA=AVX512_CORE_FP16" >> "$GITHUB_ENV"
+
+      # Kept so that any recurrence names the runner's CPU and the ISA torch
+      # selected for it; that pairing is what made the abort diagnosable.
       - name: Log CPU and torch dispatch info (Windows only)
         if: runner.os == 'Windows'
         continue-on-error: true
@@ -158,53 +168,6 @@ jobs:
           print(torch.__config__.parallel_info())
           print(torch.__config__.show())
           '
-
-      # Runs the known-flaky test on its own, ahead of the suite. It reproduces
-      # the abort in ~10s on an affected runner, so when the control run dies we
-      # immediately re-run it under each dispatcher cap in turn. One unlucky job
-      # then answers both open questions at once: which library was mid-dispatch
-      # (ONEDNN_VERBOSE names the primitive and ISA of the last kernel before
-      # the abort) and which cap is enough to prevent it. The cheapest cap that
-      # survives is the fix; capping to AVX2 also works but costs ~3x runtime.
-      # On the ~9 in 10 runners that are unaffected only the control run
-      # happens, so this normally adds a few seconds. Advisory only:
-      # `continue-on-error` plus the trailing `exit 0` keep the real test steps
-      # below in charge of the job's verdict.
-      - name: Crash canary and dispatcher probe (Windows only)
-        if: runner.os == 'Windows'
-        continue-on-error: true
-        shell: bash
-        run: |
-          set +e
-          test_id="tests/test_classifier_interface.py::test__predict__show_progress_bar_true__tiny_dataset_does_not_crash"
-          results="${RUNNER_TEMP:-.}/canary-results.txt"
-          : > "$results"
-          probe() {
-            label="$1"
-            shift
-            echo "::group::canary [$label] $*"
-            env "$@" uv run --no-sync pytest -q "$test_id" 2>&1 | tail -60
-            code=${PIPESTATUS[0]}
-            echo "::endgroup::"
-            printf '%-18s exit=%-4s %s\n' "$label" "$code" "$*" >> "$results"
-            return "$code"
-          }
-
-          probe control
-          if [ $? -ne 0 ]; then
-            echo "Control run aborted: this runner reproduces the flake."
-            echo "Probing which dispatcher issues the illegal instruction."
-            probe onednn-verbose ONEDNN_VERBOSE=1
-            probe onednn-no-amx  ONEDNN_MAX_CPU_ISA=AVX512_CORE_FP16
-            probe onednn-avx512  ONEDNN_MAX_CPU_ISA=AVX512_CORE
-            probe onednn-avx2    ONEDNN_MAX_CPU_ISA=AVX2
-            probe mkl-no-amx     MKL_ENABLE_INSTRUCTIONS=AVX512
-            probe aten-avx2      ATEN_CPU_CAPABILITY=avx2
-          fi
-
-          echo "=== canary summary (exit=0 means the test survived) ==="
-          cat "$results"
-          exit 0
 
       - name: Run Tests (all tests)
         if: ${{ matrix.dependency-set != 'lowest-direct' && github.event_name != 'pull_request' && github.event_name != 'merge_group' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,14 +127,21 @@ jobs:
 
       # Diagnostics for the intermittent Windows abort
       # `Windows fatal exception: code 0xc000001d` (STATUS_ILLEGAL_INSTRUCTION),
-      # which kills roughly 1 in 10 Windows jobs. Every occurrence so far dies
-      # at the same test -- the suite's first fit/predict on real weights --
-      # under both dependency sets, and a retry clears it. faulthandler cannot
-      # walk the native stack on Windows ("cannot get C stack on this system"),
-      # so the log never names the faulting DLL. Record the CPU and the ISA
-      # torch selects for it instead: if the aborts only ever happen on one CPU
-      # model, that confirms an AVX-512 kernel running on a runner without it;
-      # if they are spread across CPU models, the dispatch theory is dead.
+      # which kills roughly 1 in 10 Windows jobs. Every occurrence dies at the
+      # same test -- the suite's first fit/predict on real weights -- under both
+      # dependency sets, and a retry clears it. faulthandler cannot walk the
+      # native stack on Windows ("cannot get C stack on this system"), so the
+      # log never names the faulting DLL; record the CPU and the ISA torch
+      # picks for it instead.
+      #
+      # Run 30531520172 caught the split: the job on an Intel Xeon Platinum
+      # 8573C (Emerald Rapids, cpu_capability AVX512) aborted, while the job on
+      # an AMD EPYC 7763 (AVX2, no AVX-512) in the same run passed. So the
+      # abort happens on the runner with MORE ISA available, not less -- the
+      # opposite of a wheel built for an ISA the CPU lacks. The prime suspect
+      # is AMX, which Emerald Rapids advertises in CPUID but which Windows
+      # leaves off until a process opts into the tile XSTATE; an AMX kernel
+      # dispatched without that opt-in raises exactly this exception code.
       # Remove all of this once the flake is understood.
       - name: Log CPU and torch dispatch info (Windows only)
         if: runner.os == 'Windows'
@@ -152,19 +159,52 @@ jobs:
           print(torch.__config__.show())
           '
 
-      # Runs the known-flaky test on its own, ahead of the suite. When the abort
-      # happens mid-suite, two threads write the faulthandler dump at once and
-      # the output is shredded into unreadable interleaved text; in a process
-      # doing nothing else there is a chance of a legible dump. Advisory only --
-      # `continue-on-error` keeps the real test steps below in charge of the
-      # job's verdict, and a fresh process is not the same environment as one
-      # 170 tests deep, so this may simply never reproduce.
-      - name: Crash canary in an isolated process (Windows only)
+      # Runs the known-flaky test on its own, ahead of the suite. It reproduces
+      # the abort in ~10s on an affected runner, so when the control run dies we
+      # immediately re-run it under each dispatcher cap in turn. One unlucky job
+      # then answers both open questions at once: which library was mid-dispatch
+      # (ONEDNN_VERBOSE names the primitive and ISA of the last kernel before
+      # the abort) and which cap is enough to prevent it. The cheapest cap that
+      # survives is the fix; capping to AVX2 also works but costs ~3x runtime.
+      # On the ~9 in 10 runners that are unaffected only the control run
+      # happens, so this normally adds a few seconds. Advisory only:
+      # `continue-on-error` plus the trailing `exit 0` keep the real test steps
+      # below in charge of the job's verdict.
+      - name: Crash canary and dispatcher probe (Windows only)
         if: runner.os == 'Windows'
         continue-on-error: true
-        run: >
-          uv run --no-sync pytest -v
-          "tests/test_classifier_interface.py::test__predict__show_progress_bar_true__tiny_dataset_does_not_crash"
+        shell: bash
+        run: |
+          set +e
+          test_id="tests/test_classifier_interface.py::test__predict__show_progress_bar_true__tiny_dataset_does_not_crash"
+          results="${RUNNER_TEMP:-.}/canary-results.txt"
+          : > "$results"
+          probe() {
+            label="$1"
+            shift
+            echo "::group::canary [$label] $*"
+            env "$@" uv run --no-sync pytest -q "$test_id" 2>&1 | tail -60
+            code=${PIPESTATUS[0]}
+            echo "::endgroup::"
+            printf '%-18s exit=%-4s %s\n' "$label" "$code" "$*" >> "$results"
+            return "$code"
+          }
+
+          probe control
+          if [ $? -ne 0 ]; then
+            echo "Control run aborted: this runner reproduces the flake."
+            echo "Probing which dispatcher issues the illegal instruction."
+            probe onednn-verbose ONEDNN_VERBOSE=1
+            probe onednn-no-amx  ONEDNN_MAX_CPU_ISA=AVX512_CORE_FP16
+            probe onednn-avx512  ONEDNN_MAX_CPU_ISA=AVX512_CORE
+            probe onednn-avx2    ONEDNN_MAX_CPU_ISA=AVX2
+            probe mkl-no-amx     MKL_ENABLE_INSTRUCTIONS=AVX512
+            probe aten-avx2      ATEN_CPU_CAPABILITY=avx2
+          fi
+
+          echo "=== canary summary (exit=0 means the test survived) ==="
+          cat "$results"
+          exit 0
 
       - name: Run Tests (all tests)
         if: ${{ matrix.dependency-set != 'lowest-direct' && github.event_name != 'pull_request' && github.event_name != 'merge_group' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,10 +132,12 @@ jobs:
       # It is not a wheel built for an ISA the runner lacks -- it is the
       # opposite. The abort only happens on the newer Intel runners (Xeon
       # Platinum 8573C, Emerald Rapids); the AMD EPYC 7763 runners, with no
-      # AVX-512 at all, never hit it. Emerald Rapids advertises AMX in CPUID,
-      # but Windows leaves the tile XSTATE off until a process opts in, so
-      # oneDNN's AMX kernels take an illegal-instruction fault on their first
-      # tile instruction.
+      # AVX-512 at all, never hit it. Emerald Rapids advertises AMX and oneDNN
+      # dispatches AMX kernels for it, but the tile state is not usable on this
+      # runner, so the first tile instruction faults. Capping the ISA is the
+      # only lever available: Linux lets a process request that state with
+      # arch_prctl(ARCH_REQ_XCOMP_PERM, XFEATURE_XTILEDATA), but Windows has no
+      # documented user-space equivalent to opt into.
       #
       # Established by re-running the crashing test under each dispatcher cap in
       # turn on an affected runner (run 30532900721): every oneDNN cap survived,
@@ -153,6 +155,14 @@ jobs:
 
       # Kept so that any recurrence names the runner's CPU and the ISA torch
       # selected for it; that pairing is what made the abort diagnosable.
+      #
+      # GetEnabledXStateFeatures reports which XSAVE state components Windows
+      # has actually enabled. Bits 17 and 18 are the AMX tile config and tile
+      # data components, and they decide who owns the bug: if Windows reports
+      # them disabled, oneDNN dispatched AMX kernels the OS never enabled and
+      # the bug is its detection; if it reports them enabled and a tile
+      # instruction still faults, the bug is under Windows or the hypervisor
+      # and torch can only work around it.
       - name: Log CPU and torch dispatch info (Windows only)
         if: runner.os == 'Windows'
         continue-on-error: true
@@ -162,11 +172,26 @@ jobs:
             Format-List Name, Manufacturer, Description, NumberOfCores,
             NumberOfLogicalProcessors"
           uv run --no-sync python -c '
+          import ctypes
           import torch
           print("torch", torch.__version__)
           print("cpu_capability", torch.backends.cpu.get_cpu_capability())
           print(torch.__config__.parallel_info())
           print(torch.__config__.show())
+          kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+          kernel32.GetEnabledXStateFeatures.restype = ctypes.c_uint64
+          mask = kernel32.GetEnabledXStateFeatures()
+          print(f"enabled_xstate_features 0x{mask:016x}")
+          components = [
+              (2, "AVX"),
+              (5, "AVX512_KMASK"),
+              (6, "AVX512_ZMM_H"),
+              (7, "AVX512_ZMM"),
+              (17, "AMX_TILE_CONFIG"),
+              (18, "AMX_TILE_DATA"),
+          ]
+          for bit, name in components:
+              print(f"  bit {bit:>2} {name:<16} {bool(mask >> bit & 1)}")
           '
 
       - name: Run Tests (all tests)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,30 @@ jobs:
           key: model-cache-${{ hashFiles('model_cache/**') }}
           enableCrossOsArchive: true
 
+      # The hosted Windows runners have heterogeneous CPUs (Intel Xeon with
+      # AVX-512, AMD EPYC without), so kernels that dispatch on AVX-512 abort
+      # with `Windows fatal exception: code 0xc000001d`
+      # (STATUS_ILLEGAL_INSTRUCTION) on whichever machine we happen to land on.
+      # Cap each dispatcher torch can route CPU work through, so the test runs
+      # behave the same whichever machine we get:
+      #   ONEDNN_MAX_CPU_ISA      oneDNN primitives (matmul, conv, ...)
+      #   ATEN_CPU_CAPABILITY     torch's own vectorized ATen kernels
+      #   MKL_ENABLE_INSTRUCTIONS MKL's BLAS/LAPACK
+      # Written to GITHUB_ENV rather than each step's `env:` because the latter
+      # two have no "autodetect" value to pass on the other runners: an unknown
+      # value makes torch warn in every process, and MKL_ENABLE_INSTRUCTIONS
+      # would really cap Linux, whose torch wheels link MKL as well. Only the
+      # test steps follow, so this stays scoped to the test runs.
+      - name: Cap CPU ISA to AVX2 (Windows only)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          {
+            echo "ONEDNN_MAX_CPU_ISA=AVX2"
+            echo "ATEN_CPU_CAPABILITY=avx2"
+            echo "MKL_ENABLE_INSTRUCTIONS=AVX2"
+          } >> "$GITHUB_ENV"
+
       - name: Run Tests (all tests)
         if: ${{ matrix.dependency-set != 'lowest-direct' && github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
         run: uv run --no-sync pytest tests/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,29 +125,46 @@ jobs:
           key: model-cache-${{ hashFiles('model_cache/**') }}
           enableCrossOsArchive: true
 
-      # The hosted Windows runners have heterogeneous CPUs (Intel Xeon with
-      # AVX-512, AMD EPYC without), so kernels that dispatch on AVX-512 abort
-      # with `Windows fatal exception: code 0xc000001d`
-      # (STATUS_ILLEGAL_INSTRUCTION) on whichever machine we happen to land on.
-      # Cap each dispatcher torch can route CPU work through, so the test runs
-      # behave the same whichever machine we get:
-      #   ONEDNN_MAX_CPU_ISA      oneDNN primitives (matmul, conv, ...)
-      #   ATEN_CPU_CAPABILITY     torch's own vectorized ATen kernels
-      #   MKL_ENABLE_INSTRUCTIONS MKL's BLAS/LAPACK
-      # Written to GITHUB_ENV rather than each step's `env:` because the latter
-      # two have no "autodetect" value to pass on the other runners: an unknown
-      # value makes torch warn in every process, and MKL_ENABLE_INSTRUCTIONS
-      # would really cap Linux, whose torch wheels link MKL as well. Only the
-      # test steps follow, so this stays scoped to the test runs.
-      - name: Cap CPU ISA to AVX2 (Windows only)
+      # Diagnostics for the intermittent Windows abort
+      # `Windows fatal exception: code 0xc000001d` (STATUS_ILLEGAL_INSTRUCTION),
+      # which kills roughly 1 in 10 Windows jobs. Every occurrence so far dies
+      # at the same test -- the suite's first fit/predict on real weights --
+      # under both dependency sets, and a retry clears it. faulthandler cannot
+      # walk the native stack on Windows ("cannot get C stack on this system"),
+      # so the log never names the faulting DLL. Record the CPU and the ISA
+      # torch selects for it instead: if the aborts only ever happen on one CPU
+      # model, that confirms an AVX-512 kernel running on a runner without it;
+      # if they are spread across CPU models, the dispatch theory is dead.
+      # Remove all of this once the flake is understood.
+      - name: Log CPU and torch dispatch info (Windows only)
         if: runner.os == 'Windows'
+        continue-on-error: true
         shell: bash
         run: |
-          {
-            echo "ONEDNN_MAX_CPU_ISA=AVX2"
-            echo "ATEN_CPU_CAPABILITY=avx2"
-            echo "MKL_ENABLE_INSTRUCTIONS=AVX2"
-          } >> "$GITHUB_ENV"
+          pwsh -NoProfile -Command "Get-CimInstance Win32_Processor |
+            Format-List Name, Manufacturer, Description, NumberOfCores,
+            NumberOfLogicalProcessors"
+          uv run --no-sync python -c '
+          import torch
+          print("torch", torch.__version__)
+          print("cpu_capability", torch.backends.cpu.get_cpu_capability())
+          print(torch.__config__.parallel_info())
+          print(torch.__config__.show())
+          '
+
+      # Runs the known-flaky test on its own, ahead of the suite. When the abort
+      # happens mid-suite, two threads write the faulthandler dump at once and
+      # the output is shredded into unreadable interleaved text; in a process
+      # doing nothing else there is a chance of a legible dump. Advisory only --
+      # `continue-on-error` keeps the real test steps below in charge of the
+      # job's verdict, and a fresh process is not the same environment as one
+      # 170 tests deep, so this may simply never reproduce.
+      - name: Crash canary in an isolated process (Windows only)
+        if: runner.os == 'Windows'
+        continue-on-error: true
+        run: >
+          uv run --no-sync pytest -v
+          "tests/test_classifier_interface.py::test__predict__show_progress_bar_true__tiny_dataset_does_not_crash"
 
       - name: Run Tests (all tests)
         if: ${{ matrix.dependency-set != 'lowest-direct' && github.event_name != 'pull_request' && github.event_name != 'merge_group' }}

--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ TabPFN uses Pydantic settings for configuration, supporting environment variable
 
 **PyTorch Settings:**
 - `PYTORCH_CUDA_ALLOC_CONF`: PyTorch CUDA memory allocation configuration to optimize GPU memory usage (default: `max_split_size_mb:512`). See [PyTorch CUDA documentation](https://docs.pytorch.org/docs/stable/notes/cuda.html#optimizing-memory-usage-with-pytorch-cuda-alloc-conf) for more information.
+- If you experience crashes on Windows with the error message containing `Windows fatal exception: code 0xc000001d`, try to set `ONEDNN_MAX_CPU_ISA=AVX512_CORE_FP16`. This is likely an upstream pytorch/oneDNN bug.
 
 Example:
 ```bash


### PR DESCRIPTION
We occasionally get `Windows fatal exception: Windows fatal exception: code 0xcode 0xc000001dc000001d`. Let's see if disabling AVX512 solves this.

Update from Claude after debugging:

Root cause is settled, and the fix is one environment variable.

It's oneDNN's AMX kernels. All three oneDNN caps survive; capping MKL or ATen still aborts. Since AVX512_CORE_FP16 is the highest oneDNN tier below AMX, the only thing it removes versus the default is the AMX kernel set — that isolates the fault to an AMX instruction. Which matches the hardware exactly: Emerald Rapids advertises AMX in CPUID, but Windows keeps the tile XSTATE disabled until a process opts in, so the first ldtilecfg takes a #UD → 0xc000001d. The AMD EPYC runners have no AMX and never fault.

Two details worth noting from the log. This crash was on torch 2.5.0 / oneDNN v3.5.3, while the earlier one was torch 2.13.0 / oneDNN v3.12.0 — same CPU model, same fault, seven minor oneDNN versions apart. So it won't age out by bumping torch. And ONEDNN_VERBOSE=1 produced no output at all before the abort; oneDNN's verbose goes through buffered stdio, so the buffer died with the process. The exit-code table carried the result instead.
I
 kept the CPU/dispatch logging — it's ~2s and it's what made this diagnosable — but it's easy to drop if you'd rather have the quieter log.

One caveat on the value: if a future oneDNN ever rejects AVX512_CORE_FP16, it warns and falls back to unrestricted, and the crash returns silently. AVX512_CORE also survived and is the more conservative spelling if you'd prefer belt-and-braces over the last bit of AVX-512 kernel coverage.
