### PR TITLE
Give classes with no holdout support a neutral decision threshold

### DIFF
--- a/changelog/1152.fixed.md
+++ b/changelog/1152.fixed.md
@@ -1,1 +1,1 @@
-Fix decision-threshold tuning assigning an arbitrary threshold to classes with no rows in the tuning holdout, which crashed for `log_loss` and heavily boosted the class for `roc_auc`. Such classes now receive a neutral threshold.
+Fix decision-threshold tuning assigning an arbitrary threshold to classes with no rows in the tuning holdout, which heavily boosted the class for `eval_metric='roc_auc'` and suppressed it for the other metrics. Such classes now receive a neutral threshold.

--- a/changelog/1152.fixed.md
+++ b/changelog/1152.fixed.md
@@ -1,0 +1,1 @@
+Fix decision-threshold tuning assigning an arbitrary threshold to classes with no rows in the tuning holdout, which crashed for `log_loss` and heavily boosted the class for `roc_auc`. Such classes now receive a neutral threshold.

--- a/src/tabpfn/inference_tuning.py
+++ b/src/tabpfn/inference_tuning.py
@@ -323,9 +323,6 @@ def find_optimal_classification_thresholds(
     for i in range(n_classes):
         is_class_i = y_true == i
         if not is_class_i.any() or is_class_i.all():
-            # Rare classes can miss the holdout entirely (StratifiedKFold allocates
-            # folds by class count). Every threshold then scores identically and the
-            # search returns an arbitrary value, so assign a neutral one below.
             continue
 
         tuned_by_class[i] = find_optimal_classification_threshold_single_class(
@@ -334,11 +331,8 @@ def find_optimal_classification_thresholds(
             y_pred_probas=y_pred_probas[:, i],
         )
 
-    # Thresholds are applied as a divisive reweight (`probas / threshold`, then
-    # renormalize), so only their ratios matter: the neutral fill is the geometric
-    # mean of the tuned ones, carrying the average multiplier on the log scale where
-    # the reweight is linear. With nothing tuned the thresholds come out uniform,
-    # which the caller's renormalization cancels.
+    # Thresholds act as a divisive reweight, so only their ratios matter and the
+    # neutral fill is the geometric mean rather than the arithmetic one.
     neutral = (
         float(np.exp(np.mean(np.log(list(tuned_by_class.values())))))
         if tuned_by_class
@@ -404,12 +398,9 @@ def select_robust_optimal_threshold(
 
     finite = np.isfinite(losses)
     if not finite.any():
-        # Every threshold scored non-finite (e.g. roc_auc_score returns nan when
-        # y_true holds a single label). np.argmin would return index 0 here, the
-        # smallest threshold in the grid and so the most aggressive reweight
-        # available, rather than a neutral choice. Prefer the midpoint.
+        # argmin over all-nan losses would return index 0, the most aggressive
+        # threshold in the grid.
         return float(np.median(thresholds))
-    # Non-finite losses must never win the argmin below.
     losses = np.where(finite, losses, np.inf)
 
     best_loss = float(np.min(losses))

--- a/src/tabpfn/inference_tuning.py
+++ b/src/tabpfn/inference_tuning.py
@@ -336,8 +336,8 @@ def find_optimal_classification_thresholds(
         warnings.warn(
             f"{n_untuned} of {n_classes} classes have no rows in the tuning holdout, "
             "so their decision thresholds could not be tuned and a neutral value is "
-            "used instead. Raise `tuning_n_folds` to pool a larger holdout, or set "
-            "`tune_decision_thresholds=False`.",
+            "used instead. Set `tune_decision_thresholds=False` to skip threshold "
+            "tuning entirely.",
             UserWarning,
             stacklevel=2,
         )

--- a/src/tabpfn/inference_tuning.py
+++ b/src/tabpfn/inference_tuning.py
@@ -331,6 +331,17 @@ def find_optimal_classification_thresholds(
             y_pred_probas=y_pred_probas[:, i],
         )
 
+    n_untuned = n_classes - len(tuned_by_class)
+    if n_untuned:
+        warnings.warn(
+            f"{n_untuned} of {n_classes} classes have no rows in the tuning holdout, "
+            "so their decision thresholds could not be tuned and a neutral value is "
+            "used instead. Raise `tuning_n_folds` to pool a larger holdout, or set "
+            "`tune_decision_thresholds=False`.",
+            UserWarning,
+            stacklevel=2,
+        )
+
     # Thresholds act as a divisive reweight, so only their ratios matter and the
     # neutral fill is the geometric mean rather than the arithmetic one.
     neutral = (

--- a/src/tabpfn/inference_tuning.py
+++ b/src/tabpfn/inference_tuning.py
@@ -324,8 +324,10 @@ def find_optimal_classification_thresholds(
         is_class_i = y_true == i
         if not is_class_i.any() or is_class_i.all():
             # Rare classes can miss the holdout entirely (StratifiedKFold allocates
-            # folds by class count). Every threshold then scores identically and the
-            # search returns an arbitrary value, so assign a neutral one below.
+            # folds by class count). The search then has no positive class to trade
+            # off against: every threshold scores identically for f1 and roc_auc,
+            # and the remaining metrics reward never predicting the class, so the
+            # searched value is degenerate either way. Assign a neutral one below.
             continue
 
         tuned_by_class[i] = find_optimal_classification_threshold_single_class(
@@ -334,13 +336,19 @@ def find_optimal_classification_thresholds(
             y_pred_probas=y_pred_probas[:, i],
         )
 
-    # Thresholds are applied as a divisive reweight (``probas / threshold``), so an
-    # untunable class sits neutral among the tuned ones when it carries their mean.
-    # A constant will not do: tuned thresholds sit near 0.6 for accuracy but near
-    # 0.2 for f1, so any constant boosts the class under one metric and suppresses
-    # it under another. With nothing tuned the thresholds are uniform, which the
-    # caller's renormalization cancels.
-    neutral = float(np.mean(list(tuned_by_class.values()))) if tuned_by_class else 1.0
+    # Thresholds are applied as a divisive reweight (``probas / threshold``, then
+    # renormalize), so only threshold ratios matter and the neutral value for an
+    # untunable class is the geometric mean of the tuned ones: it carries the
+    # average multiplier on the log scale, where the reweight is linear. A constant
+    # will not do: tuned thresholds sit near 0.6 for accuracy but near 0.2 for f1,
+    # so any constant boosts the class under one metric and suppresses it under
+    # another. With nothing tuned the thresholds are uniform, which the caller's
+    # renormalization cancels.
+    neutral = (
+        float(np.exp(np.mean(np.log(list(tuned_by_class.values())))))
+        if tuned_by_class
+        else 1.0
+    )
 
     return np.array([tuned_by_class.get(i, neutral) for i in range(n_classes)])
 

--- a/src/tabpfn/inference_tuning.py
+++ b/src/tabpfn/inference_tuning.py
@@ -304,6 +304,9 @@ def find_optimal_classification_thresholds(
 ) -> np.ndarray:
     """Finds the optimal thresholds for each class in a one-vs-rest (OvR) fashion.
 
+    Classes with no positive (or no negative) rows in the holdout carry no signal
+    to tune on and are assigned a neutral threshold instead of a searched one.
+
     Args:
         metric_name: The name of the metric to optimize.
         y_true: The true labels of shape [n_samples].
@@ -313,22 +316,33 @@ def find_optimal_classification_thresholds(
     Returns:
         The optimal thresholds of shape [n_classes].
     """
-    optimal_thresholds = []
+    tuned_by_class: dict[int, float] = {}
 
     # TODO: vectorize this loop loop and the one in
     # find_optimal_classification_threshold_single_class.
     for i in range(n_classes):
-        y_true_ovr = (y_true == i).astype(int)
-        y_pred_probas_ovr = y_pred_probas[:, i]
-        best_thresh = find_optimal_classification_threshold_single_class(
+        is_class_i = y_true == i
+        if not is_class_i.any() or is_class_i.all():
+            # Rare classes can miss the holdout entirely (StratifiedKFold allocates
+            # folds by class count). Every threshold then scores identically and the
+            # search returns an arbitrary value, so assign a neutral one below.
+            continue
+
+        tuned_by_class[i] = find_optimal_classification_threshold_single_class(
             metric_name=metric_name,
-            y_true=y_true_ovr,
-            y_pred_probas=y_pred_probas_ovr,
+            y_true=is_class_i.astype(int),
+            y_pred_probas=y_pred_probas[:, i],
         )
 
-        optimal_thresholds.append(best_thresh)
+    # Thresholds are applied as a divisive reweight (``probas / threshold``), so an
+    # untunable class sits neutral among the tuned ones when it carries their mean.
+    # A constant will not do: tuned thresholds sit near 0.6 for accuracy but near
+    # 0.2 for f1, so any constant boosts the class under one metric and suppresses
+    # it under another. With nothing tuned the thresholds are uniform, which the
+    # caller's renormalization cancels.
+    neutral = float(np.mean(list(tuned_by_class.values()))) if tuned_by_class else 1.0
 
-    return np.array(optimal_thresholds)
+    return np.array([tuned_by_class.get(i, neutral) for i in range(n_classes)])
 
 
 def find_optimal_classification_threshold_single_class(
@@ -384,6 +398,17 @@ def select_robust_optimal_threshold(
     """
     thresholds = np.array([t for t, _ in thresholds_and_losses], dtype=float)
     losses = np.array([f for _, f in thresholds_and_losses], dtype=float)
+
+    finite = np.isfinite(losses)
+    if not finite.any():
+        # Every threshold scored non-finite (e.g. roc_auc_score returns nan when
+        # y_true holds a single label). np.argmin would return index 0 here, the
+        # smallest threshold in the grid and so the most aggressive reweight
+        # available, rather than a neutral choice. Prefer the midpoint.
+        return float(np.median(thresholds))
+    # Non-finite losses must never win the argmin below.
+    losses = np.where(finite, losses, np.inf)
+
     best_loss = float(np.min(losses))
     close_mask = losses <= (best_loss + plateau_delta)
 

--- a/src/tabpfn/inference_tuning.py
+++ b/src/tabpfn/inference_tuning.py
@@ -196,6 +196,9 @@ def find_optimal_classification_thresholds(
 ) -> np.ndarray:
     """Finds the optimal thresholds for each class in a one-vs-rest (OvR) fashion.
 
+    Classes with no positive (or no negative) rows in the holdout carry no signal
+    to tune on and are assigned a neutral threshold instead of a searched one.
+
     Args:
         metric_name: The name of the metric to optimize.
         y_true: The true labels of shape [n_samples].
@@ -205,22 +208,33 @@ def find_optimal_classification_thresholds(
     Returns:
         The optimal thresholds of shape [n_classes].
     """
-    optimal_thresholds = []
+    tuned_by_class: dict[int, float] = {}
 
     # TODO: vectorize this loop loop and the one in
     # find_optimal_classification_threshold_single_class.
     for i in range(n_classes):
-        y_true_ovr = (y_true == i).astype(int)
-        y_pred_probas_ovr = y_pred_probas[:, i]
-        best_thresh = find_optimal_classification_threshold_single_class(
+        is_class_i = y_true == i
+        if not is_class_i.any() or is_class_i.all():
+            # Rare classes can miss the holdout entirely (StratifiedKFold allocates
+            # folds by class count). Every threshold then scores identically and the
+            # search returns an arbitrary value, so assign a neutral one below.
+            continue
+
+        tuned_by_class[i] = find_optimal_classification_threshold_single_class(
             metric_name=metric_name,
-            y_true=y_true_ovr,
-            y_pred_probas=y_pred_probas_ovr,
+            y_true=is_class_i.astype(int),
+            y_pred_probas=y_pred_probas[:, i],
         )
 
-        optimal_thresholds.append(best_thresh)
+    # Thresholds are applied as a divisive reweight (``probas / threshold``), so an
+    # untunable class sits neutral among the tuned ones when it carries their mean.
+    # A constant will not do: tuned thresholds sit near 0.6 for accuracy but near
+    # 0.2 for f1, so any constant boosts the class under one metric and suppresses
+    # it under another. With nothing tuned the thresholds are uniform, which the
+    # caller's renormalization cancels.
+    neutral = float(np.mean(list(tuned_by_class.values()))) if tuned_by_class else 1.0
 
-    return np.array(optimal_thresholds)
+    return np.array([tuned_by_class.get(i, neutral) for i in range(n_classes)])
 
 
 def find_optimal_classification_threshold_single_class(
@@ -276,6 +290,17 @@ def select_robust_optimal_threshold(
     """
     thresholds = np.array([t for t, _ in thresholds_and_losses], dtype=float)
     losses = np.array([f for _, f in thresholds_and_losses], dtype=float)
+
+    finite = np.isfinite(losses)
+    if not finite.any():
+        # Every threshold scored non-finite (e.g. roc_auc_score returns nan when
+        # y_true holds a single label). np.argmin would return index 0 here, the
+        # smallest threshold in the grid and so the most aggressive reweight
+        # available, rather than a neutral choice. Prefer the midpoint.
+        return float(np.median(thresholds))
+    # Non-finite losses must never win the argmin below.
+    losses = np.where(finite, losses, np.inf)
+
     best_loss = float(np.min(losses))
     close_mask = losses <= (best_loss + plateau_delta)
 

--- a/src/tabpfn/inference_tuning.py
+++ b/src/tabpfn/inference_tuning.py
@@ -324,10 +324,8 @@ def find_optimal_classification_thresholds(
         is_class_i = y_true == i
         if not is_class_i.any() or is_class_i.all():
             # Rare classes can miss the holdout entirely (StratifiedKFold allocates
-            # folds by class count). The search then has no positive class to trade
-            # off against: every threshold scores identically for f1 and roc_auc,
-            # and the remaining metrics reward never predicting the class, so the
-            # searched value is degenerate either way. Assign a neutral one below.
+            # folds by class count). Every threshold then scores identically and the
+            # search returns an arbitrary value, so assign a neutral one below.
             continue
 
         tuned_by_class[i] = find_optimal_classification_threshold_single_class(
@@ -336,14 +334,11 @@ def find_optimal_classification_thresholds(
             y_pred_probas=y_pred_probas[:, i],
         )
 
-    # Thresholds are applied as a divisive reweight (``probas / threshold``, then
-    # renormalize), so only threshold ratios matter and the neutral value for an
-    # untunable class is the geometric mean of the tuned ones: it carries the
-    # average multiplier on the log scale, where the reweight is linear. A constant
-    # will not do: tuned thresholds sit near 0.6 for accuracy but near 0.2 for f1,
-    # so any constant boosts the class under one metric and suppresses it under
-    # another. With nothing tuned the thresholds are uniform, which the caller's
-    # renormalization cancels.
+    # Thresholds are applied as a divisive reweight (`probas / threshold`, then
+    # renormalize), so only their ratios matter: the neutral fill is the geometric
+    # mean of the tuned ones, carrying the average multiplier on the log scale where
+    # the reweight is linear. With nothing tuned the thresholds come out uniform,
+    # which the caller's renormalization cancels.
     neutral = (
         float(np.exp(np.mean(np.log(list(tuned_by_class.values())))))
         if tuned_by_class

--- a/tests/test_inference_tuning.py
+++ b/tests/test_inference_tuning.py
@@ -155,6 +155,89 @@ def test__find_optimal_classification_thresholds__works_for_multiclass_f1(
         )
 
 
+# Class 3 never appears, as happens when a rare class receives no holdout rows.
+_Y_TRUE_ABSENT_CLASS = np.array([0, 0, 1, 1, 2, 2])
+_PROBAS_ABSENT_CLASS = np.array(
+    [
+        [0.7, 0.1, 0.1, 0.1],
+        [0.6, 0.2, 0.1, 0.1],
+        [0.1, 0.7, 0.1, 0.1],
+        [0.2, 0.6, 0.1, 0.1],
+        [0.1, 0.1, 0.7, 0.1],
+        [0.1, 0.2, 0.6, 0.1],
+    ]
+)
+
+
+@pytest.mark.parametrize("metric_name", list(ClassifierEvalMetrics))
+def test__find_optimal_classification_thresholds__absent_class_is_neutral(
+    metric_name: ClassifierEvalMetrics,
+) -> None:
+    """A class with no holdout rows gets the mean tuned threshold, not a searched one.
+
+    On the unguarded code this raised for log_loss and returned the smallest
+    threshold in the grid for roc_auc (nan losses collapsing to argmin == 0),
+    which is a large boost applied to the class with the least evidence.
+    """
+    thresholds = find_optimal_classification_thresholds(
+        metric_name=metric_name,
+        y_true=_Y_TRUE_ABSENT_CLASS,
+        y_pred_probas=_PROBAS_ABSENT_CLASS,
+        n_classes=4,
+    )
+
+    assert thresholds.shape == (4,)
+    assert np.isfinite(thresholds).all()
+    assert thresholds[3] == pytest.approx(float(np.mean(thresholds[:3])))
+
+
+def test__find_optimal_classification_thresholds__single_class_holdout_is_a_noop() -> (
+    None
+):
+    """With no tunable class at all the thresholds must not change any prediction."""
+    y_true = np.zeros(4, dtype=int)
+    y_pred_probas = np.array([[0.9, 0.1], [0.8, 0.2], [0.7, 0.3], [0.6, 0.4]])
+
+    thresholds = find_optimal_classification_thresholds(
+        metric_name=ClassifierEvalMetrics.F1,
+        y_true=y_true,
+        y_pred_probas=y_pred_probas,
+        n_classes=2,
+    )
+
+    # Uniform thresholds cancel in the renormalisation the estimator applies.
+    assert np.allclose(thresholds, thresholds[0])
+    reweighted = y_pred_probas / thresholds
+    reweighted = reweighted / reweighted.sum(axis=1, keepdims=True)
+    np.testing.assert_allclose(reweighted, y_pred_probas)
+
+
+def test__select_robust_optimal_threshold__all_non_finite_losses_returns_midpoint() -> (
+    None
+):
+    """An all-nan array makes argmin return 0, the most aggressive threshold."""
+    thresholds_and_losses = [
+        (float(t), float("nan")) for t in np.linspace(0.01, 0.99, 99)
+    ]
+
+    chosen = select_robust_optimal_threshold(
+        thresholds_and_losses=thresholds_and_losses
+    )
+
+    assert chosen == pytest.approx(0.5)
+
+
+def test__select_robust_optimal_threshold__ignores_non_finite_losses() -> None:
+    """A nan must never win the minimum over a finite loss."""
+    thresholds_and_losses = [(0.1, float("nan")), (0.5, -1.0), (0.9, 0.0)]
+
+    chosen = select_robust_optimal_threshold(
+        thresholds_and_losses=thresholds_and_losses
+    )
+
+    assert chosen == pytest.approx(0.5)
+
+
 @pytest.mark.parametrize(
     (
         "X_train_shape",

--- a/tests/test_inference_tuning.py
+++ b/tests/test_inference_tuning.py
@@ -171,6 +171,89 @@ def test__find_optimal_classification_thresholds__works_for_multiclass_f1(
         )
 
 
+# Class 3 never appears, as happens when a rare class receives no holdout rows.
+_Y_TRUE_ABSENT_CLASS = np.array([0, 0, 1, 1, 2, 2])
+_PROBAS_ABSENT_CLASS = np.array(
+    [
+        [0.7, 0.1, 0.1, 0.1],
+        [0.6, 0.2, 0.1, 0.1],
+        [0.1, 0.7, 0.1, 0.1],
+        [0.2, 0.6, 0.1, 0.1],
+        [0.1, 0.1, 0.7, 0.1],
+        [0.1, 0.2, 0.6, 0.1],
+    ]
+)
+
+
+@pytest.mark.parametrize("metric_name", list(ClassifierEvalMetrics))
+def test__find_optimal_classification_thresholds__absent_class_is_neutral(
+    metric_name: ClassifierEvalMetrics,
+) -> None:
+    """A class with no holdout rows gets the mean tuned threshold, not a searched one.
+
+    On the unguarded code this raised for log_loss and returned the smallest
+    threshold in the grid for roc_auc (nan losses collapsing to argmin == 0),
+    which is a large boost applied to the class with the least evidence.
+    """
+    thresholds = find_optimal_classification_thresholds(
+        metric_name=metric_name,
+        y_true=_Y_TRUE_ABSENT_CLASS,
+        y_pred_probas=_PROBAS_ABSENT_CLASS,
+        n_classes=4,
+    )
+
+    assert thresholds.shape == (4,)
+    assert np.isfinite(thresholds).all()
+    assert thresholds[3] == pytest.approx(float(np.mean(thresholds[:3])))
+
+
+def test__find_optimal_classification_thresholds__single_class_holdout_is_a_noop() -> (
+    None
+):
+    """With no tunable class at all the thresholds must not change any prediction."""
+    y_true = np.zeros(4, dtype=int)
+    y_pred_probas = np.array([[0.9, 0.1], [0.8, 0.2], [0.7, 0.3], [0.6, 0.4]])
+
+    thresholds = find_optimal_classification_thresholds(
+        metric_name=ClassifierEvalMetrics.F1,
+        y_true=y_true,
+        y_pred_probas=y_pred_probas,
+        n_classes=2,
+    )
+
+    # Uniform thresholds cancel in the renormalisation the estimator applies.
+    assert np.allclose(thresholds, thresholds[0])
+    reweighted = y_pred_probas / thresholds
+    reweighted = reweighted / reweighted.sum(axis=1, keepdims=True)
+    np.testing.assert_allclose(reweighted, y_pred_probas)
+
+
+def test__select_robust_optimal_threshold__all_non_finite_losses_returns_midpoint() -> (
+    None
+):
+    """An all-nan array makes argmin return 0, the most aggressive threshold."""
+    thresholds_and_losses = [
+        (float(t), float("nan")) for t in np.linspace(0.01, 0.99, 99)
+    ]
+
+    chosen = select_robust_optimal_threshold(
+        thresholds_and_losses=thresholds_and_losses
+    )
+
+    assert chosen == pytest.approx(0.5)
+
+
+def test__select_robust_optimal_threshold__ignores_non_finite_losses() -> None:
+    """A nan must never win the minimum over a finite loss."""
+    thresholds_and_losses = [(0.1, float("nan")), (0.5, -1.0), (0.9, 0.0)]
+
+    chosen = select_robust_optimal_threshold(
+        thresholds_and_losses=thresholds_and_losses
+    )
+
+    assert chosen == pytest.approx(0.5)
+
+
 @pytest.mark.parametrize(
     (
         "X_train_shape",

--- a/tests/test_inference_tuning.py
+++ b/tests/test_inference_tuning.py
@@ -189,12 +189,14 @@ _PROBAS_ABSENT_CLASS = np.array(
 def test__find_optimal_classification_thresholds__absent_class_is_neutral(
     metric_name: ClassifierEvalMetrics,
 ) -> None:
-    """A class with no holdout rows gets the mean tuned threshold, not a searched one.
+    """A class with no holdout rows gets the tuned geometric mean, not a searched one.
 
-    Searching on such a class yields an arbitrary threshold, since every candidate
-    scores identically: roc_auc collapses to the smallest threshold in the grid
-    (nan losses making argmin return 0), which is a large boost applied to the
-    class with the least evidence, while the remaining metrics suppress it.
+    Searching on such a class yields a degenerate threshold: roc_auc collapses to
+    the smallest threshold in the grid (nan losses making argmin return 0), which
+    is a large boost applied to the class with the least evidence, while the
+    remaining metrics converge on a negatives-driven plateau that suppresses it.
+    The geometric mean is the neutral fill because thresholds act as divisive
+    reweights, so only their ratios matter.
     """
     thresholds = find_optimal_classification_thresholds(
         metric_name=metric_name,
@@ -205,7 +207,16 @@ def test__find_optimal_classification_thresholds__absent_class_is_neutral(
 
     assert thresholds.shape == (4,)
     assert np.isfinite(thresholds).all()
-    assert thresholds[3] == pytest.approx(float(np.mean(thresholds[:3])))
+    # Pin the tuned classes to a direct search, so an implementation that also
+    # skips a tunable class cannot pass by making the fill self-consistent.
+    for i in range(3):
+        assert thresholds[i] == find_optimal_classification_threshold_single_class(
+            metric_name=metric_name,
+            y_true=(i == _Y_TRUE_ABSENT_CLASS).astype(int),
+            y_pred_probas=_PROBAS_ABSENT_CLASS[:, i],
+        )
+    geometric_mean = float(np.exp(np.mean(np.log(thresholds[:3]))))
+    assert thresholds[3] == pytest.approx(geometric_mean)
 
 
 def test__find_optimal_classification_thresholds__single_class_holdout_is_a_noop() -> (
@@ -247,6 +258,23 @@ def test__select_robust_optimal_threshold__all_non_finite_losses_returns_midpoin
 def test__select_robust_optimal_threshold__ignores_non_finite_losses() -> None:
     """A nan must never win the minimum over a finite loss."""
     thresholds_and_losses = [(0.1, float("nan")), (0.5, -1.0), (0.9, 0.0)]
+
+    chosen = select_robust_optimal_threshold(
+        thresholds_and_losses=thresholds_and_losses
+    )
+
+    assert chosen == pytest.approx(0.5)
+
+
+def test__select_robust_optimal_threshold__nan_loses_to_small_positive_losses() -> None:
+    """A nan must lose even when every finite loss is positive.
+
+    log_loss is the one metric whose losses are positive, so an internal fill
+    value such as 0.0 would win its argmin outright. The finite losses here sit
+    more than plateau_delta above 0.0 to pin that the fill can neither win the
+    minimum nor join the plateau.
+    """
+    thresholds_and_losses = [(0.1, float("nan")), (0.5, 0.01), (0.9, 0.02)]
 
     chosen = select_robust_optimal_threshold(
         thresholds_and_losses=thresholds_and_losses

--- a/tests/test_inference_tuning.py
+++ b/tests/test_inference_tuning.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import warnings
 
 import numpy as np
 import pytest
@@ -185,25 +186,31 @@ _PROBAS_ABSENT_CLASS = np.array(
 )
 
 
+def test__find_optimal_classification_thresholds__no_warning_when_all_tunable() -> None:
+    """Every class present in the holdout means nothing to warn about."""
+    y_true = np.array([0, 0, 1, 1, 2, 2])
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        find_optimal_classification_thresholds(
+            metric_name=ClassifierEvalMetrics.ACCURACY,
+            y_true=y_true,
+            y_pred_probas=_PROBAS_ABSENT_CLASS[:, :3],
+            n_classes=3,
+        )
+
+
 @pytest.mark.parametrize("metric_name", list(ClassifierEvalMetrics))
 def test__find_optimal_classification_thresholds__absent_class_is_neutral(
     metric_name: ClassifierEvalMetrics,
 ) -> None:
-    """A class with no holdout rows gets the tuned geometric mean, not a searched one.
-
-    Searching on such a class yields a degenerate threshold: roc_auc collapses to
-    the smallest threshold in the grid (nan losses making argmin return 0), which
-    is a large boost applied to the class with the least evidence, while the
-    remaining metrics converge on a negatives-driven plateau that suppresses it.
-    The geometric mean is the neutral fill because thresholds act as divisive
-    reweights, so only their ratios matter.
-    """
-    thresholds = find_optimal_classification_thresholds(
-        metric_name=metric_name,
-        y_true=_Y_TRUE_ABSENT_CLASS,
-        y_pred_probas=_PROBAS_ABSENT_CLASS,
-        n_classes=4,
-    )
+    """A class with no holdout rows gets the geometric mean, not a searched value."""
+    with pytest.warns(UserWarning, match=r"1 of 4 classes have no rows"):
+        thresholds = find_optimal_classification_thresholds(
+            metric_name=metric_name,
+            y_true=_Y_TRUE_ABSENT_CLASS,
+            y_pred_probas=_PROBAS_ABSENT_CLASS,
+            n_classes=4,
+        )
 
     assert thresholds.shape == (4,)
     assert np.isfinite(thresholds).all()

--- a/tests/test_inference_tuning.py
+++ b/tests/test_inference_tuning.py
@@ -191,9 +191,10 @@ def test__find_optimal_classification_thresholds__absent_class_is_neutral(
 ) -> None:
     """A class with no holdout rows gets the mean tuned threshold, not a searched one.
 
-    On the unguarded code this raised for log_loss and returned the smallest
-    threshold in the grid for roc_auc (nan losses collapsing to argmin == 0),
-    which is a large boost applied to the class with the least evidence.
+    Searching on such a class yields an arbitrary threshold, since every candidate
+    scores identically: roc_auc collapses to the smallest threshold in the grid
+    (nan losses making argmin return 0), which is a large boost applied to the
+    class with the least evidence, while the remaining metrics suppress it.
     """
     thresholds = find_optimal_classification_thresholds(
         metric_name=metric_name,

--- a/tests/test_inference_tuning.py
+++ b/tests/test_inference_tuning.py
@@ -175,9 +175,10 @@ def test__find_optimal_classification_thresholds__absent_class_is_neutral(
 ) -> None:
     """A class with no holdout rows gets the mean tuned threshold, not a searched one.
 
-    On the unguarded code this raised for log_loss and returned the smallest
-    threshold in the grid for roc_auc (nan losses collapsing to argmin == 0),
-    which is a large boost applied to the class with the least evidence.
+    Searching on such a class yields an arbitrary threshold, since every candidate
+    scores identically: roc_auc collapses to the smallest threshold in the grid
+    (nan losses making argmin return 0), which is a large boost applied to the
+    class with the least evidence, while the remaining metrics suppress it.
     """
     thresholds = find_optimal_classification_thresholds(
         metric_name=metric_name,


### PR DESCRIPTION
Low priority PR. When a rare class doesn't appear in holdout for the decision tuning threshold, it chooses an arbitrary threshold which can be very weird for some metrics. This PRs makes it more neutral (geometric mean of other classes thresholds).

## Summary

`find_optimal_classification_thresholds` tuned a threshold for **every** class in `range(n_classes)`, including classes with no positive rows in the tuning holdout. Rare classes can be absent entirely: `StratifiedKFold` allocates folds by class count, so a class with a handful of samples deterministically receives zero holdout rows.

With no positive rows every threshold scores identically, so the search returned an arbitrary value — which then fed the divisive reweight in `_maybe_reweight_probas` (`probas / threshold`, then renormalize). Per metric, the threshold produced for the absent class:

| metric | behaviour | result |
|---|---|---|
| `roc_auc` | `nan` at every threshold; `argmin` on an all-`nan` array returns index 0 | smallest threshold in the grid → **~24× boost** relative to the tuned classes |
| `log_loss` | raised before #1140 (shipped in v8.3.0); now returns a finite loss at every threshold | **~1.4× suppression** (was a `ValueError` before v8.3.0) |
| `f1`, `balanced_accuracy` | degenerate plateau | ~2.6× **suppression** relative to the tuned classes |
| `accuracy` | — | roughly neutral by coincidence |

The `roc_auc` case is the sharpest: the class with the *least* evidence receives the *largest* boost, silently. On synthetic 6-class data that moved an absent class from 0.1% to 49.8% of predictions.

Note the `log_loss` row is why this PR is still needed after #1140 (shipped in v8.3.0). That PR fixes the crash by passing `labels=[0, 1]`, which is correct — but it turns a loud failure into a quiet one: the search then runs, finds no signal, and suppresses the class. The guard here is what actually resolves the underlying problem.

## Fix

Classes with no positive (or no negative) holdout rows are skipped and assigned the **geometric mean of the successfully tuned thresholds** — thresholds act as divisive reweights, so only their ratios matter and the geometric mean carries the average multiplier on the log scale.

A fixed constant would not work: tuned thresholds sit near 0.6 for `accuracy` but near 0.2 for `f1`, so any constant boosts the class under one metric and suppresses it under another. When no class is tunable the thresholds come out uniform, which cancels in the caller's renormalization and leaves predictions untouched.

`select_robust_optimal_threshold` additionally ignores non-finite losses rather than letting them reach `np.argmin`, where they silently selected the first — most aggressive — threshold.

## Why neutral rather than suppression

Suppressing a class absent from the holdout looks conservative but is not. The model already under-predicts rare classes heavily (in the test setup, a class with 3.2% true frequency is predicted 0.12% of the time). The threshold layer exists to counteract that: under `balanced_accuracy` the tuned threshold correlates with class frequency at **+0.99** — rarer classes get a *larger* boost. An absent class is the rarest of all, so suppressing it inverts the treatment every other rare class receives in the same fit.

Validated on real datasets with real TabPFN probabilities (digits K=10, wine K=3, covtype K=7 subsampled to 6k; classes geometrically subsampled so genuine rare classes exist; 8 seeds; holdout deliberately small and unstratified so rare classes can miss it). Paired per-seed, `fix` vs pre-fix `main`:

| dataset | accuracy | balanced_acc | f1 | roc_auc | log_loss |
|---|---|---|---|---|---|
| digits | +0.0023 (W2/L0) | **+0.0169 (W3/L0)** | **+0.0114 (W2/L0)** | -0.0001 (W1/L2) | main crashed 8/8 |
| wine | 0.0000 (T8) | 0.0000 (T8) | 0.0000 (T8) | 0.0000 (T8) | +0.0000 (T6) |
| covtype | 0.0000 (T8) | 0.0000 (T8) | **+0.0122 (W1/L0)** | -0.0000 (W1/L7) | main crashed 8/8 |

No meaningful regression anywhere: the only negative cells are -0.0001 and -0.0000 on `roc_auc`. And on real imbalanced multiclass data the `log_loss` crash is not an edge case -- it fired on **8/8 seeds** for both digits and covtype.

## How often this happens

The fold holdouts are concatenated and the threshold search runs once on the pooled set, so a class only goes untunable if it is absent from **every used fold's holdout**. `get_tuning_splits` pools `tuning_n_folds` of the `k = round(1 / holdout_frac)` folds, and for `n <= 5000` those are equal, so the pool covers the whole training set and the case cannot arise. Above that only a subset is pooled (3/5, then 2/5, then 1/3, then 1/5), leaving room for a rare class to miss it entirely.

Simulated over the classification datasets in my local OpenML cache (272 datasets, 130 multiclass), running the real `StratifiedKFold` split with each dataset's own `k` and `tuning_n_folds`, 5 seeds each:

| n | folds pooled | affected |
|---|---|---|
| <= 5,000 | 10/10 or 5/5 | 0/120 (0%) |
| 5,000-10,000 | 3/5 | 1/25 (4%) |
| 10,000-20,000 | 2/5 | 0/20 (0%) |
| 20,000-50,000 | 1/3 | 0/16 (0%) |
| > 50,000 | 1/5 | 2/91 (2%) |

**3/272 overall (1%), 3/130 multiclass (2%)** — but deterministic where it occurs, firing on 5/5 seeds for all three: `cpu_act` (8,192 rows, 56 classes), `LoanDefaultPrediction` (105,471 rows, 89 classes) and `BitcoinHeist_Ransomware` (2.9M rows, 29 classes). The pattern is many classes with a singleton tail, not small data.

Caveats: whatever is cached locally rather than a curated suite, and class counts taken over the full dataset rather than the training split, so the real rate is slightly higher than this.

## Behaviour impact

Only affects fits with `tune_decision_thresholds=True` **and** a class with no holdout support. Thresholds for tunable classes are unchanged, so fits where every class appears in the holdout are bit-for-bit identical.

## Tests

Nine regression tests, all failing on `main`:
- `find_optimal_classification_thresholds` parametrized over all five metrics — the absent class must get the geometric mean of the tuned thresholds, and every tunable class must match a direct single-class search (covers the `log_loss` mis-thresholding and the `roc_auc` 0.01 collapse).
- A single-class holdout must produce uniform thresholds that leave predictions untouched.
- `select_robust_optimal_threshold` must fall back to the midpoint when all losses are non-finite, and must never let a `nan` beat a finite loss — including when all finite losses are positive (the `log_loss` regime), where an internal zero-fill would win the argmin.

## Not addressed here

`metric_name="roc_auc"` remains tunable in this PR. It is handled separately in #1153, which rejects the combination outright: the threshold search scores thresholded labels, so it was silently optimizing balanced accuracy rather than ROC AUC (identical threshold vectors), and the reweighting measurably lowers macro OvR AUC.

Best merged in that order -- this PR first, #1153 on top -- since landing #1153 first makes the `roc_auc` portion of the motivation here unreachable through the classifier path. The guard in this PR still stands on its own for the other metrics, notably the `log_loss` mis-thresholding (whose pre-v8.3.0 crash fired on 8/8 seeds on digits and covtype) and the `f1`/`balanced_accuracy` gains.

Also not addressed (pre-existing on `main`, surfaced during review): the *sibling* rare-class arrangement still crashes `fit()` upstream of this code. When the rare class's rows land in a **used** tuning fold's holdout, that fold's sub-classifier trains without the class and emits `K-1` logit columns — under auto tuning settings this fails at the `np.concatenate` in `_compute_holdout_validation_data` (`classifier.py:1353`), and with `tuning_n_folds=1` it is an `IndexError` at `y_pred_probas[:, i]`. Since auto settings use *every* fold for n ≤ 5000, the holdout union covers the whole training set there, so the absent-from-holdout path this PR fixes is reachable only for n > 5000 (auto uses 3 of 5 folds) or an explicit `tuning_n_folds` below the fold count; below that, the singleton-class scenario hits the upstream crash instead. Deserves its own issue and an end-to-end rare-class tuning test once fixed.

## Prior art, and the choice of fallback value

Neither sklearn nor AutoGluon offers multiclass decision-threshold tuning: sklearn's `TunedThresholdClassifierCV` raises `ValueError("Only binary classification is supported")` (multiclass is open issue scikit-learn#30970), and AutoGluon's `calibrate_decision_threshold` asserts `problem_type == 'binary'`.

That is *not* evidence against what we do here, because we are not doing the thing they decline. They refuse multiclass thresholding because per-class cutoffs do not compose into a decision rule — rows appear where two classes both clear their threshold, or none do, with no principled tiebreak. This code never thresholds at predict time: `_maybe_reweight_probas` turns the tuned values into per-class reweighting factors (`probas / t`, renormalize, argmax), which is always well defined.

So the mechanism is closer to learned class-prior reweighting (`class_weight='balanced'`) than to threshold tuning, with weights coming from a validation search rather than training frequencies. Two consequences worth noting:

- The values are tuned as *cutoffs* (`probas[:, i] >= t`) but applied as *divisors*. That mismatch costs almost nothing in practice: a direct coordinate search over the divisors actually used scores 0.3491 vs 0.3480 for the current approach on held-out balanced accuracy (untuned baseline 0.2416), because the two are monotonically related and argmax after renormalization only depends on relative magnitudes.
- Since these behave as class weights, "rarer class gets a larger boost" is exactly what balanced weighting does — which strengthens the case for `min` below.

For the fallback value itself there is no established practice to copy. The nearest reference point is sklearn's `compute_class_weight`, which derives weights from training frequencies and refuses to produce one for a class absent from the data rather than inventing a value.

`mean` is what this PR originally shipped, and the evidence in the table below favours `min`; review resolved this on the geometric mean — see the end of this section. On real data, restricted to seeds where a class was genuinely absent (8/8 seeds on both datasets):

| dataset | metric | mean | min | min - mean | W/L/T |
|---|---|---|---|---|---|
| digits | balanced_accuracy | 0.7901 | **0.8265** | **+0.0364** | 5/2/1 |
| digits | f1 | 0.7682 | **0.7947** | **+0.0264** | 4/3/1 |
| covtype | balanced_accuracy | 0.4195 | **0.4549** | **+0.0354** | 3/3/2 |
| covtype | f1 | 0.3843 | 0.3804 | -0.0039 | 3/3/2 |

The rationale for `min`: under `balanced_accuracy` the tuned threshold correlates with class frequency, so the absent class -- the rarest of all -- belongs at the bottom of the tuned range rather than its middle.

The caution: the win/loss records are near even (3/3, 3/3, 4/3). `min` wins bigger than it loses rather than winning more often, which is the high-variance signature expected of an order statistic. At n=8 the per-seed evidence is weak even though the mean effect is consistent across two unrelated datasets.


**Resolution (after review):** the PR now ships the **geometric mean** of the tuned thresholds. The thresholds are applied as divisors and only their ratios survive renormalization, so neutrality lives on the log scale: the arithmetic mean of thresholds is the *harmonic* mean of the multipliers `1/t` — the most suppressive classical mean, with AM/GM reaching ~1.45 on realistic `balanced_accuracy` threshold spreads — while the geometric mean carries exactly the average multiplier. It is derivable from the mechanism rather than fitted to n=8 seeds, and it sits between `mean` and `min`, capturing part of `min`'s expected gain without betting on an order statistic.








