### PR TITLE
Sync external-PR reviewer list with opensource-review-team

### DIFF
--- a/.github/pr-reviewers.txt
+++ b/.github/pr-reviewers.txt
@@ -1,10 +1,8 @@
 oscarkey
-bejaeger
 anuragg1209
 klemens-floege
 priorphil
 adrian-prior
-psinger-prior
 alanprior
 eliott-kalfon
 arthur-priorlabs


### PR DESCRIPTION
Brings `.github/pr-reviewers.txt` back in line with the `opensource-review-team` roster.

### Why

`psinger-prior` and `bejaeger` were being assigned reviews on external and Dependabot PRs in tabpfn-extensions (#368, #369, #370) despite not being members of `opensource-review-team`. This file is the actual source of reviewers — `assign-pr-reviewer.yml` fetches it over raw.githubusercontent — so it had silently drifted from the team it is meant to mirror.

Checked in both directions: every current team member was already in the file, so this is only the removal of the two extras. Order of the remaining eight is unchanged to keep the diff readable.

| | |
|---|---|
| Removed (in file, not on team) | `psinger-prior`, `bejaeger` |
| Added (on team, missing from file) | none |

If either of them *should* be reviewing OSS PRs, the fix is to add them to `opensource-review-team` and re-sync rather than to revert this.

### Two things this does not fix

- **`tabpfn-extensions/.github/CODEOWNERS` is empty** (0 bytes). `assign-pr-reviewer.yml` only fires when nothing else has requested a reviewer, and its comment assumes CODEOWNERS covers some paths — so in that repo every external and Dependabot PR falls through to the random picker.
- **The picker is random, not round robin.** `reviewers[Math.floor(Math.random() * reviewers.length)]` is why one person drew two PRs in a row. Either request the team and let GitHub's own review assignment round-robin it (`opensource-review-team` already has push on the relevant repos, so no PAT is needed, contrary to the workflow comment), or make it deterministic with `pr_number % reviewers.length`.

Note for anyone editing this file later: the workflow parses it with `.filter(Boolean)`, so it has no comment syntax — a `#` header line would be treated as a username.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
