### PR TITLE
Assign external-PR reviewers deterministically, not randomly

### DIFF
--- a/.github/workflows/assign-pr-reviewer.yml
+++ b/.github/workflows/assign-pr-reviewer.yml
@@ -1,5 +1,5 @@
-# When a PR is opened from a fork or by dependabot, request a review from a randomly
-# chosen reviewer so the PR gets picked up.
+# When a PR is opened from a fork or by dependabot, request a review from a reviewer chosen
+# deterministically from the PR number, so the PR gets picked up.
 #
 # We use this workflow instead of GitHub's built-in auto-assignment system because we
 # want to avoid auto assigning reviewers to PRs from Prior Labs team members, and GitHub
@@ -41,7 +41,7 @@ jobs:
       )
     runs-on: ubuntu-slim
     steps:
-      - name: Request review from a random reviewer
+      - name: Request review from the rotation
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -62,7 +62,16 @@ jobs:
               throw new Error("pr-reviewers.txt is empty; cannot assign a reviewer.");
             }
 
-            const reviewer = reviewers[Math.floor(Math.random() * reviewers.length)];
+            // Deterministic rather than random, keyed on the PR number. Dependabot
+            // opens its PRs in a run of consecutive numbers, so consecutive numbers
+            // must not collide: n % len guarantees that, which random did not (one
+            // reviewer drew two of #368/#369 in tabpfn-extensions). It is also
+            // idempotent, so a reopen re-requests the same person rather than adding
+            // a second reviewer. Note this is a spread, not a true round robin:
+            // long-run counts are as uneven as random, because the numbers that
+            // reach this workflow are sparse. Equal counts would need stored state.
+            const reviewer =
+              reviewers[context.payload.pull_request.number % reviewers.length];
             core.info(`Requesting review from ${reviewer}`);
 
             await github.rest.pulls.requestReviewers({


### PR DESCRIPTION
Replaces the random reviewer pick with a deterministic one keyed on the PR number. The file stays as the source of reviewers.

```diff
-const reviewer = reviewers[Math.floor(Math.random() * reviewers.length)];
+const reviewer =
+  reviewers[context.payload.pull_request.number % reviewers.length];
```

### Why

Dependabot opens its PRs as a run of consecutive numbers, and `Math.random()` happily gives the same person several in a row - one reviewer drew both #368 and #369 in tabpfn-extensions. Modulo makes consecutive numbers structurally distinct.

Measured against the real eligible-PR history (fork + Dependabot PRs, 8 reviewers):

| | TabPFN (59 PRs) | tabpfn-extensions (101 PRs) |
|---|---|---|
| Back-to-back repeats, modulo | 3 of 58 | 3 of 100 |
| Back-to-back repeats, random | 8 | 13 |
| Consecutive-number pairs landing on the same reviewer | 0 of 27 | 0 of 40 |

**What this is not:** a round robin. Long-run counts are about as uneven as random (modulo spread 4-10 across 8 buckets on TabPFN, 8-16 on tabpfn-extensions; random baseline 4-11 and 8-18), because the PR numbers that reach this workflow are sparse - it fires only for forks and Dependabot, and PR numbers share a counter with issues. Equal counts per reviewer would need stored state or GitHub's own team-based review assignment. This fixes the clustering, not the fairness, and the comment in the workflow says so.

Side benefit: it is idempotent. A reopen or ready-for-review re-request now names the same person instead of possibly adding a second reviewer.

Same change is going into the other copy of this workflow (TabPFN and tabpfn-extensions are the only two repos that have it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
