### PR TITLE
Add "fp8" as a KV cache precision

### DIFF
--- a/changelog/1157.added.md
+++ b/changelog/1157.added.md
@@ -1,0 +1,1 @@
+Add fp8 kv cache dtype.

--- a/src/tabpfn/architectures/kv_cache.py
+++ b/src/tabpfn/architectures/kv_cache.py
@@ -22,6 +22,12 @@ from torch import Tensor
 QUANTIZED_KV_DTYPE: torch.dtype = torch.int8  # default
 FP8_KV_DTYPE: torch.dtype = torch.float8_e4m3fn
 
+#: Storage dtype for each quantized ``kv_cache_precision`` value.
+KV_CACHE_PRECISION_DTYPES: dict[str, torch.dtype] = {
+    "int8": QUANTIZED_KV_DTYPE,
+    "fp8": FP8_KV_DTYPE,
+}
+
 # Low, high, max-magnitude value for each integer dtype.
 # int8 uses the symmetric range [-127, 127] (one code below the full int8
 # range) so that ``-max * scale`` equals ``+max * scale`` and dequantization

--- a/src/tabpfn/architectures/kv_cache.py
+++ b/src/tabpfn/architectures/kv_cache.py
@@ -6,7 +6,7 @@ Provides cache containers for storing key-value projections from attention
 layers, enabling efficient inference by reusing computed values across
 different test sets without storing state inside the model.
 
-Includes optional integer quantization (e.g. int8) via
+Includes optional quantization (int8 or fp8) via
 :class:`QuantizedKVCacheEntry` for reduced memory footprint with per-tensor
 symmetric quantization.
 """
@@ -19,10 +19,10 @@ from dataclasses import dataclass, field
 import torch
 from torch import Tensor
 
-# only supported KV quantization so far
-QUANTIZED_KV_DTYPE: torch.dtype = torch.int8
+QUANTIZED_KV_DTYPE: torch.dtype = torch.int8  # default
+FP8_KV_DTYPE: torch.dtype = torch.float8_e4m3fn
 
-# Low, high, max-magnitude value for each dtype.
+# Low, high, max-magnitude value for each integer dtype.
 # int8 uses the symmetric range [-127, 127] (one code below the full int8
 # range) so that ``-max * scale`` equals ``+max * scale`` and dequantization
 # cannot exceed the original absmax in magnitude.
@@ -30,32 +30,44 @@ _QUANTIZATION_RANGES: dict[torch.dtype, tuple[int, int, int]] = {
     torch.int8: (-127, 127, 127),
 }
 
+# Float dtypes are scaled onto the representable range and rounded by the
+# dtype cast. e4m3fn has no infinity, so the clamp is required: casting a
+# value above the max would produce NaN.
+_FLOAT_QUANTIZATION_DTYPES = (torch.float8_e4m3fn,)
+
 
 def _quantize_tensor(
     t: Tensor, dtype: torch.dtype = torch.int8
 ) -> tuple[Tensor, Tensor]:
-    """Per-tensor symmetric quantization to the given integer *dtype*.
+    """Per-tensor symmetric quantization to the given *dtype*.
 
-    Returns ``(quantized, scale)`` where
-    ``scale = absmax / max_val`` and ``quantized = round(t / scale)``.
+    Returns ``(quantized, scale)`` where ``scale = absmax / max_val`` and
+    ``quantized ~= t / scale``, so ``float = quantized * scale``.
     """
-    if dtype not in _QUANTIZATION_RANGES:
+    if dtype in _QUANTIZATION_RANGES:
+        lo, hi, max_val = _QUANTIZATION_RANGES[dtype]
+    elif dtype in _FLOAT_QUANTIZATION_DTYPES:
+        max_val = torch.finfo(dtype).max
+        lo, hi = -max_val, max_val
+    else:
         raise ValueError(
-            f"Unsupported quantization dtype {dtype}. "
-            f"Supported: {list(_QUANTIZATION_RANGES)}"
+            f"Unsupported quantization dtype {dtype}. Supported: "
+            f"{list(_QUANTIZATION_RANGES) + list(_FLOAT_QUANTIZATION_DTYPES)}"
         )
-    lo, hi, max_val = _QUANTIZATION_RANGES[dtype]
     absmax = t.abs().amax()
     scale = absmax / float(max_val)
     # Avoid division by zero for all-zero tensors; floor at scale.dtype's
     # smallest positive normal so the clamp is representable in any dtype.
     scale = torch.clamp(scale, min=torch.finfo(scale.dtype).tiny)
-    quantized = (t / scale).round().clamp(lo, hi).to(dtype)
+    scaled = t / scale
+    if dtype in _QUANTIZATION_RANGES:
+        scaled = scaled.round()
+    quantized = scaled.clamp(lo, hi).to(dtype)
     return quantized, scale
 
 
 def _dequantize_tensor(t: Tensor, scale: Tensor, dtype: torch.dtype) -> Tensor:
-    """Dequantize an integer tensor back to floating-point *dtype*."""
+    """Dequantize a quantized tensor back to floating-point *dtype*."""
     return t.to(dtype) * scale.to(dtype)
 
 
@@ -87,7 +99,7 @@ class KVCacheEntry:
         """Quantize this entry with per-tensor symmetric scaling.
 
         Args:
-            dtype: Target integer dtype (default `QUANTIZED_KV_DTYPE`).
+            dtype: Target quantization dtype (default `QUANTIZED_KV_DTYPE`).
         """
         assert self.is_valid()
         k_q, k_s = _quantize_tensor(self.key, dtype)
@@ -97,11 +109,11 @@ class KVCacheEntry:
 
 @dataclass
 class QuantizedKVCacheEntry:
-    """Quantized key-value cache entry with per-tensor scale factors.
+    """Quantized key-value cache entry with scale factors.
 
-    Stores K/V as integer tensors alongside scalar scale factors for
-    symmetric quantization: ``float_value = int_value * scale``. The
-    integer dtype is implicit in the stored tensors (see ``self.key.dtype``);
+    Stores K/V as quantized tensors alongside scale factors for symmetric
+    quantization: ``float_value = quantized_value * scale``. The quantized
+    dtype is implicit in the stored tensors (see ``self.key.dtype``);
     the scale already encodes the dtype's quantization range, so dequantizing
     requires no extra dtype bookkeeping.
 

--- a/src/tabpfn/architectures/tabpfn_v3.py
+++ b/src/tabpfn/architectures/tabpfn_v3.py
@@ -262,7 +262,7 @@ def get_cache_size(
     n_features: int,
     model_config: TabPFNV3Config,
     base_dtype: torch.dtype | Literal["autocast"],
-    kv_cache_precision: Literal["auto", "int8"] = "int8",
+    kv_cache_precision: Literal["auto", "int8", "fp8"] = "int8",
 ) -> int:
     """Calculate the cached memory in bytes for a single TabPFN v3 estimator.
 
@@ -306,21 +306,20 @@ def get_cache_size(
             ``"autocast"`` (GPU autocast path -- KV and ``train_embeddings`` are
             sized at fp16 while ``inducing_hidden`` and ``scaler_cache`` stay
             fp32, since autocast keeps those ops in fp32).
-        kv_cache_precision: If ``"int8"`` (default), the KV cache is sized at
-            :data:`~tabpfn.architectures.kv_cache.QUANTIZED_KV_DTYPE` plus
-            per-tensor scales; if ``"auto"``, K/V are sized at the compute
-            dtype with no scales.
+        kv_cache_precision: If ``"int8"`` (default) or ``"fp8"``, the KV cache
+            is sized at one byte per element plus scales; if ``"auto"``, K/V
+            are sized at the compute dtype with no scales.
 
     Returns:
         Per-estimator cache size in bytes. Multiply by the ensemble size for the
         total (each estimator holds its own cache); divide by ``1024 ** 2`` for MB.
     """
-    if kv_cache_precision not in ("auto", "int8"):
+    if kv_cache_precision not in ("auto", "int8", "fp8"):
         raise ValueError(
             f"Invalid kv_cache_precision: {kv_cache_precision}. "
-            "Must be one of 'auto' or 'int8'."
+            "Must be one of 'auto', 'int8' or 'fp8'."
         )
-    quantize_kv_cache = kv_cache_precision == "int8"
+    quantize_kv_cache = kv_cache_precision in ("int8", "fp8")
 
     # Set the stored dtype of each cached component up front. On the forced-
     # precision path the model and inputs are cast to ``dtype``, so every
@@ -1966,7 +1965,7 @@ class TabPFNV3(Architecture):
 
     @override
     def get_supported_kv_cache_precisions(self) -> tuple[str, ...]:
-        return ("auto", "int8")
+        return ("auto", "int8", "fp8")
 
     def _prepare_y(
         self,

--- a/src/tabpfn/base.py
+++ b/src/tabpfn/base.py
@@ -290,7 +290,7 @@ def create_inference_engine(  # noqa: PLR0913
     use_autocast_: bool,
     inference_mode: bool = True,
     keep_cache_on_device: bool = True,
-    kv_cache_precision: Literal["auto", "int8"] | None = None,
+    kv_cache_precision: Literal["auto", "int8", "fp8"] | None = None,
 ) -> InferenceEngine:
     """Create the appropriate TabPFN inference engine based on `fit_mode`.
 
@@ -321,7 +321,8 @@ def create_inference_engine(  # noqa: PLR0913
             against what the architecture supports. ``None`` (default) picks the
             architecture default (``"int8"`` when it can quantize, else
             ``"auto"``); ``"int8"`` quantizes the KV cache to save memory;
-            ``"auto"`` keeps the computed dtype.
+            ``"fp8"`` stores it as 8-bit floats (same size, float rounding
+            semantics); ``"auto"`` keeps the computed dtype.
     """
     if fit_mode == "low_memory":
         return InferenceEngineOnDemand(

--- a/src/tabpfn/classifier.py
+++ b/src/tabpfn/classifier.py
@@ -233,7 +233,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
         ] = "fit_preprocessors",
         memory_saving_mode: MemorySavingMode = "auto",
         keep_cache_on_device: bool = True,
-        kv_cache_precision: Literal["auto", "int8"] | None = None,
+        kv_cache_precision: Literal["auto", "int8", "fp8"] | None = None,
         random_state: int | np.random.RandomState | np.random.Generator | None = 0,
         n_jobs: Annotated[int | None, deprecated("Use n_preprocessing_jobs")] = None,
         n_preprocessing_jobs: int = 1,
@@ -425,9 +425,11 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
                 what the model architecture supports. `None` (default) picks the
                 architecture default (`"int8"` when it can quantize, e.g. TabPFN-3,
                 else `"auto"`); `"int8"` quantizes the key-value cache to save
-                memory; `"auto"` keeps the computed dtype. Requesting `"int8"` on
-                an architecture that cannot quantize warns and falls back to
-                `"auto"`.
+                memory; `"fp8"` stores it as 8-bit floats instead (same size,
+                float rounding semantics — plain tensor casts, no accelerator
+                requirements); `"auto"` keeps the computed dtype. Requesting a
+                quantized precision on an architecture that cannot quantize
+                warns and falls back to `"auto"`.
 
             random_state:
                 Controls the randomness of the model. Pass an int for reproducible

--- a/src/tabpfn/classifier.py
+++ b/src/tabpfn/classifier.py
@@ -426,8 +426,8 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
                 architecture default (`"int8"` when it can quantize, e.g. TabPFN-3,
                 else `"auto"`); `"int8"` quantizes the key-value cache to save
                 memory; `"fp8"` stores it as 8-bit floats instead (same size,
-                float rounding semantics — plain tensor casts, no accelerator
-                requirements); `"auto"` keeps the computed dtype. Requesting a
+                float rounding semantics; not supported on MPS);
+                `"auto"` keeps the computed dtype. Requesting a
                 quantized precision on an architecture that cannot quantize
                 warns and falls back to `"auto"`.
 

--- a/src/tabpfn/inference.py
+++ b/src/tabpfn/inference.py
@@ -19,6 +19,7 @@ from typing_extensions import override
 import joblib
 import torch
 
+from tabpfn.architectures.kv_cache import FP8_KV_DTYPE
 from tabpfn.architectures.shared.workaround_mps_linear_bug import (
     maybe_replace_linears_on_mps,
 )
@@ -823,10 +824,10 @@ class InferenceEngineCachePreprocessing(MultiDeviceInferenceEngine):
 
 
 def resolve_kv_cache_precision(
-    kv_cache_precision: Literal["auto", "int8"] | None,
+    kv_cache_precision: Literal["auto", "int8", "fp8"] | None,
     *,
     architecture: Architecture,
-) -> Literal["auto", "int8"]:
+) -> Literal["auto", "int8", "fp8"]:
     """Resolve the KV cache dtype against ``architecture``."""
     supported = architecture.get_supported_kv_cache_precisions()
     if kv_cache_precision is None:
@@ -859,7 +860,9 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
 
     For TabPFN-3 models, ``kv_cache_precision="int8"`` (the default) stores the KV
     cache with per-tensor symmetric quantization to save memory, dequantizing
-    on-the-fly in the attention layer; ``"auto"`` keeps the computed dtype.
+    on-the-fly in the attention layer; ``"fp8"`` stores it as 8-bit floats
+    instead (same size, float rounding semantics); ``"auto"`` keeps the
+    computed dtype.
 
     At predict, only X_test is preprocessed (CPU and GPU). The model is
     called with ``x_is_test_only=True``. ``y`` still carries the full
@@ -879,7 +882,7 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
         save_peak_mem: MemorySavingMode,
         autocast: bool,
         keep_cache_on_device: bool = True,
-        kv_cache_precision: Literal["auto", "int8"] | None = None,
+        kv_cache_precision: Literal["auto", "int8", "fp8"] | None = None,
     ) -> None:
         """Initialize the explicit KV cache inference engine.
 
@@ -908,8 +911,9 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
                 what the architecture supports (see
                 :func:`resolve_kv_cache_precision`). ``None`` (default) picks the
                 architecture default (``"int8"`` when it can quantize, else
-                ``"auto"``); ``"int8"`` quantizes to save memory; ``"auto"``
-                keeps the computed dtype.
+                ``"auto"``); ``"int8"`` quantizes to save memory; ``"fp8"``
+                stores 8-bit floats instead; ``"auto"`` keeps the computed
+                dtype.
         """
         super().__init__(
             model_caches=[_PerDeviceModelCache(model) for model in models],
@@ -1039,6 +1043,8 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
         assert cache is not None
         if kv_cache_precision == "int8":
             cache = cache.quantize()
+        elif kv_cache_precision == "fp8":
+            cache = cache.quantize(FP8_KV_DTYPE)
         if self.keep_cache_on_device:
             return cache
         return cache.to("cpu")

--- a/src/tabpfn/inference.py
+++ b/src/tabpfn/inference.py
@@ -19,7 +19,7 @@ from typing_extensions import override
 import joblib
 import torch
 
-from tabpfn.architectures.kv_cache import FP8_KV_DTYPE
+from tabpfn.architectures.kv_cache import KV_CACHE_PRECISION_DTYPES
 from tabpfn.architectures.shared.workaround_mps_linear_bug import (
     maybe_replace_linears_on_mps,
 )
@@ -827,8 +827,20 @@ def resolve_kv_cache_precision(
     kv_cache_precision: Literal["auto", "int8", "fp8"] | None,
     *,
     architecture: Architecture,
+    device: torch.device,
 ) -> Literal["auto", "int8", "fp8"]:
-    """Resolve the KV cache dtype against ``architecture``."""
+    """Resolve the KV cache dtype against ``architecture`` and ``device``.
+
+    Raises:
+        ValueError: If ``"fp8"`` is requested on MPS, which has no float8
+            casts. Rejected here, before any fitting work starts; the rest of
+            the fp8 path can then assume a capable device.
+    """
+    if kv_cache_precision == "fp8" and device.type == "mps":
+        raise ValueError(
+            "kv_cache_precision='fp8' is not supported on MPS: PyTorch cannot "
+            "cast to float8 dtypes there. Use 'int8' (the default) or 'auto'."
+        )
     supported = architecture.get_supported_kv_cache_precisions()
     if kv_cache_precision is None:
         return "int8" if "int8" in supported else "auto"
@@ -987,7 +999,7 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
         """
         model = self.model_caches[model_index].get(device)
         kv_cache_precision = resolve_kv_cache_precision(
-            self.kv_cache_precision, architecture=model
+            self.kv_cache_precision, architecture=model, device=device
         )
 
         # Cast model weights to match force_inference_dtype (else linear
@@ -1041,10 +1053,8 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
             )
 
         assert cache is not None
-        if kv_cache_precision == "int8":
-            cache = cache.quantize()
-        elif kv_cache_precision == "fp8":
-            cache = cache.quantize(FP8_KV_DTYPE)
+        if kv_cache_precision != "auto":
+            cache = cache.quantize(KV_CACHE_PRECISION_DTYPES[kv_cache_precision])
         if self.keep_cache_on_device:
             return cache
         return cache.to("cpu")

--- a/src/tabpfn/inference.py
+++ b/src/tabpfn/inference.py
@@ -823,7 +823,7 @@ class InferenceEngineCachePreprocessing(MultiDeviceInferenceEngine):
         self.inference_mode = use_inference
 
 
-def resolve_kv_cache_precision(
+def _resolve_kv_cache_precision(
     kv_cache_precision: Literal["auto", "int8", "fp8"] | None,
     *,
     architecture: Architecture,
@@ -921,7 +921,7 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
                 transferred to the target device on every predict call.
             kv_cache_precision: Dtype the KV cache is stored in, resolved against
                 what the architecture supports (see
-                :func:`resolve_kv_cache_precision`). ``None`` (default) picks the
+                :func:`_resolve_kv_cache_precision`). ``None`` (default) picks the
                 architecture default (``"int8"`` when it can quantize, else
                 ``"auto"``); ``"int8"`` quantizes to save memory; ``"fp8"``
                 stores 8-bit floats instead; ``"auto"`` keeps the computed
@@ -936,7 +936,7 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
 
         self.keep_cache_on_device = keep_cache_on_device
         # Kept as the raw request; resolved per ensemble member in _build_cache
-        # against that member's own architecture (see resolve_kv_cache_precision).
+        # against that member's own architecture (see _resolve_kv_cache_precision).
         self.kv_cache_precision = kv_cache_precision
         self.ensemble_preprocessor = ensemble_preprocessor
 
@@ -998,7 +998,7 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
         in parallel threads.
         """
         model = self.model_caches[model_index].get(device)
-        kv_cache_precision = resolve_kv_cache_precision(
+        kv_cache_precision = _resolve_kv_cache_precision(
             self.kv_cache_precision, architecture=model, device=device
         )
 

--- a/src/tabpfn/regressor.py
+++ b/src/tabpfn/regressor.py
@@ -427,8 +427,8 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
                 architecture default (`"int8"` when it can quantize, e.g. TabPFN-3,
                 else `"auto"`); `"int8"` quantizes the key-value cache to save
                 memory; `"fp8"` stores it as 8-bit floats instead (same size,
-                float rounding semantics — plain tensor casts, no accelerator
-                requirements); `"auto"` keeps the computed dtype. Requesting a
+                float rounding semantics; not supported on MPS);
+                `"auto"` keeps the computed dtype. Requesting a
                 quantized precision on an architecture that cannot quantize
                 warns and falls back to `"auto"`.
 

--- a/src/tabpfn/regressor.py
+++ b/src/tabpfn/regressor.py
@@ -243,7 +243,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
         ] = "fit_preprocessors",
         memory_saving_mode: MemorySavingMode = "auto",
         keep_cache_on_device: bool = True,
-        kv_cache_precision: Literal["auto", "int8"] | None = None,
+        kv_cache_precision: Literal["auto", "int8", "fp8"] | None = None,
         random_state: int | np.random.RandomState | np.random.Generator | None = 0,
         n_jobs: Annotated[int | None, deprecated("Use n_preprocessing_jobs")] = None,
         n_preprocessing_jobs: int = 1,
@@ -426,9 +426,11 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
                 what the model architecture supports. `None` (default) picks the
                 architecture default (`"int8"` when it can quantize, e.g. TabPFN-3,
                 else `"auto"`); `"int8"` quantizes the key-value cache to save
-                memory; `"auto"` keeps the computed dtype. Requesting `"int8"` on
-                an architecture that cannot quantize warns and falls back to
-                `"auto"`.
+                memory; `"fp8"` stores it as 8-bit floats instead (same size,
+                float rounding semantics — plain tensor casts, no accelerator
+                requirements); `"auto"` keeps the computed dtype. Requesting a
+                quantized precision on an architecture that cannot quantize
+                warns and falls back to `"auto"`.
 
             random_state:
                 Controls the randomness of the model. Pass an int for reproducible

--- a/tests/test_architectures/test_kv_cache.py
+++ b/tests/test_architectures/test_kv_cache.py
@@ -1,0 +1,155 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+"""Tests for KV cache quantization, including the fp8 storage format.
+
+Everything here is hardware-independent: fp8 KV storage is plain tensor casts
+(``quantized = clamp(t / scale)`` cast to ``float8_e4m3fn``, ``float =
+quantized * scale`` back), so the whole suite runs on CPU.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+
+from tabpfn import TabPFNClassifier
+from tabpfn.architectures.kv_cache import (
+    FP8_KV_DTYPE,
+    KVCacheEntry,
+    _dequantize_tensor,
+    _quantize_tensor,
+)
+from tabpfn.architectures.tabpfn_v3 import TabPFNV3Config, get_cache_size
+from tabpfn.inference import resolve_kv_cache_precision
+
+
+def _kv_tensor(seed: int = 0) -> torch.Tensor:
+    torch.manual_seed(seed)
+    # (B, N, num_kv_heads, head_dim), with per-head magnitude variation so
+    # per-head scales actually differ.
+    t = torch.randn(2, 64, 4, 8)
+    return t * torch.tensor([0.1, 1.0, 5.0, 50.0]).view(1, 1, 4, 1)
+
+
+def test_fp8_roundtrip_error_band() -> None:
+    t = _kv_tensor()
+    quantized, scale = _quantize_tensor(t, FP8_KV_DTYPE)
+    assert quantized.dtype == FP8_KV_DTYPE
+    restored = _dequantize_tensor(quantized, scale, torch.float32)
+    # e4m3 has a 3-bit mantissa: a few percent relative error.
+    assert (restored - t).norm() / t.norm() < 0.05
+
+
+def test_fp8_uses_the_same_scalar_scale_contract_as_int8() -> None:
+    t = _kv_tensor()
+    _, scale = _quantize_tensor(t, FP8_KV_DTYPE)
+    assert scale.dim() == 0
+    # Unlike int8's uniform grid, fp8's relative precision is unaffected by
+    # the per-head amplitude spread under a single scale.
+    for head in range(4):
+        head_slice = t[:, :, head]
+        quantized, s = _quantize_tensor(t, FP8_KV_DTYPE)
+        restored = _dequantize_tensor(quantized, s, torch.float32)[:, :, head]
+        assert (restored - head_slice).norm() / head_slice.norm() < 0.05
+
+
+def test_int8_behaviour_unchanged() -> None:
+    t = _kv_tensor()
+    quantized, scale = _quantize_tensor(t, torch.int8)
+    assert quantized.dtype == torch.int8
+    assert scale.dim() == 0  # per-tensor scalar, as before
+    restored = _dequantize_tensor(quantized, scale, torch.float32)
+    # int8's uniform grid is dominated by the loudest head here, so the
+    # tolerance is loose; the point is the code path is untouched.
+    assert (restored - t).norm() / t.norm() < 0.2
+
+
+def test_fp8_never_produces_nan_and_respects_absmax() -> None:
+    # e4m3fn has no inf: values above the max would become NaN without the
+    # clamp. Include an extreme outlier and an all-zero tensor.
+    t = _kv_tensor()
+    t[0, 0, 0, 0] = 1e30
+    quantized, scale = _quantize_tensor(t, FP8_KV_DTYPE)
+    restored = _dequantize_tensor(quantized, scale, torch.float32)
+    assert not torch.isnan(restored).any()
+    assert restored.abs().max() <= t.abs().max() * 1.01
+
+    zeros = torch.zeros(1, 4, 2, 8)
+    quantized, scale = _quantize_tensor(zeros, FP8_KV_DTYPE)
+    assert torch.all(_dequantize_tensor(quantized, scale, torch.float32) == 0)
+
+
+def test_unsupported_dtype_raises() -> None:
+    with pytest.raises(ValueError, match="Unsupported quantization dtype"):
+        _quantize_tensor(_kv_tensor(), torch.int16)
+
+
+def test_entry_quantize_to_fp8_and_back() -> None:
+    k, v = _kv_tensor(1), _kv_tensor(2)
+    entry = KVCacheEntry(key=k, value=v).quantize(FP8_KV_DTYPE)
+    assert entry.key.dtype == FP8_KV_DTYPE
+    assert entry.value.dtype == FP8_KV_DTYPE
+    restored = entry.dequantize(torch.float32)
+    assert (restored.key - k).norm() / k.norm() < 0.05
+    assert (restored.value - v).norm() / v.norm() < 0.05
+
+
+class _FakeArchitecture:
+    def __init__(self, supported: tuple[str, ...]):
+        self._supported = supported
+
+    def get_supported_kv_cache_precisions(self) -> tuple[str, ...]:
+        return self._supported
+
+
+def test_resolve_accepts_fp8_and_default_stays_int8() -> None:
+    arch = _FakeArchitecture(("auto", "int8", "fp8"))
+    assert resolve_kv_cache_precision("fp8", architecture=arch) == "fp8"
+    # The default is unchanged by this feature: unset still resolves to int8.
+    assert resolve_kv_cache_precision(None, architecture=arch) == "int8"
+
+
+def test_resolve_falls_back_to_auto_when_unsupported() -> None:
+    arch = _FakeArchitecture(("auto",))
+    with pytest.warns(UserWarning, match="not supported"):
+        assert resolve_kv_cache_precision("fp8", architecture=arch) == "auto"
+
+
+def test_get_cache_size_accepts_fp8() -> None:
+    config = TabPFNV3Config()
+    kwargs = {
+        "n_train": 1000,
+        "n_features": 20,
+        "model_config": config,
+        "base_dtype": torch.float32,
+    }
+    # int8 and fp8 are both one byte per element plus scales.
+    assert get_cache_size(kv_cache_precision="fp8", **kwargs) == get_cache_size(
+        kv_cache_precision="int8", **kwargs
+    )
+    with pytest.raises(ValueError, match="Invalid kv_cache_precision"):
+        get_cache_size(kv_cache_precision="int4", **kwargs)  # type: ignore[arg-type]
+
+
+def test_classifier_fp8_cache_end_to_end_on_cpu() -> None:
+    """The whole feature is tensor casts only, so it must work on plain CPU."""
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(60, 4))
+    y = (X[:, 0] + rng.normal(scale=0.3, size=60) > 0).astype(int)
+    clf = TabPFNClassifier(
+        fit_mode="fit_with_cache",
+        kv_cache_precision="fp8",
+        n_estimators=1,
+        device="cpu",
+        random_state=0,
+    )
+    clf.fit(X[:40], y[:40])
+    dtypes = {
+        entry.key.dtype
+        for cache in clf.executor_.kv_caches
+        for entry in cache.kv.values()
+    }
+    assert dtypes == {FP8_KV_DTYPE}
+    proba = clf.predict_proba(X[40:])
+    assert np.all(np.isfinite(proba))
+    assert proba.shape == (20, 2)

--- a/tests/test_architectures/test_kv_cache.py
+++ b/tests/test_architectures/test_kv_cache.py
@@ -20,7 +20,7 @@ from tabpfn.architectures.kv_cache import (
     _quantize_tensor,
 )
 from tabpfn.architectures.tabpfn_v3 import TabPFNV3Config, get_cache_size
-from tabpfn.inference import resolve_kv_cache_precision
+from tabpfn.inference import _resolve_kv_cache_precision
 
 
 def _kv_tensor(seed: int = 0) -> torch.Tensor:
@@ -105,16 +105,16 @@ class _FakeArchitecture:
 def test_resolve_accepts_fp8_and_default_stays_int8() -> None:
     arch = _FakeArchitecture(("auto", "int8", "fp8"))
     cpu = torch.device("cpu")
-    assert resolve_kv_cache_precision("fp8", architecture=arch, device=cpu) == "fp8"
+    assert _resolve_kv_cache_precision("fp8", architecture=arch, device=cpu) == "fp8"
     # The default is unchanged by this feature: unset still resolves to int8.
-    assert resolve_kv_cache_precision(None, architecture=arch, device=cpu) == "int8"
+    assert _resolve_kv_cache_precision(None, architecture=arch, device=cpu) == "int8"
 
 
 def test_resolve_falls_back_to_auto_when_unsupported() -> None:
     arch = _FakeArchitecture(("auto",))
     with pytest.warns(UserWarning, match="not supported"):
         assert (
-            resolve_kv_cache_precision(
+            _resolve_kv_cache_precision(
                 "fp8", architecture=arch, device=torch.device("cpu")
             )
             == "auto"
@@ -125,7 +125,9 @@ def test_resolve_rejects_fp8_on_mps() -> None:
     """MPS has no float8 casts; requesting fp8 there fails fast at resolution."""
     arch = _FakeArchitecture(("auto", "int8", "fp8"))
     with pytest.raises(ValueError, match="not supported on MPS"):
-        resolve_kv_cache_precision("fp8", architecture=arch, device=torch.device("mps"))
+        _resolve_kv_cache_precision(
+            "fp8", architecture=arch, device=torch.device("mps")
+        )
 
 
 def test_get_cache_size_accepts_fp8() -> None:

--- a/tests/test_architectures/test_kv_cache.py
+++ b/tests/test_architectures/test_kv_cache.py
@@ -104,15 +104,28 @@ class _FakeArchitecture:
 
 def test_resolve_accepts_fp8_and_default_stays_int8() -> None:
     arch = _FakeArchitecture(("auto", "int8", "fp8"))
-    assert resolve_kv_cache_precision("fp8", architecture=arch) == "fp8"
+    cpu = torch.device("cpu")
+    assert resolve_kv_cache_precision("fp8", architecture=arch, device=cpu) == "fp8"
     # The default is unchanged by this feature: unset still resolves to int8.
-    assert resolve_kv_cache_precision(None, architecture=arch) == "int8"
+    assert resolve_kv_cache_precision(None, architecture=arch, device=cpu) == "int8"
 
 
 def test_resolve_falls_back_to_auto_when_unsupported() -> None:
     arch = _FakeArchitecture(("auto",))
     with pytest.warns(UserWarning, match="not supported"):
-        assert resolve_kv_cache_precision("fp8", architecture=arch) == "auto"
+        assert (
+            resolve_kv_cache_precision(
+                "fp8", architecture=arch, device=torch.device("cpu")
+            )
+            == "auto"
+        )
+
+
+def test_resolve_rejects_fp8_on_mps() -> None:
+    """MPS has no float8 casts; requesting fp8 there fails fast at resolution."""
+    arch = _FakeArchitecture(("auto", "int8", "fp8"))
+    with pytest.raises(ValueError, match="not supported on MPS"):
+        resolve_kv_cache_precision("fp8", architecture=arch, device=torch.device("mps"))
 
 
 def test_get_cache_size_accepts_fp8() -> None:

--- a/tests/test_architectures/test_tabpfn_v3.py
+++ b/tests/test_architectures/test_tabpfn_v3.py
@@ -15,6 +15,7 @@ from tabpfn import TabPFNClassifier
 from tabpfn.architectures import tabpfn_v3
 from tabpfn.architectures.interface import PerformanceOptions
 from tabpfn.architectures.kv_cache import (
+    FP8_KV_DTYPE,
     KVCacheEntry,
     QuantizedKVCacheEntry,
 )
@@ -614,20 +615,24 @@ def _build_cache(
     x: torch.Tensor,
     y: torch.Tensor,
     *,
-    kv_cache_precision: Literal["auto", "int8"],
+    kv_cache_precision: Literal["auto", "int8", "fp8"],
 ) -> TabPFNV3Cache:
     """Build a cache the way the inference engine does: forward to populate it,
-    then apply the ``kv_cache_precision="int8"`` step (``cache.quantize()``).
+    then apply the quantization step for the requested precision.
     """
     _, cache = arch(x, y, return_kv_cache=True)
-    return cache.quantize() if kv_cache_precision == "int8" else cache
+    if kv_cache_precision == "int8":
+        return cache.quantize()
+    if kv_cache_precision == "fp8":
+        return cache.quantize(FP8_KV_DTYPE)
+    return cache
 
 
 @torch.no_grad()
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
-@pytest.mark.parametrize("kv_cache_precision", ["int8", "auto"])
+@pytest.mark.parametrize("kv_cache_precision", ["int8", "fp8", "auto"])
 def test__calculate_cache_size__matches_whole_classifier_cache(
-    kv_cache_precision: Literal["auto", "int8"],
+    kv_cache_precision: Literal["auto", "int8", "fp8"],
     dtype: torch.dtype,
 ) -> None:
     """get_cache_size equals the exact byte size of every tensor in a real
@@ -668,9 +673,9 @@ def test__calculate_cache_size__matches_whole_classifier_cache(
     reason="Autocast inference is only enabled on CUDA (disabled on CPU/MPS), so "
     "the mixed-precision cache it produces can only be built on a GPU.",
 )
-@pytest.mark.parametrize("kv_cache_precision", ["int8", "auto"])
+@pytest.mark.parametrize("kv_cache_precision", ["int8", "fp8", "auto"])
 def test__calculate_cache_size__matches_whole_classifier_cache_autocast(
-    kv_cache_precision: Literal["auto", "int8"],
+    kv_cache_precision: Literal["auto", "int8", "fp8"],
 ) -> None:
     """get_cache_size matches the exact byte size of a real classifier cache built
     on the GPU autocast path (the default for ``inference_precision='auto'`` on a
@@ -697,6 +702,8 @@ def test__calculate_cache_size__matches_whole_classifier_cache_autocast(
         _, cache = arch(x, y, return_kv_cache=True)
     if kv_cache_precision == "int8":
         cache = cache.quantize()
+    elif kv_cache_precision == "fp8":
+        cache = cache.quantize(FP8_KV_DTYPE)
 
     total = get_cache_size(
         n_train=n_train,

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -27,7 +27,7 @@ from tabpfn.inference import (
     InferenceEngineExplicitKVCache,
     InferenceEngineOnDemand,
     MultiDeviceInferenceEngine,
-    resolve_kv_cache_precision,
+    _resolve_kv_cache_precision,
 )
 from tabpfn.preprocessing import (
     ClassifierEnsembleConfig,
@@ -903,7 +903,7 @@ def test__resolve_kv_cache_precision__warns_when_unsupported() -> None:
         cache_trainset_representation=False,
     )
     with pytest.warns(UserWarning, match="not supported"):
-        resolved = resolve_kv_cache_precision(
+        resolved = _resolve_kv_cache_precision(
             "int8", architecture=arch, device=torch.device("cpu")
         )
     assert resolved == "auto"

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -903,5 +903,7 @@ def test__resolve_kv_cache_precision__warns_when_unsupported() -> None:
         cache_trainset_representation=False,
     )
     with pytest.warns(UserWarning, match="not supported"):
-        resolved = resolve_kv_cache_precision("int8", architecture=arch)
+        resolved = resolve_kv_cache_precision(
+            "int8", architecture=arch, device=torch.device("cpu")
+        )
     assert resolved == "auto"


### PR DESCRIPTION
[RES-2356: Add FP8 KV cache dtype](https://linear.app/priorlabs/issue/RES-2356/add-fp8-kv-cache-dtype)

Adds FP8 KV cache as another option, without changing any default behavior.
---

## Public API Changes

-   [ ] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?

---

## Checklist

-   [ ] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [ ] A changelog entry has been added (see `changelog/README.md`), or "no changelog needed" label requested.
-   [ ] The code follows the project's style guidelines.
-   [ ] I have considered the impact of these changes on the public API.

---
