### PR TITLE
Add workflow that re-approves PRs from team members.

### DIFF
--- a/.github/workflows/reapprove-internal-prs.yml
+++ b/.github/workflows/reapprove-internal-prs.yml
@@ -1,0 +1,118 @@
+# Automatically re-approve PRs from PriorLabs org members when new code is pushed.
+#
+# The branch protection rules require that the most recent push is reviewed and
+# approved, which is important for PRs from external collaborators. However, this is
+# extra overhead for PRs from Prior Labs members, where we might want to request small
+# changes during review and trust that the author will apply these. In this case,
+# approve the current version of the PR if a previous version was already approved.
+name: Re-approve internal PRs
+
+on:
+  pull_request:
+    types: [synchronize]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  reapprove:
+    name: Restore dismissed approval
+    # MEMBER means the author is a member of the organisation that owns the repository.
+    # Also check if the PR came from a fork, to avoid approving PRs from member's forks,
+    # and for defence in depth.
+    if: >
+      (
+        github.event.pull_request.author_association == 'MEMBER' ||
+        github.event.pull_request.author_association == 'OWNER'
+      ) &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-slim
+    steps:
+      - name: Restore approval dismissed by this push
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pullNumber = context.payload.pull_request.number;
+
+            const isHuman = (user) => user?.type === "User";
+
+            // The push that triggered this run also dismisses the existing approvals,
+            // and there is no ordering guarantee between the two. Thus, wait 10 seconds
+            // to give the dismissal more time to process.
+            await new Promise((resolve) => setTimeout(resolve, 10000));
+
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              owner,
+              repo,
+              pull_number: pullNumber,
+              per_page: 100,
+            });
+
+            if (reviews.some((r) => r.state === "APPROVED" && isHuman(r.user))) {
+              core.info("PR still has a standing human approval, nothing to restore.");
+              return;
+            }
+
+            // Once a review is dismissed its entry in the reviews list reports state
+            // DISMISSED, which does not say whether it was an approval or a change
+            // request. Only the review_dismissed timeline event keeps the original
+            // state, so the evidence that a human really did approve has to come from
+            // there.
+            const timeline = await github.paginate(
+              github.rest.issues.listEventsForTimeline,
+              { owner, repo, issue_number: pullNumber, per_page: 100 },
+            );
+
+            const reviewsById = new Map(reviews.map((r) => [r.id, r]));
+
+            // dismissal_commit_id is set when the stale review rule dismissed the
+            // approval because of a push, and unset when a reviewer dismissed it by
+            // hand. A reviewer withdrawing their approval deliberately should stay
+            // withdrawn, so only push dismissals count.
+            const restorable = timeline
+              .filter((e) => e.event === "review_dismissed")
+              .map((e) => e.dismissed_review)
+              .filter(
+                (d) =>
+                  d?.state === "approved" &&
+                  d.dismissal_commit_id &&
+                  isHuman(reviewsById.get(d.review_id)?.user),
+              )
+              .map((d) => reviewsById.get(d.review_id));
+
+            if (restorable.length === 0) {
+              core.info("PR has not yet been approved by a human, not approving.");
+              return;
+            }
+
+            // A change request survives a push, and outranks an earlier approval from
+            // the same reviewer, so it must not be approved over.
+            const latestStateByReviewer = new Map();
+            for (const review of reviews) {
+              if (isHuman(review.user) && review.state !== "COMMENTED") {
+                latestStateByReviewer.set(review.user.login, review.state);
+              }
+            }
+            const blocking = [...latestStateByReviewer].filter(
+              ([, state]) => state === "CHANGES_REQUESTED",
+            );
+            if (blocking.length > 0) {
+              const who = blocking.map(([login]) => login).join(", ");
+              core.info(`Changes are still requested by ${who}, not approving.`);
+              return;
+            }
+
+            const credits = restorable
+              .map((r) => `@${r.user.login} (${r.commit_id.slice(0, 7)})`)
+              .join(", ");
+            core.info(`Approved, restoring the approval of ${credits}.`);
+            await github.rest.pulls.createReview({
+              owner,
+              repo,
+              pull_number: pullNumber,
+              event: "APPROVE",
+              body:
+                `Restoring the approval of ${credits} after push.\n\n` +
+                "Dismiss this review to require re-review.",
+            });

--- a/.github/workflows/reapprove-internal-prs.yml
+++ b/.github/workflows/reapprove-internal-prs.yml
@@ -31,6 +31,8 @@ jobs:
     # - The dismissed review comes from an org member or owner. Without this, an
     #   external user can trigger this bot to approve a PR by submitting an approval
     #   themselves. Not a big risk, as the PR's author must still be an internal user.
+    #   We include 'github-actions[bot]' so that the workflow can reapprove again after
+    #   a second push from the user.
     # - The PR does not come from a fork, for defence in depth.
     if: >
       (
@@ -61,9 +63,10 @@ jobs:
               per_page: 100,
             });
 
-            // The head can already be approved, either by a human or by an earlier run
-            // of this workflow.
-            if (reviews.some((r) => r.state === "APPROVED" && r.commit_id === headSha)) {
+            // Check if any of the reviews of this PR already approved the head commit.
+            // They might come from a human or an earlier run of the workflow.
+            // In this case, exit early to avoid approving again.
+            if (reviews.some((r) => r.commit_id === headSha && r.state === "APPROVED")) {
               core.info("The current head is already approved, not approving again.");
               return;
             }
@@ -98,9 +101,9 @@ jobs:
             }
 
             core.info("Approving to restore the dismissed approval.");
-            // This approves the current HEAD, not the commit "headSha" that trigerred
+            // This approves the current HEAD, not the commit "headSha" that triggered
             // this workflow. This avoids a race condition when someone makes two pushes
-            // in quick succession, as the workflow would only be trigerred for the
+            // in quick succession, as the workflow would only be triggered for the
             // first one. It's safe, because the push can only come from an org member.
             await github.rest.pulls.createReview({
               owner,

--- a/.github/workflows/reapprove-internal-prs.yml
+++ b/.github/workflows/reapprove-internal-prs.yml
@@ -1,46 +1,58 @@
-# Automatically re-approve PRs from PriorLabs org members when new code is pushed.
+# Automatically reapprove PRs from PriorLabs org members after new code is pushed.
 #
-# The branch protection rules require that the most recent push is reviewed and
-# approved, which is important for PRs from external collaborators. However, this is
-# extra overhead for PRs from Prior Labs members, where we might want to request small
-# changes during review and trust that the author will apply these. In this case,
-# approve the current version of the PR if a previous version was already approved.
-name: Re-approve internal PRs
+# The branch protection rules dismiss all approvals when new code is pushed to a PR, to
+# ensure the most recent push is reviewed and approved. This is important for external
+# collaborators, but is extra overhead for internal PRs where we trust the authors. In
+# this case, the workflow automatically approves the current version of the PR if a
+# previous version was already approved.
+name: Reapprove internal PRs
 
 on:
-  pull_request:
-    types: [synchronize]
+  pull_request_review:
+    types: [dismissed]
 
 permissions:
   pull-requests: write
 
+# One push can dismiss several approvals, and each dismissal starts its own run. Run
+# them one at a time per PR, so that a later run sees the approval an earlier one
+# created instead of adding a duplicate.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+  # We need to check every review that was dismissed, in case it was an approval.
+  queue: max
+
 jobs:
   reapprove:
     name: Restore dismissed approval
-    # MEMBER means the author is a member of the organisation that owns the repository.
-    # Also check if the PR came from a fork, to avoid approving PRs from member's forks,
-    # and for defence in depth.
+    # Three checks:
+    # - This PR comes from an org member or owner
+    # - The dismissed review comes from an org member or owner. Without this, an
+    #   external user can trigger this bot to approve a PR by submitting an approval
+    #   themselves. Not a big risk, as the PR's author must still be an internal user.
+    # - The PR does not come from a fork, for defence in depth.
     if: >
       (
         github.event.pull_request.author_association == 'MEMBER' ||
         github.event.pull_request.author_association == 'OWNER'
       ) &&
+      (
+        github.event.review.author_association == 'MEMBER' ||
+        github.event.review.author_association == 'OWNER' ||
+        github.event.review.user.login == 'github-actions[bot]'
+      ) &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-slim
     steps:
-      - name: Restore approval dismissed by this push
+      - name: Restore the dismissed approval
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { owner, repo } = context.repo;
             const pullNumber = context.payload.pull_request.number;
-
-            const isHuman = (user) => user?.type === "User";
-
-            // The push that triggered this run also dismisses the existing approvals,
-            // and there is no ordering guarantee between the two. Thus, wait 10 seconds
-            // to give the dismissal more time to process.
-            await new Promise((resolve) => setTimeout(resolve, 10000));
+            const headSha = context.payload.pull_request.head.sha;
+            const dismissedReview = context.payload.review;
 
             const reviews = await github.paginate(github.rest.pulls.listReviews, {
               owner,
@@ -49,70 +61,53 @@ jobs:
               per_page: 100,
             });
 
-            if (reviews.some((r) => r.state === "APPROVED" && isHuman(r.user))) {
-              core.info("PR still has a standing human approval, nothing to restore.");
+            // The head can already be approved, either by a human or by an earlier run
+            // of this workflow.
+            if (reviews.some((r) => r.state === "APPROVED" && r.commit_id === headSha)) {
+              core.info("The current head is already approved, not approving again.");
               return;
             }
 
-            // Once a review is dismissed its entry in the reviews list reports state
-            // DISMISSED, which does not say whether it was an approval or a change
-            // request. Only the review_dismissed timeline event keeps the original
-            // state, so the evidence that a human really did approve has to come from
-            // there.
+            // The payload to this workflow doesn't tell us if the dismissed review was
+            // previously an approval, or why it was dismissed. To find this out, we
+            // find the review_dismissed event in the PR timeline.
             const timeline = await github.paginate(
               github.rest.issues.listEventsForTimeline,
               { owner, repo, issue_number: pullNumber, per_page: 100 },
             );
-
-            const reviewsById = new Map(reviews.map((r) => [r.id, r]));
-
-            // dismissal_commit_id is set when the stale review rule dismissed the
-            // approval because of a push, and unset when a reviewer dismissed it by
-            // hand. A reviewer withdrawing their approval deliberately should stay
-            // withdrawn, so only push dismissals count.
-            const restorable = timeline
+            const dismissal = timeline
               .filter((e) => e.event === "review_dismissed")
               .map((e) => e.dismissed_review)
-              .filter(
-                (d) =>
-                  d?.state === "approved" &&
-                  d.dismissal_commit_id &&
-                  isHuman(reviewsById.get(d.review_id)?.user),
-              )
-              .map((d) => reviewsById.get(d.review_id));
-
-            if (restorable.length === 0) {
-              core.info("PR has not yet been approved by a human, not approving.");
+              .find((d) => d?.review_id === dismissedReview.id);
+            if (!dismissal) {
+              core.info(`Found no dismissal of review ${dismissedReview.id}.`);
               return;
             }
 
-            // A change request survives a push, and outranks an earlier approval from
-            // the same reviewer, so it must not be approved over.
-            const latestStateByReviewer = new Map();
-            for (const review of reviews) {
-              if (isHuman(review.user) && review.state !== "COMMENTED") {
-                latestStateByReviewer.set(review.user.login, review.state);
-              }
+            // The dismissed review may not have been an approval (e.g. if it requested
+            // changes), in which case we don't want to approve.
+            if (dismissal.state !== "approved") {
+              core.info("The dismissed review was not an approval, not approving.");
+              return;
             }
-            const blocking = [...latestStateByReviewer].filter(
-              ([, state]) => state === "CHANGES_REQUESTED",
-            );
-            if (blocking.length > 0) {
-              const who = blocking.map(([login]) => login).join(", ");
-              core.info(`Changes are still requested by ${who}, not approving.`);
+            // We only want to reapprove when the dismissal was due to new code being
+            // pushed, not if the reviewer manually dismissed the review.
+            if (!dismissal.dismissal_commit_id) {
+              core.info("The approval was dismissed by hand, not restoring it.");
               return;
             }
 
-            const credits = restorable
-              .map((r) => `@${r.user.login} (${r.commit_id.slice(0, 7)})`)
-              .join(", ");
-            core.info(`Approved, restoring the approval of ${credits}.`);
+            core.info("Approving to restore the dismissed approval.");
+            // This approves the current HEAD, not the commit "headSha" that trigerred
+            // this workflow. This avoids a race condition when someone makes two pushes
+            // in quick succession, as the workflow would only be trigerred for the
+            // first one. It's safe, because the push can only come from an org member.
             await github.rest.pulls.createReview({
               owner,
               repo,
               pull_number: pullNumber,
               event: "APPROVE",
               body:
-                `Restoring the approval of ${credits} after push.\n\n` +
-                "Dismiss this review to require re-review.",
+                "Reapproving after a push, as this is a PR from an internal author " +
+                "and was already approved."
             });


### PR DESCRIPTION
We now require the most recent push to be approved, to avoid external PRs merging unreviewed code. This is too much overhead for internal PRs, so re-approve them automatically.

It's possible this workflow might need the `issues: read` permission to read the timeline, but that's unclear. So try without it first.

Manual testing: merge this, verify that it approves for internal PRs but not for PRs from a fork 