### PR TITLE
Add workflow to send Slack alert when CI fails.

### DIFF
--- a/.github/workflows/slack-ci-alert.yml
+++ b/.github/workflows/slack-ci-alert.yml
@@ -1,0 +1,46 @@
+# Reusable Slack alert that reports CI failures on main.
+#
+# See trigger-slack.ci-alert.yml for how to call it.
+name: Slack CI alert (reusable)
+
+on:
+  workflow_call:
+    secrets:
+      CI_STATUS_SLACK_WEBHOOK_URL:
+        description: Slack incoming webhook URL to post the alert to.
+        required: true
+
+permissions: {}
+
+jobs:
+  notify:
+    if: >
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.event == 'push'
+    runs-on: ubuntu-slim
+    steps:
+      - name: Build Slack payload
+        env:
+          REPO_NAME: ${{ github.event.workflow_run.repository.name }}
+          REPO_URL: ${{ github.event.workflow_run.repository.html_url }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+          AUTHOR: ${{ github.event.workflow_run.head_commit.author.name }}
+          TITLE: ${{ github.event.workflow_run.display_title }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+        run: |
+          jq -n \
+            --arg repo_name "$REPO_NAME" \
+            --arg repo "$REPO_URL" \
+            --arg sha "$SHA" \
+            --arg author "$AUTHOR" \
+            --arg title "$TITLE" \
+            --arg run_url "$RUN_URL" \
+            '{text: (":red_circle: \($repo_name) CI failed on `main`\nCommit: <\($repo)/commit/\($sha)|\($sha)> by \($author)\n_\($title)_\n<\($run_url)|View run>")}' \
+            > "$RUNNER_TEMP/slack-payload.json"
+      - name: Post to Slack
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
+        with:
+          webhook: ${{ secrets.CI_STATUS_SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload-file-path: ${{ runner.temp }}/slack-payload.json

--- a/.github/workflows/trigger-slack-ci-alert.yml
+++ b/.github/workflows/trigger-slack-ci-alert.yml
@@ -1,0 +1,14 @@
+# Send a Slack alert when the CI fails on main.
+name: Slack CI alert
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions: {}
+
+jobs:
+  notify:
+    uses: ./.github/workflows/slack-ci-alert.yml
+    secrets: inherit

--- a/.github/workflows/trigger-slack-ci-alert.yml
+++ b/.github/workflows/trigger-slack-ci-alert.yml
@@ -11,4 +11,5 @@ permissions: {}
 jobs:
   notify:
     uses: ./.github/workflows/slack-ci-alert.yml
-    secrets: inherit
+    secrets:
+      CI_STATUS_SLACK_WEBHOOK_URL: ${{ secrets.CI_STATUS_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Make the workflow reusable so we can call it from our other public repos later.