### PR TITLE
Cache built models in load_model (opt-in)

### DIFF
--- a/changelog/1162.added.md
+++ b/changelog/1162.added.md
@@ -1,0 +1,1 @@
+Add an opt-in built-model cache to `load_model`, enabled via the `TABPFN_MODEL_CACHE_SIZE` environment variable (default off). When set, repeated loads of the same checkpoint reuse the constructed model instead of rebuilding the architecture and re-running `load_state_dict`. Only the non-mutating (`cache_trainset_representation=False`) build is cached.

--- a/src/tabpfn/model_loading.py
+++ b/src/tabpfn/model_loading.py
@@ -17,10 +17,12 @@ import tempfile
 import urllib.request
 import warnings
 import zipfile
+from collections import OrderedDict
 from dataclasses import asdict, dataclass
 from enum import Enum
 from importlib import import_module
 from pathlib import Path
+from threading import Lock
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast, overload
 from urllib.error import URLError
 
@@ -851,6 +853,34 @@ def _load_checkpoint_cached(path: str, _identity: tuple[int, int]) -> dict:
     return Checkpoint(path).load()
 
 
+# Bounded, opt-in cache of *built* models (architecture + loaded weights),
+# keyed by (resolved path, file identity). Enabled by setting the env var
+# ``TABPFN_MODEL_CACHE_SIZE`` to a positive integer (an LRU of that size;
+# default 0 disables it, preserving prior behaviour). Only the non-mutating
+# build is cached: with ``cache_trainset_representation`` the model accumulates
+# the train-set representation during fit, so a shared instance can't be reused
+# across fits. The cached model is shared by reference and left in ``eval()``
+# mode — intended for repeated sequential fit/predict (cross-validation,
+# per-group models, or servers that manage their own concurrency). RES-2422
+# tracks the follow-up that externalises per-fit state so a single backbone can
+# be shared across threads too.
+_BUILT_MODEL_CACHE: OrderedDict[tuple[str, tuple[int, int]], tuple] = OrderedDict()
+_BUILT_MODEL_CACHE_LOCK = Lock()
+
+
+def _built_model_cache_size() -> int:
+    try:
+        return max(0, int(os.environ.get("TABPFN_MODEL_CACHE_SIZE", "0")))
+    except ValueError:
+        return 0
+
+
+def clear_built_model_cache() -> None:
+    """Drop all entries from the built-model cache (see ``TABPFN_MODEL_CACHE_SIZE``)."""
+    with _BUILT_MODEL_CACHE_LOCK:
+        _BUILT_MODEL_CACHE.clear()
+
+
 def load_model(
     *,
     path: Path,
@@ -863,9 +893,12 @@ def load_model(
 ]:
     """Loads a model from a given path. Only for inference.
 
-    The raw checkpoint is cached in memory so that repeated calls with the
-    same path skip disk I/O.  The cache is automatically invalidated when
-    the file is modified (detected via mtime and size).
+    The raw checkpoint is cached in memory so repeated calls with the same path
+    skip disk I/O. When ``TABPFN_MODEL_CACHE_SIZE`` is a positive integer the
+    *built* model (architecture + loaded weights) is also cached, as an LRU of
+    that size, so repeated calls skip reconstruction and ``load_state_dict``
+    entirely. Only the non-mutating build (``cache_trainset_representation=False``)
+    is cached. Both caches invalidate when the file changes (mtime + size).
 
     Args:
         path: Path to the checkpoint
@@ -873,7 +906,44 @@ def load_model(
             trainset representation. Forwarded to get_architecture.
     """
     resolved = str(path.resolve())
-    checkpoint = _load_checkpoint_cached(resolved, Checkpoint(resolved).identity())
+    identity = Checkpoint(resolved).identity()
+
+    use_cache = _built_model_cache_size() > 0 and not cache_trainset_representation
+    key = (resolved, identity)
+    if use_cache:
+        with _BUILT_MODEL_CACHE_LOCK:
+            cached = _BUILT_MODEL_CACHE.get(key)
+            if cached is not None:
+                _BUILT_MODEL_CACHE.move_to_end(key)
+                return cached
+
+    result = _build_model(
+        resolved, identity, cache_trainset_representation=cache_trainset_representation
+    )
+
+    if use_cache:
+        size = _built_model_cache_size()
+        with _BUILT_MODEL_CACHE_LOCK:
+            _BUILT_MODEL_CACHE[key] = result
+            _BUILT_MODEL_CACHE.move_to_end(key)
+            while len(_BUILT_MODEL_CACHE) > size:
+                _BUILT_MODEL_CACHE.popitem(last=False)
+    return result
+
+
+def _build_model(
+    resolved: str,
+    identity: tuple[int, int],
+    *,
+    cache_trainset_representation: bool = True,
+) -> tuple[
+    Architecture,
+    nn.BCEWithLogitsLoss | nn.CrossEntropyLoss | FullSupportBarDistribution | None,
+    ArchitectureConfig,
+    InferenceConfig,
+]:
+    """Build a model from a resolved checkpoint path (no built-model cache)."""
+    checkpoint = _load_checkpoint_cached(resolved, identity)
 
     # V2 models don't have the "architecture_name" key, V2.5 models have the
     # architecture name set to "base", so we remap. From V2.6 onwards, the architecture

--- a/src/tabpfn/model_loading.py
+++ b/src/tabpfn/model_loading.py
@@ -868,7 +868,7 @@ _BUILT_MODEL_CACHE: OrderedDict[tuple[str, tuple[int, int]], tuple] = OrderedDic
 _BUILT_MODEL_CACHE_LOCK = Lock()
 
 
-def _built_model_cache_size() -> int:
+def _get_built_model_cache_size() -> int:
     try:
         return max(0, int(os.environ.get("TABPFN_MODEL_CACHE_SIZE", "0")))
     except ValueError:
@@ -908,7 +908,7 @@ def load_model(
     resolved = str(path.resolve())
     identity = Checkpoint(resolved).identity()
 
-    use_cache = _built_model_cache_size() > 0 and not cache_trainset_representation
+    use_cache = _get_built_model_cache_size() > 0 and not cache_trainset_representation
     key = (resolved, identity)
     if use_cache:
         with _BUILT_MODEL_CACHE_LOCK:
@@ -922,7 +922,7 @@ def load_model(
     )
 
     if use_cache:
-        size = _built_model_cache_size()
+        size = _get_built_model_cache_size()
         with _BUILT_MODEL_CACHE_LOCK:
             _BUILT_MODEL_CACHE[key] = result
             _BUILT_MODEL_CACHE.move_to_end(key)

--- a/tests/test_model_cache.py
+++ b/tests/test_model_cache.py
@@ -1,0 +1,102 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
+"""Tests for the opt-in built-model cache in ``tabpfn.model_loading``."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from tabpfn import model_loading
+
+
+@pytest.fixture
+def ckpt(tmp_path: Path) -> Path:
+    # Only stat() is read (Checkpoint.identity); the build itself is patched.
+    p = tmp_path / "model.ckpt"
+    p.write_bytes(b"not a real checkpoint")
+    return p
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache() -> Iterator[None]:
+    model_loading.clear_built_model_cache()
+    yield
+    model_loading.clear_built_model_cache()
+
+
+def _patch_build(monkeypatch: pytest.MonkeyPatch) -> dict[str, int]:
+    """Replace the real build with a counter returning a fresh sentinel tuple."""
+    calls = {"n": 0}
+
+    def fake_build(*_args: object, **_kwargs: object) -> tuple:
+        calls["n"] += 1
+        return (object(), None, object(), object())
+
+    monkeypatch.setattr(model_loading, "_build_model", fake_build)
+    return calls
+
+
+def test_cache_hit_reuses_built_model(ckpt: Path, monkeypatch: pytest.MonkeyPatch):
+    calls = _patch_build(monkeypatch)
+    monkeypatch.setenv("TABPFN_MODEL_CACHE_SIZE", "4")
+
+    first = model_loading.load_model(path=ckpt, cache_trainset_representation=False)
+    second = model_loading.load_model(path=ckpt, cache_trainset_representation=False)
+
+    assert first is second  # same built model handed back
+    assert calls["n"] == 1  # built once, not twice
+
+
+def test_mutating_build_is_never_cached(ckpt: Path, monkeypatch: pytest.MonkeyPatch):
+    calls = _patch_build(monkeypatch)
+    monkeypatch.setenv("TABPFN_MODEL_CACHE_SIZE", "4")
+
+    # cache_trainset_representation=True mutates the model during fit, so it is
+    # rebuilt every time rather than served from the shared cache.
+    model_loading.load_model(path=ckpt, cache_trainset_representation=True)
+    model_loading.load_model(path=ckpt, cache_trainset_representation=True)
+    assert calls["n"] == 2
+
+
+def test_cache_disabled_by_default(ckpt: Path, monkeypatch: pytest.MonkeyPatch):
+    calls = _patch_build(monkeypatch)
+    monkeypatch.delenv("TABPFN_MODEL_CACHE_SIZE", raising=False)  # default 0 = off
+
+    model_loading.load_model(path=ckpt, cache_trainset_representation=False)
+    model_loading.load_model(path=ckpt, cache_trainset_representation=False)
+    assert calls["n"] == 2  # no caching; prior behaviour preserved
+
+
+def test_lru_eviction(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    calls = _patch_build(monkeypatch)
+    monkeypatch.setenv("TABPFN_MODEL_CACHE_SIZE", "1")
+    a = tmp_path / "a.ckpt"
+    a.write_bytes(b"a")
+    b = tmp_path / "b.ckpt"
+    b.write_bytes(b"b")
+
+    model_loading.load_model(path=a, cache_trainset_representation=False)
+    model_loading.load_model(path=b, cache_trainset_representation=False)  # evicts a
+    model_loading.load_model(path=a, cache_trainset_representation=False)  # rebuilds a
+    assert calls["n"] == 3
+
+
+def test_load_model_signature_is_tracked_by_the_cache():
+    """Tripwire: the cache correctness depends on `load_model`'s exact inputs.
+
+    It keys on (path, file-identity) and caches only when
+    ``cache_trainset_representation`` is False. So a *new build-affecting*
+    parameter must be added to the cache key (else a hit returns a stale model),
+    and a *new mutation flag* must extend the gate (else a mutated model gets
+    shared). If this assertion fails, revisit `_BUILT_MODEL_CACHE` / `load_model`
+    before updating the expected set.
+    """
+    params = set(inspect.signature(model_loading.load_model).parameters)
+    assert params == {"path", "cache_trainset_representation"}, (
+        f"load_model parameters changed to {sorted(params)}; the built-model "
+        "cache key and/or its cache_trainset_representation gate must be updated."
+    )


### PR DESCRIPTION
This is a nice-to-have in server contexts where the model state dict is ideally loaded once and then should stay resident. Otherwise weight loading (in `.fit()`) dominates small inferences.
I'm flexible about the exact design, what's proposed herein is an opt-in LRU cache stored on the module level. Opt-in is gated on `TABPFN_MODEL_CACHE_SIZE`

<details>
<summary>Claude:</summary>

load_model rebuilds the architecture and re-runs load_state_dict on every call — only the raw checkpoint bytes are cached (_load_checkpoint_cached), never the built module. Any workload that reloads the same checkpoint (cross-validation, per-group models, serving) pays that rebuild each time; in a serving setup it was ~40% of warm latency.

Add an opt-in LRU of built models keyed by (path, file identity), behind TABPFN_MODEL_CACHE_SIZE (default 0 = off, behaviour unchanged). Only the non-mutating build (cache_trainset_representation=False) is cached; the caching path always rebuilds, so a shared instance never carries a prior fit's train-set state.

Tests: cache hit reuses the model, the mutating build is never cached, off by default, LRU eviction, and a signature tripwire so the cache key is revisited if load_model gains a parameter.

</details>