### PR TITLE
fix seed inside truncated svd

### DIFF
--- a/changelog/1167.fixed.md
+++ b/changelog/1167.fixed.md
@@ -1,0 +1,1 @@
+fixed the randomness in the truncated SVD to make runs more reproducible.

--- a/src/tabpfn/preprocessing/torch/factory.py
+++ b/src/tabpfn/preprocessing/torch/factory.py
@@ -54,7 +54,7 @@ def create_gpu_preprocessing_pipeline(
         feature_schema: Feature schema from the CPU preprocessing output.
             Used to read ``scheduled_gpu_transform`` column annotations.
         n_train_samples: Number of training samples (after subsampling).
-        random_state: Random state for the shuffle step.
+        random_state: Random state for the SVD and shuffle steps.
     """
     steps: list[tuple[TorchPreprocessingStep, set[FeatureModality] | None]] = []
     pconfig = config.preprocess_config
@@ -110,6 +110,7 @@ def create_gpu_preprocessing_pipeline(
                 (
                     TorchAddSVDFeaturesStep(
                         global_transformer_name=pconfig.global_transformer_name,
+                        random_state=random_state,
                     ),
                     None,
                 )

--- a/src/tabpfn/preprocessing/torch/steps.py
+++ b/src/tabpfn/preprocessing/torch/steps.py
@@ -370,6 +370,7 @@ class TorchAddSVDFeaturesStep(TorchPreprocessingStep):
     def __init__(
         self,
         global_transformer_name: Literal["svd", "svd_quarter_components"] = "svd",
+        random_state: int | np.random.Generator | None = None,
     ) -> None:
         """Initialize the SVD features step.
 
@@ -377,9 +378,12 @@ class TorchAddSVDFeaturesStep(TorchPreprocessingStep):
             global_transformer_name: Name of the SVD variant. The number of
                 components is computed inside ``_fit`` via
                 :func:`get_svd_n_components`, matching the CPU pipeline.
+            random_state: Seeds the SVD's random projection, as in the CPU
+                :class:`AddSVDFeaturesStep`.
         """
         super().__init__()
         self.global_transformer_name = global_transformer_name
+        self.random_state = random_state
         self._scaler = TorchSafeStandardScaler()
         self._svd: TorchTruncatedSVD | None = None
 
@@ -411,7 +415,11 @@ class TorchAddSVDFeaturesStep(TorchPreprocessingStep):
             n_features=num_features,
         )
 
-        self._svd = TorchTruncatedSVD(n_components=effective_n_components)
+        static_seed, _ = infer_random_state(self.random_state)
+        self._svd = TorchTruncatedSVD(
+            n_components=effective_n_components,
+            random_state=static_seed,
+        )
 
         # Fit scaler on training data (flatten batch dimension for fitting)
         # Shape: [num_train_rows, batch_size, num_cols] -> flattened

--- a/src/tabpfn/preprocessing/torch/torch_svd.py
+++ b/src/tabpfn/preprocessing/torch/torch_svd.py
@@ -111,10 +111,12 @@ class TorchTruncatedSVD:
         )
 
         if use_lowrank:
-            # torch.svd_lowrank returns (U, S, V) with A ≈ U diag(S) V^T.
-            # fork_rng keeps the seeding local: the global stream is restored
-            # afterwards, so no other consumer of torch's RNG is affected.
-            with torch.random.fork_rng(devices=[]):
+            # torch.svd_lowrank returns (U, S, V) with A ≈ U diag(S) V^T. It draws a
+            # random projection from the global RNG and takes no generator, so an
+            # unseeded call returns different components every time. Seed it, and fork
+            # every device so the caller's streams are restored on exit
+            # (torch.manual_seed reseeds CPU *and* all CUDA devices).
+            with torch.random.fork_rng(devices=range(torch.cuda.device_count())):
                 torch.manual_seed(0)
                 u, s, v = torch.svd_lowrank(x_filled, q=q, niter=2)
             # Truncate oversampling dimensions

--- a/src/tabpfn/preprocessing/torch/torch_svd.py
+++ b/src/tabpfn/preprocessing/torch/torch_svd.py
@@ -111,13 +111,21 @@ class TorchTruncatedSVD:
         )
 
         if use_lowrank:
-            # torch.svd_lowrank returns (U, S, V) with A ≈ U diag(S) V^T. It draws a
-            # random projection from the global RNG and takes no generator, so an
-            # unseeded call returns different components every time. Seed it, and fork
-            # every device so the caller's streams are restored on exit
-            # (torch.manual_seed reseeds CPU *and* all CUDA devices).
-            with torch.random.fork_rng(devices=range(torch.cuda.device_count())):
-                torch.manual_seed(0)
+            # torch.svd_lowrank returns (U, S, V) with A ≈ U diag(S) V^T. It draws its
+            # projection from the default generator of x_filled.device and takes no
+            # generator argument, so an unseeded call returns different components
+            # every time. Fork and seed only that device's generator: torch.manual_seed
+            # would also reseed CUDA/MPS/XPU, which a CPU-only fork_rng does not
+            # restore, and forking every device would initialise a context on each.
+            device = x_filled.device
+            fork_devices = [] if device.type == "cpu" else [device]
+            with torch.random.fork_rng(devices=fork_devices, device_type=device.type):
+                if device.type == "cpu":
+                    torch.default_generator.manual_seed(0)
+                else:
+                    # Seeding is per *current* device, so make it the right one.
+                    with getattr(torch, device.type).device(device):
+                        getattr(torch, device.type).manual_seed(0)
                 u, s, v = torch.svd_lowrank(x_filled, q=q, niter=2)
             # Truncate oversampling dimensions
             u = u[:, :n_components]

--- a/src/tabpfn/preprocessing/torch/torch_svd.py
+++ b/src/tabpfn/preprocessing/torch/torch_svd.py
@@ -6,6 +6,18 @@ from __future__ import annotations
 
 import torch
 
+#: Seed for the randomized-SVD projection. ``torch.svd_lowrank`` draws its random
+#: projection from the *global* torch RNG and accepts no generator argument, so an
+#: unseeded call returns different components on every invocation. This SVD is refitted
+#: on the combined train+test matrix on every predict, which made predictions
+#: irreproducible call to call: on a 1M x 246 table, 6-12% of predicted classes changed
+#: between two identical ``predict_proba`` calls on one fitted model.
+#:
+#: A fixed constant is sufficient. Ensemble members already differ from one another
+#: through their feature subsets, so no additional randomness is needed across
+#: estimators.
+_LOWRANK_SVD_SEED = 0
+
 
 def _svd_flip_stable(
     u: torch.Tensor,
@@ -111,8 +123,12 @@ class TorchTruncatedSVD:
         )
 
         if use_lowrank:
-            # torch.svd_lowrank returns (U, S, V) with A ≈ U diag(S) V^T
-            u, s, v = torch.svd_lowrank(x_filled, q=q, niter=2)
+            # torch.svd_lowrank returns (U, S, V) with A ≈ U diag(S) V^T.
+            # fork_rng keeps the seeding local: the global stream is restored
+            # afterwards, so no other consumer of torch's RNG is affected.
+            with torch.random.fork_rng(devices=[]):
+                torch.manual_seed(_LOWRANK_SVD_SEED)
+                u, s, v = torch.svd_lowrank(x_filled, q=q, niter=2)
             # Truncate oversampling dimensions
             u = u[:, :n_components]
             s = s[:n_components]

--- a/src/tabpfn/preprocessing/torch/torch_svd.py
+++ b/src/tabpfn/preprocessing/torch/torch_svd.py
@@ -6,18 +6,6 @@ from __future__ import annotations
 
 import torch
 
-#: Seed for the randomized-SVD projection. ``torch.svd_lowrank`` draws its random
-#: projection from the *global* torch RNG and accepts no generator argument, so an
-#: unseeded call returns different components on every invocation. This SVD is refitted
-#: on the combined train+test matrix on every predict, which made predictions
-#: irreproducible call to call: on a 1M x 246 table, 6-12% of predicted classes changed
-#: between two identical ``predict_proba`` calls on one fitted model.
-#:
-#: A fixed constant is sufficient. Ensemble members already differ from one another
-#: through their feature subsets, so no additional randomness is needed across
-#: estimators.
-_LOWRANK_SVD_SEED = 0
-
 
 def _svd_flip_stable(
     u: torch.Tensor,
@@ -127,7 +115,7 @@ class TorchTruncatedSVD:
             # fork_rng keeps the seeding local: the global stream is restored
             # afterwards, so no other consumer of torch's RNG is affected.
             with torch.random.fork_rng(devices=[]):
-                torch.manual_seed(_LOWRANK_SVD_SEED)
+                torch.manual_seed(0)
                 u, s, v = torch.svd_lowrank(x_filled, q=q, niter=2)
             # Truncate oversampling dimensions
             u = u[:, :n_components]

--- a/src/tabpfn/preprocessing/torch/torch_svd.py
+++ b/src/tabpfn/preprocessing/torch/torch_svd.py
@@ -4,7 +4,14 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import torch
+
+from tabpfn.utils import infer_random_state
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 def _svd_flip_stable(
@@ -50,13 +57,21 @@ class TorchTruncatedSVD:
     If centering is needed, apply it before calling fit.
     """
 
-    def __init__(self, n_components: int) -> None:
+    def __init__(
+        self,
+        n_components: int,
+        random_state: int | np.random.Generator | None = None,
+    ) -> None:
         """Initialize the truncated SVD.
 
         Args:
             n_components: Number of components to keep.
+            random_state: Seeds the random projection drawn by the randomized
+                path. As in sklearn's ``TruncatedSVD``, ``None`` means a fresh
+                projection on every fit; the exact path ignores it.
         """
         self.n_components = n_components
+        self.random_state = random_state
 
     def fit(self, x: torch.Tensor) -> dict[str, torch.Tensor]:
         """Compute the truncated SVD on the training data.
@@ -113,19 +128,22 @@ class TorchTruncatedSVD:
         if use_lowrank:
             # torch.svd_lowrank returns (U, S, V) with A ≈ U diag(S) V^T. It draws its
             # projection from the default generator of x_filled.device and takes no
-            # generator argument, so an unseeded call returns different components
-            # every time. Fork and seed only that device's generator: torch.manual_seed
-            # would also reseed CUDA/MPS/XPU, which a CPU-only fork_rng does not
-            # restore, and forking every device would initialise a context on each.
+            # generator argument, so the only way to control it is to seed that
+            # generator. Do so inside a fork, which restores the caller's state on
+            # exit: seeding is a side effect on process-global state that callers own.
+            # Fork only the tensor's own device -- torch.manual_seed would also reseed
+            # CUDA/MPS/XPU, which a CPU-only fork_rng does not restore, and forking
+            # every device would initialise a context on each.
+            static_seed, _ = infer_random_state(self.random_state)
             device = x_filled.device
             fork_devices = [] if device.type == "cpu" else [device]
             with torch.random.fork_rng(devices=fork_devices, device_type=device.type):
                 if device.type == "cpu":
-                    torch.default_generator.manual_seed(0)
+                    torch.default_generator.manual_seed(static_seed)
                 else:
                     # Seeding is per *current* device, so make it the right one.
                     with getattr(torch, device.type).device(device):
-                        getattr(torch, device.type).manual_seed(0)
+                        getattr(torch, device.type).manual_seed(static_seed)
                 u, s, v = torch.svd_lowrank(x_filled, q=q, niter=2)
             # Truncate oversampling dimensions
             u = u[:, :n_components]

--- a/tests/test_torch_preprocessing/test_torch_svd.py
+++ b/tests/test_torch_preprocessing/test_torch_svd.py
@@ -679,21 +679,21 @@ def test__add_svd_features__single_feature_is_noop_like_cpu():
     assert cpu_step.num_added_features(40, schema) == 0
 
 
-def test__torch_truncated_svd__fit_is_deterministic():
-    """Fitting the same data twice must give the same components.
+def test__torch_truncated_svd__random_state_controls_the_projection():
+    """``random_state`` must fix the randomized projection, and different seeds vary it.
 
-    ``torch.svd_lowrank`` draws its random projection from the global torch RNG, so an
+    ``torch.svd_lowrank`` draws its projection from the global torch RNG, so an
     unseeded call returns different components each time. This shape takes that branch
     (>1M cells, and min(n, f) >= 2 * (n_components + 10)); smaller inputs use the exact
     path, which is deterministic anyway.
     """
     x = torch.randn(5_000, 250, generator=torch.Generator().manual_seed(0))
-    svd = TorchTruncatedSVD(n_components=8)
 
-    first = svd.fit(x)
-    second = svd.fit(x)
+    same = [TorchTruncatedSVD(n_components=8, random_state=0).fit(x) for _ in range(2)]
+    other = TorchTruncatedSVD(n_components=8, random_state=1).fit(x)
 
-    assert torch.equal(first["components"], second["components"])
+    assert torch.equal(same[0]["components"], same[1]["components"])
+    assert not torch.equal(same[0]["components"], other["components"])
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs a CUDA device")
@@ -702,6 +702,6 @@ def test__torch_truncated_svd__fit_leaves_cuda_rng_untouched():
     x = torch.randn(5_000, 250, generator=torch.Generator().manual_seed(0)).cuda()
     before = torch.cuda.get_rng_state()
 
-    TorchTruncatedSVD(n_components=8).fit(x)
+    TorchTruncatedSVD(n_components=8, random_state=0).fit(x)
 
     assert torch.equal(before, torch.cuda.get_rng_state())

--- a/tests/test_torch_preprocessing/test_torch_svd.py
+++ b/tests/test_torch_preprocessing/test_torch_svd.py
@@ -694,3 +694,14 @@ def test__torch_truncated_svd__fit_is_deterministic():
     second = svd.fit(x)
 
     assert torch.equal(first["components"], second["components"])
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs a CUDA device")
+def test__torch_truncated_svd__fit_leaves_cuda_rng_untouched():
+    """Seeding must not leak: CUDA RNG state must survive the call unchanged."""
+    x = torch.randn(5_000, 250, generator=torch.Generator().manual_seed(0)).cuda()
+    before = torch.cuda.get_rng_state()
+
+    TorchTruncatedSVD(n_components=8).fit(x)
+
+    assert torch.equal(before, torch.cuda.get_rng_state())

--- a/tests/test_torch_preprocessing/test_torch_svd.py
+++ b/tests/test_torch_preprocessing/test_torch_svd.py
@@ -677,3 +677,20 @@ def test__add_svd_features__single_feature_is_noop_like_cpu():
     assert cpu_step.is_no_op
     assert cpu_result.X.shape == X_np.shape
     assert cpu_step.num_added_features(40, schema) == 0
+
+
+def test__torch_truncated_svd__fit_is_deterministic():
+    """Fitting the same data twice must give the same components.
+
+    ``torch.svd_lowrank`` draws its random projection from the global torch RNG, so an
+    unseeded call returns different components each time. This shape takes that branch
+    (>1M cells, and min(n, f) >= 2 * (n_components + 10)); smaller inputs use the exact
+    path, which is deterministic anyway.
+    """
+    x = torch.randn(5_000, 250, generator=torch.Generator().manual_seed(0))
+    svd = TorchTruncatedSVD(n_components=8)
+
+    first = svd.fit(x)
+    second = svd.fit(x)
+
+    assert torch.equal(first["components"], second["components"])


### PR DESCRIPTION
## Issue
On main the Truncated SVD is not deterministic. But it cannot directly be seeded. This leads to nondeterministic behavior. On large datasets of BeyondArena, which uses this path this lead to heavily non-deterministic results (that seemed statistically significant far apart).

This PR adds a test (that fails on main) and the locally forces a fixed random seed for the truncated SVD, I don't think there is any need for randomness in the SVD operation.

## Motivation and Context

---

## Public API Changes

-   [x] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?

---

## Checklist

-   [x] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [ ] A changelog entry has been added (see `changelog/README.md`), or "no changelog needed" label requested.
-   [x] The code follows the project's style guidelines.
-   [x] I have considered the impact of these changes on the public API.

---
