### PR TITLE
Split FA3's KV sequence for short query chunks

### DIFF
--- a/changelog/1168.changed.md
+++ b/changelog/1168.changed.md
@@ -1,0 +1,1 @@
+Speed up cached prediction on Hopper GPUs with FlashAttention-3 installed, by splitting attention over the key/value sequence when few test rows attend over a large training cache.

--- a/src/tabpfn/architectures/shared/fa3_backend.py
+++ b/src/tabpfn/architectures/shared/fa3_backend.py
@@ -33,6 +33,11 @@ _FA3_SUPPORTED_HEAD_DIMS = frozenset({64, 96, 128, 192, 256})
 # n_features=100/500); FA3 wins uniformly from n_train=100k upward.
 _FA3_MIN_SEQLEN_FOR_SPEEDUP = 10_000
 
+_FA3_LONG_KV_SEQLEN = 50_000
+_FA3_SPLIT_KV_MAX_SEQLEN_Q = 1024
+_FA3_SPLIT_KV_MAX_SEQLEN_Q_LONG_KV = 4096
+_FA3_SPLIT_KV_NUM_SPLITS = 32
+
 
 @functools.cache
 def _load_fa3_func() -> Callable | None:
@@ -79,7 +84,9 @@ def fa3_attn_func(
 ) -> torch.Tensor:
     """Call ``flash_attn_func`` with the v3 attention layout (B, S, H, D).
 
-    GQA is handled natively by FA3 when ``nheads_q % nheads_k == 0``.
+    GQA is handled natively by FA3 when ``nheads_q % nheads_k == 0``. Short
+    query sequences run split over the KV sequence; see
+    ``_FA3_SPLIT_KV_NUM_SPLITS``.
     """
     fn = _load_fa3_func()
     if fn is None:
@@ -87,7 +94,15 @@ def fa3_attn_func(
             "FA3 path requested but flash_attn_interface is not importable; "
             "see fa3_setup.md (next to this file)."
         )
-    return fn(q, k, v)
+    # determine num_splits manually, because FA3's heuristic num_splits=0
+    # does not compile
+    max_seqlen_q = (
+        _FA3_SPLIT_KV_MAX_SEQLEN_Q_LONG_KV
+        if k.shape[1] > _FA3_LONG_KV_SEQLEN
+        else _FA3_SPLIT_KV_MAX_SEQLEN_Q
+    )
+    splits = _FA3_SPLIT_KV_NUM_SPLITS if q.shape[1] <= max_seqlen_q else 1
+    return fn(q, k, v, num_splits=splits)
 
 
 class FA3Backend(AttentionBackend):


### PR DESCRIPTION
## Motivation and Context

Stacked on #1165 (registry refactor); this is the first behaviour change on the FA3 path.

FA3 can do context parallelism, which is very helpful to saturate the hardware if there are few queries. FA3 has a heuristic to decide into how many chunks to split the KV, which is triggered by `num_splits=0`. Although today we do not compile, this heiristic would break compilation, so for now, I'd resort to a simple coarse and hand-designed heuristic. 
Therefore we just use 3 buckets. From LLM work I know that 32 splits is often pretty good so we do

The FA3 kernel only ever get's engaged in KV > 10K so we them implemented rule does:

```
If 10K < KV < 50K:
  if Q <=1024:
    num_splits = 32
  else: 
    num_splits = 1 (what we use today)
    
If KV > 50K:
   if Q <= 4K:
     num_splits = 32
   else:
     num_splits = 1
     
else:
 num_splits = 1
```

Measurements for different num_splits on H100 (ignore the rule column)

```
v3 ICL cross-attn: 8:1 MQA head_dim=64 batch=1 bf16 | rule: split when S_q <= 1024

MQA 8:1, S_kv=10,000
     S_q   splits=1  splits=32   ratio     accum   rel_err  rule
       1      0.184      0.086    2.13        0M  2.78e-03  split
      32      0.180      0.082    2.19        2M  2.84e-03  split
      64      0.180      0.082    2.18        4M  2.86e-03  split
     128      0.179      0.083    2.17        8M  2.87e-03  split
     256      0.181      0.095    1.90       16M  2.88e-03  split
     512      0.174      0.118    1.48       32M  2.88e-03  split
    1024      0.183      0.175    1.05       64M  2.89e-03  split
    2048      0.179      0.282    0.63      128M  2.88e-03  single
    4096      0.297      0.500    0.59      256M  2.88e-03  single

MQA 8:1, S_kv=20,000
     S_q   splits=1  splits=32   ratio     accum   rel_err  rule
       1      0.294      0.085    3.47        0M  2.77e-03  split
      32      0.288      0.086    3.33        2M  2.92e-03  split
      64      0.288      0.081    3.53        4M  2.87e-03  split
     128      0.286      0.090    3.16        8M  2.92e-03  split
     256      0.287      0.107    2.69       16M  2.90e-03  split
     512      0.276      0.140    1.98       32M  2.89e-03  split
    1024      0.290      0.212    1.37       64M  2.89e-03  split
    2048      0.276      0.353    0.78      128M  2.89e-03  single
    4096      0.497      0.650    0.76      256M  2.89e-03  single

MQA 8:1, S_kv=50,000
     S_q   splits=1  splits=32   ratio     accum   rel_err  rule
       1      0.647      0.089    7.32        0M  2.78e-03  split
      32      0.625      0.088    7.11        2M  2.99e-03  split
      64      0.627      0.091    6.89        4M  2.99e-03  split
     128      0.628      0.116    5.42        8M  2.99e-03  split
     256      0.627      0.139    4.51       16M  2.97e-03  split
     512      0.582      0.196    2.98       32M  2.99e-03  split
    1024      0.616      0.331    1.86       64M  2.99e-03  split
    2048      0.585      0.569    1.03      128M  2.99e-03  single
    4096      1.120      1.086    1.03      256M  2.99e-03  single

MQA 8:1, S_kv=100,000
     S_q   splits=1  splits=32   ratio     accum   rel_err  rule
       1      1.208      0.103   11.74        0M  2.89e-03  split
      32      1.178      0.107   11.02        2M  3.01e-03  split
      64      1.178      0.105   11.22        4M  3.08e-03  split
     128      1.155      0.148    7.79        8M  3.01e-03  split
     256      1.155      0.191    6.05       16M  3.04e-03  split
     512      1.113      0.318    3.50       32M  3.05e-03  split
    1024      1.182      0.527    2.24       64M  3.04e-03  split
    2048      1.119      0.957    1.17      128M  3.04e-03  single
    4096      2.204      1.810    1.22      256M  3.04e-03  single

MQA 8:1, S_kv=500,000
     S_q   splits=1  splits=32   ratio     accum   rel_err  rule
       1      5.814      0.238   24.44        0M  3.32e-03  split
      32      5.463      0.238   22.97        2M  3.11e-03  split
      64      5.460      0.243   22.46        4M  3.11e-03  split
     128      5.463      0.425   12.85        8M  3.07e-03  split
     256      5.466      0.604    9.05       16M  3.09e-03  split
     512      5.183      1.141    4.54       32M  3.08e-03  split
    1024      5.658      2.038    2.78       64M  3.08e-03  split
    2048      5.376      4.020    1.34      128M  3.08e-03  single
    4096     10.612      8.320    1.28      256M  3.08e-03  single

crossover (last S_q where 32 splits still wins):
  S_kv= 10,000:   1024   (threshold 1024)
  S_kv= 20,000:   1024   (threshold 1024)
  S_kv= 50,000:   4096   (threshold 1024)
  S_kv=100,000:   4096   (threshold 1024)
  S_kv=500,000:   4096   (threshold 1024)
```


## Public API Changes

-   [x] No Public API changes

## How Has This Been Tested?

-   Existing architecture and inference suites (118 passed / 36 skipped locally).
-   Ablation on an H100 80GB: the table above, plus a `torch.compile` matrix confirming an explicit split count traces under `fullgraph=True`, does not recompile across a KV-length sweep, and stays numerically exact across cudagraph replays and shape switches.
-   Split-KV does not cost accuracy: rel-L2 vs the unsplit output is ~3e-3 at every query length, the same magnitude as bf16 noise.

## Checklist

-   [x] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [x] A changelog entry has been added (see `changelog/README.md`), or "no changelog needed" label requested.
-   [x] The code follows the project's style guidelines.
-   [x] I have considered the impact of these changes on the public API.
