### PR TITLE
perf: assemble `clean_data`'s encoded array instead of stacking and reordering it

### DIFF
--- a/changelog/1174.changed.md
+++ b/changelog/1174.changed.md
@@ -1,0 +1,1 @@
+`fit()` uses less memory on tables with categorical columns: the encoded array is now assembled in place instead of being stacked and then reordered, cutting transient memory by about a quarter on a half-string table.

--- a/src/tabpfn/preprocessing/clean.py
+++ b/src/tabpfn/preprocessing/clean.py
@@ -605,12 +605,14 @@ def _apply_ordinal_encoder(
         # inner encoder its categories from every row.
         ord_encoder.fit(X.iloc[:1])
         selected = _encoder_selection(ord_encoder)
+        if not _can_write_encoded_columns(X, selected):
+            # Bail before learning any categories: `fit_transform` learns them again
+            # from scratch, so doing it first would be a wasted pass over the data.
+            # Only the one-row fit above is lost, which costs no pass at all.
+            return ord_encoder.fit_transform(X)
         if selected:
             ord_encoder.named_transformers_["encoder"].fit(X[selected])
-        if _can_write_encoded_columns(X, selected):
-            return _encode_into_preallocated(X, ord_encoder, selected)
-        # Not assemblable: refit properly and let sklearn do the whole thing.
-        return ord_encoder.fit_transform(X)
+        return _encode_into_preallocated(X, ord_encoder, selected)
     if ord_encoder is not None:
         # Left on sklearn deliberately. `transform` also validates the frame against
         # the one seen at fit -- column count, names, order -- and the assembly above

--- a/src/tabpfn/preprocessing/clean.py
+++ b/src/tabpfn/preprocessing/clean.py
@@ -224,6 +224,14 @@ def _column_kind(dtype: Any) -> str:
     return dtype.kind
 
 
+def _encoder_selection(ord_encoder: OrderPreservingColumnTransformer) -> list[Any]:
+    """The columns a fitted encoder takes, in the order it holds them."""
+    return next(
+        (cols for name, _, cols in ord_encoder.transformers_ if name == "encoder"),
+        [],
+    )
+
+
 def _is_single_float_block(X: pd.DataFrame) -> bool:
     """True if ``X`` is backed by a single contiguous numpy float block.
 
@@ -262,10 +270,7 @@ def _align_columns_to_fitted_dtypes(
     encoder = ord_encoder.named_transformers_.get("encoder")
     if encoder is None or not hasattr(encoder, "categories_"):
         return X
-    selected = next(
-        (cols for name, _, cols in ord_encoder.transformers_ if name == "encoder"),
-        [],
-    )
+    selected = _encoder_selection(ord_encoder)
     to_string, to_numeric = [], []
     for col, categories in zip(selected, encoder.categories_, strict=True):
         fit_kind = categories.dtype.kind
@@ -505,6 +510,63 @@ def _owned_float64_values(X: pd.DataFrame) -> np.ndarray:
     return out
 
 
+def _can_write_encoded_columns(X: pd.DataFrame, selected: list[Any]) -> bool:
+    """Whether the encoded array can be assembled column by column.
+
+    Two things have to hold. Every column the encoder does *not* take must already be
+    plain float64, so writing it into a float64 output is a copy and not a conversion
+    that could differ from the one `ColumnTransformer` would have done -- notably an
+    `object` column, which the encoder's dtype selector skips and the old path carried
+    through as objects until the closing cast. And the column names must be unique,
+    since each column is placed by name.
+    """
+    if X.columns.has_duplicates:
+        return False
+    taken = set(selected)
+    return all(
+        dtype == _FLOAT64
+        for column, dtype in zip(X.columns, X.dtypes, strict=True)
+        if column not in taken
+    )
+
+
+def _encode_into_preallocated(
+    X: pd.DataFrame,
+    ord_encoder: OrderPreservingColumnTransformer,
+    selected: list[Any],
+) -> np.ndarray:
+    """Assemble the encoded array by writing each column straight to its final place.
+
+    `ColumnTransformer` gets the same result in three full-size arrays: one per
+    transformer, a second from stacking them, and a third from the gather
+    `_preserve_order` needs to undo the stacking's column order. A mixed-column clean
+    reaches its RAM peak twice inside that -- once in the stack, once in the gather --
+    which is why removing either one alone changes nothing. Writing into the output
+    costs one array, plus the block of codes the encoder returns.
+
+    Column order is the frame's own, so no reordering is needed afterwards, and the
+    layout is column-major to match what the stack used to produce.
+    """
+    positions = {column: index for index, column in enumerate(X.columns)}
+    taken = set(selected)
+    out = np.empty(X.shape, dtype=np.float64, order="F")
+
+    if selected:
+        # One call rather than one per column: the encoder validates against the
+        # column count it was fitted on, so its codes come as a single block.
+        codes = ord_encoder.named_transformers_["encoder"].transform(X[selected])
+        out[:, [positions[column] for column in selected]] = codes
+        del codes
+
+    # Per column, so no full-width temporary is built for the passthrough half; each
+    # write is a copy out of the frame's block, which `_can_write_encoded_columns` has
+    # established is already float64.
+    for column, index in positions.items():
+        if column not in taken:
+            out[:, index] = X[column].to_numpy(dtype=np.float64, copy=False)
+    return out
+
+
 def _apply_ordinal_encoder(
     X: pd.DataFrame,
     ord_encoder: OrderPreservingColumnTransformer | None,
@@ -515,8 +577,8 @@ def _apply_ordinal_encoder(
 
     Every branch returns an array the caller owns, which is what lets it write the
     placeholder and +/-inf cells in place and cast to float64 with ``copy=False``.
-    Three of the four allocate outright -- the copy, and the encoder's own hstack at
-    fit and at transform. The fourth, `X.to_numpy()`, does not: for a single-block
+    Three of the four allocate outright -- the copy, the preallocated output, the
+    encoder's own hstack. The fourth, `X.to_numpy()`, does not: for a single-block
     frame pandas hands back the block itself, read-only under copy-on-write and
     aliasing the caller's ndarray without it.
 
@@ -536,8 +598,24 @@ def _apply_ordinal_encoder(
             ord_encoder.fit(X.iloc[:1])
         return _owned_float64_values(X)
     if fit_encoder and ord_encoder is not None:
+        # `ColumnTransformer.fit` is implemented as `fit_transform`, so fitting on the
+        # whole frame would run the very transform the assembly below replaces. Fit on
+        # one row for the column bookkeeping instead -- widths and output indices do
+        # not depend on the row count for a one-to-one encoder -- and then teach the
+        # inner encoder its categories from every row.
+        ord_encoder.fit(X.iloc[:1])
+        selected = _encoder_selection(ord_encoder)
+        if selected:
+            ord_encoder.named_transformers_["encoder"].fit(X[selected])
+        if _can_write_encoded_columns(X, selected):
+            return _encode_into_preallocated(X, ord_encoder, selected)
+        # Not assemblable: refit properly and let sklearn do the whole thing.
         return ord_encoder.fit_transform(X)
     if ord_encoder is not None:
+        # Left on sklearn deliberately. `transform` also validates the frame against
+        # the one seen at fit -- column count, names, order -- and the assembly above
+        # does not, so using it here would trade a real check for memory the wrapper
+        # has already validated by other means.
         return ord_encoder.transform(X)
     return X.to_numpy()
 

--- a/tests/test_preprocessing/test_data_cleaning.py
+++ b/tests/test_preprocessing/test_data_cleaning.py
@@ -10,6 +10,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import torch
+from sklearn.preprocessing import OrdinalEncoder
 
 from tabpfn import TabPFNClassifier, TabPFNRegressor
 from tabpfn.errors import TabPFNValidationError
@@ -1081,9 +1082,19 @@ def test__clean_data__object_passthrough_falls_back_to_the_encoder() -> None:
     assert not clean_module._can_write_encoded_columns(
         frame, clean_module._encoder_selection(encoder.fit(frame.iloc[:1]))
     )
-    # And the real call still works, through sklearn.
-    out = process_text_na_dataframe(
-        frame, ord_encoder=get_ordinal_encoder(), fit_encoder=True
+    # The real call still works, through sklearn, and learns the categories exactly
+    # once. Declining the assembly *after* fitting them would pay for a second pass
+    # over the data and then discard it, since `fit_transform` fits again itself.
+    unpatched_fit = OrdinalEncoder.fit
+    with mock.patch.object(
+        OrdinalEncoder, "fit", autospec=True, side_effect=unpatched_fit
+    ) as fitted:
+        out = process_text_na_dataframe(
+            frame, ord_encoder=get_ordinal_encoder(), fit_encoder=True
+        )
+    rows_per_fit = [len(call.args[1]) for call in fitted.call_args_list]
+    assert rows_per_fit.count(len(frame)) == 1, (
+        f"expected one fit over all {len(frame)} rows, got fits over {rows_per_fit}"
     )
     assert out.shape == (6, 3)
     assert out.dtype == np.float64

--- a/tests/test_preprocessing/test_data_cleaning.py
+++ b/tests/test_preprocessing/test_data_cleaning.py
@@ -974,3 +974,116 @@ def test__process_text_na_dataframe__frozen_shortcut_taken_when_lined_up() -> No
 
     assert shortcut.call_count == 1
     np.testing.assert_array_equal(out, frame.to_numpy())
+
+
+# --- mixed-column assembly -------------------------------------------------------
+#
+# With categorical columns present, `clean_data` writes the encoded columns straight
+# into the output array rather than letting `ColumnTransformer` stack its
+# transformers' outputs and then reorder them. These pin what that has to preserve:
+# the fitted encoder sklearn would have produced, and the values in the right places.
+
+
+def _mixed_frame_inputs(
+    n: int = 200, levels: int = 6
+) -> tuple[np.ndarray, FeatureSchema]:
+    """An object array of alternating numeric and low-cardinality string columns."""
+    rng = np.random.default_rng(0)
+    cols = 6
+    X = np.empty((n, cols), dtype=object)
+    numeric_cols, string_cols = range(0, cols, 2), range(1, cols, 2)
+    X[:, numeric_cols] = rng.standard_normal((n, len(numeric_cols)))
+    names = np.array([f"lvl_{i:02d}" for i in range(levels)], dtype=object)
+    X[:, string_cols] = names[rng.integers(0, levels, (n, len(string_cols)))]
+    return X, _numeric_schema(cols, cat_indices=tuple(string_cols))
+
+
+def test__clean_data__mixed_columns_take_the_assembly_path() -> None:
+    """The assembly is used, and its result is placed by column, not by transformer."""
+    X, schema = _mixed_frame_inputs()
+
+    with mock.patch(
+        "tabpfn.preprocessing.clean._encode_into_preallocated",
+        wraps=clean_module._encode_into_preallocated,
+    ) as assembled:
+        out, _encoder, _ = clean_data(X=X, feature_schema=schema)
+
+    assert assembled.call_count == 1, "fell back to ColumnTransformer.fit_transform"
+    # Numeric columns keep their own values, in their own positions -- the thing the
+    # reorder used to be responsible for.
+    for index in range(0, X.shape[1], 2):
+        np.testing.assert_array_equal(out[:, index], X[:, index].astype(np.float64))
+    # Encoded columns hold codes within the learned range, at their own positions.
+    for index in range(1, X.shape[1], 2):
+        assert set(np.unique(out[:, index])) <= set(range(6))
+    assert out.dtype == np.float64
+    assert out.flags.writeable
+
+
+def test__clean_data__assembly_fits_the_encoder_sklearn_would_have() -> None:
+    """The one-row structural fit plus a full refit must leave sklearn's own state.
+
+    The encoder is stored on the estimator and drives predict, so any divergence here
+    outlives the call that produced it.
+    """
+    X, schema = _mixed_frame_inputs()
+    frame = fix_dtypes(
+        X.copy(), cat_indices=schema.indices_for(FeatureModality.CATEGORICAL)
+    )
+
+    _, assembled, _ = clean_data(X=X, feature_schema=schema)
+    reference = get_ordinal_encoder()
+    reference.fit_transform(frame)
+
+    assert reference.n_features_in_ == assembled.n_features_in_
+    assert reference.output_indices_ == assembled.output_indices_
+    assert reference.sparse_output_ == assembled.sparse_output_
+    assert [(name, cols) for name, _, cols in reference.transformers_] == [
+        (name, cols) for name, _, cols in assembled.transformers_
+    ]
+    for expected, got in zip(
+        reference.named_transformers_["encoder"].categories_,
+        assembled.named_transformers_["encoder"].categories_,
+        strict=True,
+    ):
+        np.testing.assert_array_equal(expected, got)
+
+
+def test__clean_data__assembly_matches_the_column_transformer_exactly() -> None:
+    """Same values as routing the same frame through the encoder itself."""
+    X, schema = _mixed_frame_inputs()
+    frame = fix_dtypes(
+        X.copy(), cat_indices=schema.indices_for(FeatureModality.CATEGORICAL)
+    )
+
+    assembled, _, _ = clean_data(X=X, feature_schema=schema)
+    expected = get_ordinal_encoder().fit_transform(frame).astype(np.float64)
+
+    np.testing.assert_array_equal(assembled, expected)
+
+
+def test__clean_data__object_passthrough_falls_back_to_the_encoder() -> None:
+    """A column the encoder skips but that is not float64 must not be assembled.
+
+    `object` is not in the encoder's dtype selection, so it reaches the output through
+    the passthrough; writing it into a float64 array is not the conversion the
+    encoder's path would have done, so the assembly has to decline.
+    """
+    frame = pd.DataFrame(
+        {
+            "num": np.arange(6, dtype="float64"),
+            "cat": pd.Categorical(["a", "b"] * 3),
+            "obj": np.array([1, 2, 3, 4, 5, 6], dtype=object),
+        }
+    )
+    encoder = get_ordinal_encoder()
+
+    assert not clean_module._can_write_encoded_columns(
+        frame, clean_module._encoder_selection(encoder.fit(frame.iloc[:1]))
+    )
+    # And the real call still works, through sklearn.
+    out = process_text_na_dataframe(
+        frame, ord_encoder=get_ordinal_encoder(), fit_encoder=True
+    )
+    assert out.shape == (6, 3)
+    assert out.dtype == np.float64


### PR DESCRIPTION
## Issue

[RES-2240: clean_data: redundant fp64 copies dominate remaining `fit()` CPU preprocessing and drive host-RAM peaks on wide tables](https://linear.app/priorlabs/issue/RES-2240/clean-data-redundant-fp64-copies-dominate-remaining-fit-cpu)

## Motivation and Context

**What**

- The encoded array is assembled column by column instead of being stacked by `ColumnTransformer` and then reordered.
- The assembly's precondition is checked before the inner encoder is fitted, not after.

**Why**

- The stack and the reorder gather each reached the RAM peak, which is why removing a later copy (#1173) moved the timing but not the peak.
- An input that fails the precondition was paying for a full pass over the categorical columns and then discarding it.

**How**

- Encoded columns are written straight into the output array at their own positions, so nothing needs stacking and nothing needs reordering.
- Column bookkeeping comes from a one-row structural fit (it makes no pass over the data); the inner encoder is then refit on every row for its categories.

______________________________________________________________________

## Public API Changes

- [x] No Public API changes
- [ ] Yes, Public API changes (Details below)

______________________________________________________________________

## How Has This Been Tested?

### Highest supported version

Benchmarked with `scripts/bench_clean_data.py --reference <parent branch>` from the `arthur/benchmark-clean-data` branch on a `cpuhighmem16spot` node (pandas 3.0.3). The harness also compares outputs against the reference on every run.

> [!WARNING]
> Time deltas are noisy (up to ~7% delta when A/A testing), but RSS isn't (0.5% delta)


Shapes:

- `numeric` is 666,667 x 2,000 float32 (5.33 GB);
- `half-string` and `numeric-object` are 333,333 x 400 object arrays, `half-string` with every other column a 20-level string.

"Transient RSS" is peak minus entry, i.e. what the call adds on top of what it was handed; wall time is the median of 3 repeats after 1 warmup.

| mix | transient RSS (parent) | transient RSS (this) | Δ RSS | median wall (parent) | median wall (this) | Δ time |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `numeric` | 10.67 GB | 10.67 GB | +0.0% | 5.409 s | 5.373 s | −0.7% |
| `half-string` | 2.74 GB | 2.09 GB | **−23.6%** | 14.189 s | 13.602 s | −4.1% |
| `numeric-object` | 2.79 GB | 2.79 GB | −0.0% | 9.847 s | 9.687 s | −1.6% |

<details><summary>Benchmark details</summary>

| mix | side | entry RSS | peak RSS | retained | cold call | median | min | max | spread | stdev |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| `numeric` | parent | 6.01 GB | 16.67 GB | 10.67 GB | 5.410 s | 5.409 s | 5.385 s | 5.415 s | 0.6% | 15.9 ms |
| `numeric` | this | 6.00 GB | 16.67 GB | 10.67 GB | 5.417 s | 5.373 s | 5.350 s | 5.381 s | 0.6% | 15.7 ms |
| `half-string` | parent | 3.88 GB | 6.62 GB | 1.06 GB | 14.305 s | 14.189 s | 14.076 s | 14.259 s | 1.3% | 92.0 ms |
| `half-string` | this | 3.88 GB | 5.97 GB | 1.06 GB | 13.736 s | 13.602 s | 13.506 s | 13.733 s | 1.7% | 113.7 ms |
| `numeric-object` | parent | 5.97 GB | 8.76 GB | 1.06 GB | 9.818 s | 9.847 s | 9.828 s | 9.851 s | 0.2% | 12.1 ms |
| `numeric-object` | this | 5.97 GB | 8.76 GB | 1.06 GB | 9.891 s | 9.687 s | 9.604 s | 9.703 s | 1.0% | 52.6 ms |

</details>

`half-string` is the only mix with categorical columns to encode, and the only one that moves: its peak RSS falls 6.62 → 5.97 GB (−9.8%). `numeric` and `numeric-object` never reach the new path.

### Lowest supported versions

| mix | transient RSS (parent) | transient RSS (this) | Δ RSS | median wall (parent) | median wall (this) | Δ time |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `numeric` (66,667 x 2,000) | 1.07 GB | 1.07 GB | +0.0% | 0.528 s | 0.526 s | −0.4% |
| `half-string` | 3.36 GB | 2.71 GB | **−19.2%** | 187.979 s | 185.406 s | −1.4% |
| `numeric-object` | 3.32 GB | 3.32 GB | +0.1% | 24.408 s | 21.797 s | −10.7% |

<details><summary>Benchmark explanation</summary>

Re-run against the floors in `pyproject.toml`, resolved with `uv pip install --resolution lowest-direct`: **pandas 1.4.0, numpy 1.21.6, scikit-learn 1.2.0, torch 2.5.0, Python 3.10**. Same harness, same node type, outputs identical to the parent branch again on all three mixes. `numeric` is measured at 66,667 x 2,000, the shape #1173's lowest-version run is pinned to.

The memory win mostly survives on the old stack (−19.2% against −23.6%). The timing win does not (−1.4% against −4.1%): `half-string` costs 188 s there against 14 s on pandas 3, and the assembly's saving is small against that.

`numeric-object`'s −10.7% is not a win this PR can claim. That mix takes the identity path, which neither commit here touches, and the identical parent-branch code measured 22.841 s on one node and 24.408 s on another.

</details>

Added tests:

- `tests/test_preprocessing/test_data_cleaning.py`: the assembly path is taken for a mixed frame, and its result matches `ColumnTransformer.fit_transform` exactly -- array and fitted state (`n_features_in_`, `output_indices_`, `sparse_output_`, `transformers_`, `categories_`).
- Inputs that fail the precondition (`object` passthrough, duplicate column names) fall back to sklearn, and a test counts encoder fits over the full row set: two before, one now.

______________________________________________________________________

## Checklist

- [x] The changes have been tested locally.
- [x] Documentation has been updated (if the public API or usage changes).
- [x] A changelog entry has been added (see `changelog/README.md`), or "no changelog needed" label requested.
- [x] The code follows the project's style guidelines.
- [x] I have considered the impact of these changes on the public API.

______________________________________________________________________

