### PR TITLE
Skip the Claude review workflow on release PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,17 @@ jobs:
     # cleaner workflow-run history.
     #
     # Skip Dependabot PRs: the Claude action will fail by default on them.
-    if: github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]'
+    #
+    # Skip release PRs: `release-create-pr.yml` opens them as
+    # github-actions[bot], and the action hard-fails on bot actors that are not
+    # in `allowed_bots` ("Workflow initiated by non-human actor"). They match
+    # the `paths` filter only because they bump `pyproject.toml`, and they
+    # contain no reviewable code — just a version bump and the Towncrier
+    # changelog build. `check-changelog.yml` skips them on the same grounds.
+    if: >-
+      github.event.pull_request.head.repo.fork == false &&
+      github.actor != 'dependabot[bot]' &&
+      !startsWith(github.head_ref, 'release/v')
 
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/changelog/1177.fixed.md
+++ b/changelog/1177.fixed.md
@@ -1,0 +1,1 @@
+Skip the Claude code review workflow on bot-authored release PRs, which previously failed the `claude-review` check on every release.


### PR DESCRIPTION
Release PRs opened by `release-create-pr.yml` are authored by `github-actions[bot]`. `claude-code-action` refuses to run for bot actors not listed in `allowed_bots` and hard-fails the job:

```
Action failed with error: Workflow initiated by non-human actor:
github-actions (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.
```

Release PRs only match this workflow's `paths` filter because they bump `pyproject.toml`. They contain no reviewable code — just the version bump and the Towncrier changelog build — so there is nothing for the review to say.

This has been reddening release PRs since at least v8.1.0: #1110 was merged on 2026-07-13 with `claude-review` failing on the identical error, and #1176 (v8.3.0) hit it again today. The check is not in the `Restrict Main Branch` required-checks list, so it never blocked a merge, but it has made every release PR look broken.

`check-changelog.yml` already skips `release/v*` heads on the same grounds; this mirrors that gate.

## Verification

`if` expression parses to a single condition:

```
github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]' && !startsWith(github.head_ref, 'release/v')
```

Takes effect for the next release PR cut after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)