### PR TITLE
perf: efficient pandas dtype casting

### DIFF
--- a/changelog/1180.changed.md
+++ b/changelog/1180.changed.md
@@ -1,0 +1,1 @@
+`fit()` no longer slows to a crawl on wide tables with categorical columns under pandas < 3: the dtype casts no longer rebuild the frame one column at a time, which took minutes on a 333,333 x 400 table and now takes seconds.

--- a/src/tabpfn/preprocessing/clean.py
+++ b/src/tabpfn/preprocessing/clean.py
@@ -55,18 +55,13 @@ def _cast_columns_share_a_block(
 ) -> bool:
     """Whether any of `columns` sits in a block that holds more than one column.
 
-    That is what makes assigning a cast back expensive: the block a column is deleted
-    from is rebuilt whole, so a column with a block to itself costs nothing and one
-    sharing a block of 400 costs 400 columns' worth of copying. Blocks holding no
-    column being cast are not touched, so they do not count.
-
-    A frame that does not expose its blocks in the shape expected here answers `True`
-    as well, sending it down the route that cannot go quadratic.
+    That would make assigning a cast back expensive: the block a column is deleted
+    from is rebuilt whole.
+    Since columns are assigned one at a time, casting `c` columns out of a block
+    costs `c(c+1)/2` column copies.
     """
-    blocks = getattr(getattr(X, "_mgr", None), "blocks", None)
-    if blocks is None:
-        return True
     try:
+        blocks = X._mgr.blocks
         columns_in_block = np.zeros(X.shape[1], dtype=np.intp)
         for block in blocks:
             positions = block.mgr_locs.as_array
@@ -74,9 +69,11 @@ def _cast_columns_share_a_block(
         cast_positions = X.columns.get_indexer_for(columns)
     except (AttributeError, TypeError, ValueError, IndexError):
         return True
-    if len(cast_positions) == 0 or (cast_positions < 0).any():
-        return True
-    return bool((columns_in_block[cast_positions] > 1).any())
+    return (
+        len(cast_positions) == 0
+        or (cast_positions < 0).any().item()
+        or (columns_in_block[cast_positions] > 1).any().item()
+    )
 
 
 def _cast_columns(

--- a/src/tabpfn/preprocessing/clean.py
+++ b/src/tabpfn/preprocessing/clean.py
@@ -40,8 +40,65 @@ OBJECT_DTYPE_KINDS = "OV"
 STRING_DTYPE_KINDS = "SaU"
 UNSUPPORTED_DTYPE_KINDS = "cM"  # Not needed, just for completeness
 PANDAS_FASTER_THAN_MIXED_PATH = Version(pd.__version__) < Version("3.0.0")
+# Before 3.0 `astype` copies every column by default, including the ones it is not
+# casting; from 3.0 copy-on-write makes the keyword a no-op and passing it warns.
+_ASTYPE_KEEPS_UNCAST_COLUMNS = (
+    {"copy": False} if Version(pd.__version__) < Version("3.0.0") else {}
+)
 
 _FLOAT64 = np.dtype(np.float64)
+
+
+def _cast_columns(
+    X: pd.DataFrame,
+    columns: pd.Index | Sequence[Any],
+    dtype: Any,
+) -> pd.DataFrame:
+    """`X` with `columns` cast to `dtype`, by whichever route suits its blocks.
+
+    `X[columns] = X[columns].astype(dtype)` is one `__setitem__` per column before
+    pandas 3, and each one deletes its column out of the block manager. What that
+    costs depends entirely on whether the column has a block to itself:
+
+    * A block holding many columns is rebuilt by an `np.delete` over the whole thing,
+      once per column, so the cast is quadratic in column count. That is the frame
+      the categorical cast is handed -- a freshly built object array, still one
+      block. Measured at 200,000 x 400: 347.7 s and a 805 MB peak, against 9.5 s and
+      1 MB for `astype`.
+    * A block per column, which is what `convert_dtypes` leaves behind, makes the
+      delete free and the two spellings equivalent in time (247 ms against 152 ms)
+      -- but only the assignment releases each source column as it goes. `astype`
+      builds every cast column before assembling them, so it holds the whole old set
+      alongside the whole new one: an extra 1.59 GB on the `numeric-object` mix,
+      +47.7% of its transient RSS.
+
+    So the layout decides. `astype` where a block is shared, the assignment where it
+    is not, and an unrecognisable frame takes `astype`, which is never pathological
+    in time -- only in memory, and only by one copy.
+
+    Duplicate column labels also take `astype`, which is the only one of the two that
+    can express the cast: selecting `["dup", "dup"]` hands back both columns twice
+    over, and the assignment refuses the width it gets back.
+    """
+    if len(columns) == 0:
+        return X
+
+    blocks = getattr(getattr(X, "_mgr", None), "blocks", None)
+    if (
+        blocks is not None
+        and len(blocks) >= X.shape[1]
+        and not X.columns.has_duplicates
+    ):
+        # A block per column. Copied shallowly first because the assignment writes
+        # into the frame's own manager: whole columns are replaced, never the arrays
+        # behind them, so the caller keeps both its columns and its data.
+        X = X.copy(deep=False)
+        X[columns] = X[columns].astype(dtype)
+        return X
+
+    # `fromkeys` rather than a comprehension: duplicate labels collapse to one entry,
+    # which is what a single dtype for all of them means anyway.
+    return X.astype(dict.fromkeys(columns, dtype), **_ASTYPE_KEEPS_UNCAST_COLUMNS)
 
 
 def clean_data(
@@ -126,13 +183,13 @@ def coerce_nullable_dtypes_to_numpy(X: pd.DataFrame) -> pd.DataFrame:
         if pd.api.types.is_bool_dtype(dtype)
         or (pd.api.types.is_extension_array_dtype(dtype) and dtype.kind in "iuf")
     ]
-    if cols:
-        X = X.copy()
-        X[cols] = X[cols].astype("float64")
-    return X
+    # Through `_cast_columns` for the reason given there, which also removes the copy
+    # this needed: it built one so the cast would not land in the caller's frame, and
+    # `astype` does not write into the frame at all.
+    return _cast_columns(X, cols, "float64")
 
 
-def fix_dtypes(  # noqa: D103, C901, PLR0912
+def fix_dtypes(  # noqa: D103
     X: pd.DataFrame | np.ndarray,
     cat_indices: Sequence[int | str] | None,
     numeric_dtype: Literal["float32", "float64"] = "float64",
@@ -174,9 +231,9 @@ def fix_dtypes(  # noqa: D103, C901, PLR0912
         use_col_names = is_numeric_indices and not columns_are_numeric
         if use_col_names:
             cat_col_names = [X.columns[i] for i in cat_indices]
-            X[cat_col_names] = X[cat_col_names].astype("category")
+            X = _cast_columns(X, cat_col_names, "category")
         else:
-            X[cat_indices] = X[cat_indices].astype("category")
+            X = _cast_columns(X, cat_indices, "category")
 
     # Alright, pandas can have a few things go wrong.
     #
@@ -200,8 +257,7 @@ def fix_dtypes(  # noqa: D103, C901, PLR0912
         # `object` at fit (-> passthrough) but `string` at predict; the frozen
         # passthrough then lets raw strings reach the float cast below and crash.
         object_columns = X.select_dtypes(include=["object"]).columns
-        if len(object_columns) > 0:
-            X[object_columns] = X[object_columns].astype("string")
+        X = _cast_columns(X, object_columns, "string")
 
     numerical_columns = X.select_dtypes(include=["number"]).columns
     # Assigning the numeric columns back is not free even when the cast is a no-op:
@@ -213,7 +269,7 @@ def fix_dtypes(  # noqa: D103, C901, PLR0912
         len(numerical_columns) > 0
         and not (X.dtypes[numerical_columns] == np.dtype(numeric_dtype)).all()
     ):
-        X[numerical_columns] = X[numerical_columns].astype(numeric_dtype)
+        X = _cast_columns(X, numerical_columns, numeric_dtype)
     return X
 
 

--- a/src/tabpfn/preprocessing/clean.py
+++ b/src/tabpfn/preprocessing/clean.py
@@ -49,6 +49,36 @@ _ASTYPE_KEEPS_UNCAST_COLUMNS = (
 _FLOAT64 = np.dtype(np.float64)
 
 
+def _cast_columns_share_a_block(
+    X: pd.DataFrame,
+    columns: pd.Index | Sequence[Any],
+) -> bool:
+    """Whether any of `columns` sits in a block that holds more than one column.
+
+    That is what makes assigning a cast back expensive: the block a column is deleted
+    from is rebuilt whole, so a column with a block to itself costs nothing and one
+    sharing a block of 400 costs 400 columns' worth of copying. Blocks holding no
+    column being cast are not touched, so they do not count.
+
+    A frame that does not expose its blocks in the shape expected here answers `True`
+    as well, sending it down the route that cannot go quadratic.
+    """
+    blocks = getattr(getattr(X, "_mgr", None), "blocks", None)
+    if blocks is None:
+        return True
+    try:
+        columns_in_block = np.zeros(X.shape[1], dtype=np.intp)
+        for block in blocks:
+            positions = block.mgr_locs.as_array
+            columns_in_block[positions] = len(positions)
+        cast_positions = X.columns.get_indexer_for(columns)
+    except (AttributeError, TypeError, ValueError, IndexError):
+        return True
+    if len(cast_positions) == 0 or (cast_positions < 0).any():
+        return True
+    return bool((columns_in_block[cast_positions] > 1).any())
+
+
 def _cast_columns(
     X: pd.DataFrame,
     columns: pd.Index | Sequence[Any],
@@ -72,26 +102,27 @@ def _cast_columns(
       alongside the whole new one: an extra 1.59 GB on the `numeric-object` mix,
       +47.7% of its transient RSS.
 
-    So the layout decides. `astype` where a block is shared, the assignment where it
-    is not, and an unrecognisable frame takes `astype`, which is never pathological
-    in time -- only in memory, and only by one copy.
+    So the layout decides -- and only the layout of the columns being cast, since a
+    delete rebuilds the block its own column sits in and no other. A frame can hold a
+    shared block and still cast cheaply by assignment, which is not a corner case:
+    pandas 3 gives a mixed object frame one block per string column and a single
+    consolidated block for all the numeric ones, so the categorical cast's columns
+    are private there while the frame as a whole is not.
 
-    Duplicate column labels also take `astype`, which is the only one of the two that
-    can express the cast: selecting `["dup", "dup"]` hands back both columns twice
-    over, and the assignment refuses the width it gets back.
+    A frame whose blocks cannot be read takes `astype`, which is never pathological
+    in time -- only in memory, and only by one copy. So do duplicate column labels,
+    `astype` being the only one of the two that can express the cast at all:
+    selecting `["dup", "dup"]` hands back both columns twice over, and the assignment
+    refuses the width it gets back.
     """
     if len(columns) == 0:
         return X
 
-    blocks = getattr(getattr(X, "_mgr", None), "blocks", None)
-    if (
-        blocks is not None
-        and len(blocks) >= X.shape[1]
-        and not X.columns.has_duplicates
-    ):
-        # A block per column. Copied shallowly first because the assignment writes
-        # into the frame's own manager: whole columns are replaced, never the arrays
-        # behind them, so the caller keeps both its columns and its data.
+    if not _cast_columns_share_a_block(X, columns) and not X.columns.has_duplicates:
+        # Every column to cast has a block to itself. Copied shallowly first because
+        # the assignment writes into the frame's own manager: whole columns are
+        # replaced, never the arrays behind them, so the caller keeps both its
+        # columns and its data.
         X = X.copy(deep=False)
         X[columns] = X[columns].astype(dtype)
         return X

--- a/src/tabpfn/preprocessing/clean.py
+++ b/src/tabpfn/preprocessing/clean.py
@@ -81,51 +81,19 @@ def _cast_columns(
     columns: pd.Index | Sequence[Any],
     dtype: Any,
 ) -> pd.DataFrame:
-    """`X` with `columns` cast to `dtype`, by whichever route suits its blocks.
-
-    `X[columns] = X[columns].astype(dtype)` is one `__setitem__` per column before
-    pandas 3, and each one deletes its column out of the block manager. What that
-    costs depends entirely on whether the column has a block to itself:
-
-    * A block holding many columns is rebuilt by an `np.delete` over the whole thing,
-      once per column, so the cast is quadratic in column count. That is the frame
-      the categorical cast is handed -- a freshly built object array, still one
-      block. Measured at 200,000 x 400: 347.7 s and a 805 MB peak, against 9.5 s and
-      1 MB for `astype`.
-    * A block per column, which is what `convert_dtypes` leaves behind, makes the
-      delete free and the two spellings equivalent in time (247 ms against 152 ms)
-      -- but only the assignment releases each source column as it goes. `astype`
-      builds every cast column before assembling them, so it holds the whole old set
-      alongside the whole new one: an extra 1.59 GB on the `numeric-object` mix,
-      +47.7% of its transient RSS.
-
-    So the layout decides -- and only the layout of the columns being cast, since a
-    delete rebuilds the block its own column sits in and no other. A frame can hold a
-    shared block and still cast cheaply by assignment, which is not a corner case:
-    pandas 3 gives a mixed object frame one block per string column and a single
-    consolidated block for all the numeric ones, so the categorical cast's columns
-    are private there while the frame as a whole is not.
-
-    A frame whose blocks cannot be read takes `astype`, which is never pathological
-    in time -- only in memory, and only by one copy. So do duplicate column labels,
-    `astype` being the only one of the two that can express the cast at all:
-    selecting `["dup", "dup"]` hands back both columns twice over, and the assignment
-    refuses the width it gets back.
-    """
+    """Efficiently cast `columns` in `X` to `dtype`."""
     if len(columns) == 0:
         return X
 
     if not _cast_columns_share_a_block(X, columns) and not X.columns.has_duplicates:
-        # Every column to cast has a block to itself. Copied shallowly first because
-        # the assignment writes into the frame's own manager: whole columns are
-        # replaced, never the arrays behind them, so the caller keeps both its
-        # columns and its data.
+        # this path uses less memory when available
+        # Copied shallowly to not copy the columns themselves:
         X = X.copy(deep=False)
         X[columns] = X[columns].astype(dtype)
         return X
 
-    # `fromkeys` rather than a comprehension: duplicate labels collapse to one entry,
-    # which is what a single dtype for all of them means anyway.
+    # fallback: never costly in time
+    # cast only the columns that need to be:
     return X.astype(dict.fromkeys(columns, dtype), **_ASTYPE_KEEPS_UNCAST_COLUMNS)
 
 
@@ -211,9 +179,6 @@ def coerce_nullable_dtypes_to_numpy(X: pd.DataFrame) -> pd.DataFrame:
         if pd.api.types.is_bool_dtype(dtype)
         or (pd.api.types.is_extension_array_dtype(dtype) and dtype.kind in "iuf")
     ]
-    # Through `_cast_columns` for the reason given there, which also removes the copy
-    # this needed: it built one so the cast would not land in the caller's frame, and
-    # `astype` does not write into the frame at all.
     return _cast_columns(X, cols, "float64")
 
 

--- a/src/tabpfn/preprocessing/clean.py
+++ b/src/tabpfn/preprocessing/clean.py
@@ -57,8 +57,8 @@ def _cast_columns_share_a_block(
 
     That would make assigning a cast back expensive: the block a column is deleted
     from is rebuilt whole.
-    Since columns are assigned one at a time, casting `c` columns out of a block
-    costs `c(c+1)/2` column copies.
+    Since columns are assigned one at a time on pandas < 3, casting `c` columns
+    out of a block costs `c(c+1)/2` column copies.
     """
     try:
         blocks = X._mgr.blocks
@@ -91,6 +91,8 @@ def _cast_columns(
         X = X.copy(deep=False)
         X[columns] = X[columns].astype(dtype)
         return X
+
+    # NOTE: this path is there for pandas < 3 compatibility
 
     # fallback: never costly in time
     # cast only the columns that need to be:

--- a/tests/test_preprocessing/test_data_cleaning.py
+++ b/tests/test_preprocessing/test_data_cleaning.py
@@ -1098,3 +1098,92 @@ def test__clean_data__object_passthrough_falls_back_to_the_encoder() -> None:
     )
     assert out.shape == (6, 3)
     assert out.dtype == np.float64
+
+
+def test__cast_columns__a_shared_block_is_never_assigned_into() -> None:
+    """A frame whose columns share a block must not be cast one `__setitem__` at a time.
+
+    That spelling deletes each column out of the block it sits in, rebuilding the
+    whole block every time, so the cast is quadratic in column count -- the reason
+    the mixed mixes ran for minutes on the lowest supported pandas. It is the layout
+    `fix_dtypes` hands the categorical cast: a freshly built object array.
+    """
+    values = np.empty((4, 6), dtype=object)
+    values[:, :] = "lvl"
+    frame = pd.DataFrame(values, copy=True)
+    if len(frame._mgr.blocks) >= frame.shape[1]:
+        pytest.skip("this pandas gives an object array a block per column")
+
+    with mock.patch.object(
+        pd.DataFrame, "__setitem__", autospec=True, side_effect=AssertionError
+    ):
+        out = clean_module._cast_columns(frame, frame.columns[1::2], "category")
+
+    assert list(out.dtypes[1::2].map(str)) == ["category"] * 3
+    assert list(out.dtypes[0::2].map(str)) == ["object"] * 3
+
+
+def test__cast_columns__a_block_per_column_frame_keeps_its_own_columns() -> None:
+    """The assignment route is taken there, and still must not reach the caller.
+
+    `astype` is the wrong tool once every column has its own block: the delete it
+    avoids is free, and building every cast column before assembling them holds a
+    second full copy of the frame, which cost 47.7% more transient RSS on the
+    `numeric-object` mix.
+    """
+    frame = _fragmented_float_frame(np.random.default_rng(0).standard_normal((8, 5)))
+    assert len(frame._mgr.blocks) >= frame.shape[1]
+    before = list(frame.dtypes)
+
+    out = clean_module._cast_columns(frame, frame.columns[:3], "float32")
+
+    assert [str(dtype) for dtype in out.dtypes] == ["float32"] * 3 + ["float64"] * 2
+    assert list(frame.dtypes) == before
+
+
+def test__fix_dtypes__leaves_a_caller_s_frame_as_it_found_it() -> None:
+    """Casting returns a new frame rather than writing into the one handed in."""
+    X, schema = _mixed_frame_inputs()
+    caller_frame = pd.DataFrame(X)
+    before = list(caller_frame.dtypes)
+
+    fix_dtypes(
+        caller_frame, cat_indices=schema.indices_for(FeatureModality.CATEGORICAL)
+    )
+
+    assert list(caller_frame.dtypes) == before
+
+
+def test__coerce_nullable_dtypes_to_numpy__converts_without_touching_the_input() -> (
+    None
+):
+    """Nullable and boolean columns become float64; the caller's frame is untouched."""
+    frame = pd.DataFrame(
+        {
+            "nullable": pd.array([1, None, 3], dtype="Int64"),
+            "boolean": pd.array([True, False, None], dtype="boolean"),
+            "text": pd.array(["a", "b", "c"], dtype="string"),
+        }
+    )
+
+    out = clean_module.coerce_nullable_dtypes_to_numpy(frame)
+
+    assert [str(dtype) for dtype in out.dtypes] == ["float64", "float64", "string"]
+    np.testing.assert_array_equal(out["nullable"], [1.0, np.nan, 3.0])
+    np.testing.assert_array_equal(out["boolean"], [1.0, 0.0, np.nan])
+    assert [str(dtype) for dtype in frame.dtypes] == ["Int64", "boolean", "string"]
+
+
+def test__fix_dtypes__duplicate_column_names_are_all_cast() -> None:
+    """Duplicate labels collapse to one entry in the mapping, and both columns cast.
+
+    Columns of different dtypes under one label remain unsupported -- selecting them
+    by name takes both, so the cast that suits one is applied to the other and
+    raises, before this change as after it.
+    """
+    frame = pd.DataFrame(np.array([[1, 2], [3, 4]], dtype=object))
+    frame.columns = ["dup", "dup"]
+
+    out = fix_dtypes(frame, cat_indices=None)
+
+    assert [str(dtype) for dtype in out.dtypes] == ["float64", "float64"]

--- a/tests/test_preprocessing/test_data_cleaning.py
+++ b/tests/test_preprocessing/test_data_cleaning.py
@@ -1111,13 +1111,14 @@ def test__cast_columns__a_shared_block_is_never_assigned_into() -> None:
     values = np.empty((4, 6), dtype=object)
     values[:, :] = "lvl"
     frame = pd.DataFrame(values, copy=True)
-    if len(frame._mgr.blocks) >= frame.shape[1]:
+    columns = frame.columns[1::2]
+    if not clean_module._cast_columns_share_a_block(frame, columns):
         pytest.skip("this pandas gives an object array a block per column")
 
     with mock.patch.object(
         pd.DataFrame, "__setitem__", autospec=True, side_effect=AssertionError
     ):
-        out = clean_module._cast_columns(frame, frame.columns[1::2], "category")
+        out = clean_module._cast_columns(frame, columns, "category")
 
     assert list(out.dtypes[1::2].map(str)) == ["category"] * 3
     assert list(out.dtypes[0::2].map(str)) == ["object"] * 3
@@ -1139,6 +1140,35 @@ def test__cast_columns__a_block_per_column_frame_keeps_its_own_columns() -> None
 
     assert [str(dtype) for dtype in out.dtypes] == ["float32"] * 3 + ["float64"] * 2
     assert list(frame.dtypes) == before
+
+
+def test__cast_columns__a_shared_block_it_does_not_touch_does_not_count() -> None:
+    """Only the blocks the cast columns sit in decide the route.
+
+    A frame can hold a shared block and still cast cheaply, which is the shape
+    pandas 3 hands the categorical cast: every string column in a block of its own,
+    all the numeric ones consolidated into one. Routing that to `astype` would copy
+    the consolidated block for nothing.
+    """
+    frame = pd.DataFrame(np.random.default_rng(0).standard_normal((8, 4)))
+    frame["a"] = pd.array(range(8), dtype="Int64")
+    frame["b"] = pd.array(range(8), dtype="Int64")
+    assert clean_module._cast_columns_share_a_block(frame, frame.columns) is True
+    assert clean_module._cast_columns_share_a_block(frame, ["a", "b"]) is False
+
+    assignments = []
+    original = pd.DataFrame.__setitem__
+
+    def recording(self, key, value):  # noqa: ANN202
+        assignments.append(key)
+        return original(self, key, value)
+
+    with mock.patch.object(pd.DataFrame, "__setitem__", recording):
+        out = clean_module._cast_columns(frame, ["a", "b"], "float64")
+
+    assert assignments, "the private columns should have been assigned, not astyped"
+    assert [str(dtype) for dtype in out.dtypes[-2:]] == ["float64", "float64"]
+    assert [str(dtype) for dtype in frame.dtypes[-2:]] == ["Int64", "Int64"]
 
 
 def test__fix_dtypes__leaves_a_caller_s_frame_as_it_found_it() -> None:


### PR DESCRIPTION
## Issue

[RES-2240: clean_data: redundant fp64 copies dominate remaining `fit()` CPU preprocessing and drive host-RAM peaks on wide tables](https://linear.app/priorlabs/issue/RES-2240/clean-data-redundant-fp64-copies-dominate-remaining-fit-cpu)

## Motivation and Context

**Why**

- Assigning back is one `__setitem__` per column before pandas 3, and each rebuilds the block its column sits in: casting `c` columns out of a block costs `c(c+1)/2` column copies.
- `astype` holds a second full copy of a frame that already has a block per column, which cost `numeric-object` 47.7% more transient RSS when applied everywhere.

**How**

2 code paths:

- A shared block takes `astype` with a dtype mapping, which casts each column once (so it's never slower).
- When each column has its own block, we can release each input column as we replace it, which costs less memory.

______________________________________________________________________

## Public API Changes

- [x] No Public API changes
- [ ] Yes, Public API changes (Details below)

______________________________________________________________________

## How Has This Been Tested?

Benchmarked with `scripts/bench_clean_data.py --reference <parent branch>` from the `arthur/benchmark-clean-data` branch on a `cpuhighmem16spot` node. Outputs are identical to the parent branch on all six pairs.

| environment | mix | Δ transient RSS | Δ median wall |
| --- | --- | ---: | ---: |
| pandas 1.4.0 | `half-string` | +0.2% | 191.3 s → 19.2 s (**−90.0%**) |
| pandas 1.4.0 | `numeric-object` | 3.33 GB → 2.80 GB (**−16.0%**) | −2.3% |
| pandas 3.0.3 | `half-string` | +0.5% | −0.8% |
| pandas 3.0.3 | `numeric-object` | +0.1% | −5.8% |
| pandas 3.0.3 | `numeric` | +0.0% | −0.0% |

An A/A run of this harness puts its floor at ±3% on wall time and ≤0.5% on transient RSS, so the two bolded numbers are the result and the rest is the point: nothing on pandas 3 moves.

<details><summary>Details</summary>

The cast, timed on its own at 200,000 x 400 on pandas 1.4:

| frame the cast is handed | assign back | `astype` mapping |
| --- | ---: | ---: |
| one block for 400 columns (`pd.DataFrame(object_array)`, what the categorical cast sees) | 347.7 s, +805 MB | 9.5 s, +1 MB |
| a block per column (what `convert_dtypes` leaves, what the numeric cast sees) | 247 ms, +24 MB | 152 ms, +21 MB |

`X[cols] = X[cols].astype(dtype)` reaches `_setitem_array`, which loops `for k1, k2 in zip(key, value.columns): self[k1] = value[k2]` (`pandas/core/frame.py:3687` in 1.4.0). Each single-column assignment deletes that column out of its block, and `Block.delete` is an `np.delete` over the whole block -- free when the block holds one column, a full-block rebuild when it holds 400.

pandas 3 splits an object array into one block per column, so nothing there shares a block and the two spellings measure the same (133 ms against 128 ms). This is why the switch is on layout rather than on version: the layout is what the cost depends on, and pandas 3 simply never presents the bad one.

`half-string` on pandas 1.4 now takes 19.2 s against 12.9 s on pandas 3, where it took 191 s before. The remaining gap is the pure-pandas inf-mask path `PANDAS_FASTER_THAN_MIXED_PATH` selects, not this cast.

`numeric-object`'s −16.0% is not from the routing: with no categorical columns the old code still ran `X[[]] = X[[]].astype("category")`, and the helper returns early on an empty selection. Inferred from the code path rather than measured separately.

</details>

Added tests:

- `_cast_columns` is pinned from both sides: a shared-block frame must not be assigned into one column at a time (`__setitem__` patched to fail; skipped on pandas 3, which has no such frame), and a block-per-column frame must come back cast without the caller's dtypes changing.
- `fix_dtypes` no longer casts into a `DataFrame` handed to it, duplicate labels are cast rather than refused, and `coerce_nullable_dtypes_to_numpy` converts nullable and boolean columns while leaving its input alone.

______________________________________________________________________

## Checklist

- [x] The changes have been tested locally.
- [x] Documentation has been updated (if the public API or usage changes).
- [x] A changelog entry has been added (see `changelog/README.md`), or "no changelog needed" label requested.
- [x] The code follows the project's style guidelines.
- [x] I have considered the impact of these changes on the public API.

______________________________________________________________________