### PR TITLE
Add estimator sharding for DDP fine-tuning

### DIFF
--- a/changelog/1182.added.md
+++ b/changelog/1182.added.md
@@ -1,0 +1,1 @@
+In the previous setup, all GPUs in finetuning with DDP held all activations of all estimators in memory. This PR divides estimator activations across the available GPUs.

--- a/src/tabpfn/finetuning/finetuned_base.py
+++ b/src/tabpfn/finetuning/finetuned_base.py
@@ -293,6 +293,20 @@ def _slice_batch_estimators(
     )
 
 
+def _get_loss_for_logging(
+    loss: torch.Tensor,
+    estimator_shard: _EstimatorShard | None,
+) -> float:
+    """Return the global estimator-mean loss without changing its gradients."""
+    loss_for_logging = loss.detach()
+    if estimator_shard is not None:
+        # ``loss`` includes the DDP gradient-correction scale. Its rank mean is
+        # therefore the global estimator mean, including for uneven shards.
+        loss_for_logging = loss_for_logging / estimator_shard.world_size
+        dist.all_reduce(loss_for_logging, op=dist.ReduceOp.SUM)
+    return float(loss_for_logging.item())
+
+
 @dataclass
 class EvalResult:
     """Container for evaluation results.
@@ -1169,7 +1183,7 @@ class FinetunedTabPFNBase(BaseEstimator, ABC):
                 if scheduler is not None:
                     scheduler.step()
 
-                loss_scalar = float(loss.detach().item())
+                loss_scalar = _get_loss_for_logging(loss, estimator_shard)
 
                 epoch_loss_sum += loss_scalar
                 epoch_batches += 1

--- a/src/tabpfn/finetuning/finetuned_base.py
+++ b/src/tabpfn/finetuning/finetuned_base.py
@@ -1098,13 +1098,16 @@ class FinetunedTabPFNBase(BaseEstimator, ABC):
             for batch in progress_bar:
                 optimizer.zero_grad()
 
+                # Decide whether to skip from the complete estimator ensemble.
+                # Classifier context labels may be permuted per estimator, so a
+                # rank-local shard alone does not preserve the original check's
+                # union-of-labels semantics.
+                should_skip = self._should_skip_batch(batch)
                 rank_batch = (
                     _slice_batch_estimators(batch, estimator_shard)
                     if estimator_shard is not None
                     else batch
                 )
-
-                should_skip = self._should_skip_batch(rank_batch)
                 if using_ddp:
                     # All ranks must agree — if any rank skips, all skip,
                     # otherwise DDP all-reduce in backward will deadlock.

--- a/src/tabpfn/finetuning/finetuned_base.py
+++ b/src/tabpfn/finetuning/finetuned_base.py
@@ -18,7 +18,7 @@ import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from contextlib import contextmanager
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
@@ -236,6 +236,63 @@ class _TabPFNDDPWrapper(torch.nn.Module):
         return self.estimator.forward(*args, **kwargs)
 
 
+@dataclass(frozen=True)
+class _EstimatorShard:
+    """Contiguous estimator shard assigned to one distributed rank."""
+
+    start: int
+    stop: int
+    total_estimators: int
+    world_size: int
+
+    @property
+    def size(self) -> int:
+        """Number of estimators handled by this rank."""
+        return self.stop - self.start
+
+    @property
+    def gradient_scale(self) -> float:
+        """Scale local mean loss so DDP's rank mean equals the global mean."""
+        return self.world_size * self.size / self.total_estimators
+
+
+def _get_estimator_shard(
+    total_estimators: int, rank: int, world_size: int
+) -> _EstimatorShard:
+    """Split estimators as evenly as possible into non-empty rank shards."""
+    if world_size < 1:
+        raise ValueError(f"world_size must be positive; got {world_size}.")
+    if not 0 <= rank < world_size:
+        raise ValueError(f"rank must be in [0, {world_size}); got {rank}.")
+    if total_estimators < world_size:
+        raise ValueError(
+            "Estimator sharding requires n_estimators_finetune >= world_size; "
+            f"got {total_estimators} estimators and {world_size} ranks."
+        )
+    base, remainder = divmod(total_estimators, world_size)
+    start = rank * base + min(rank, remainder)
+    stop = start + base + int(rank < remainder)
+    return _EstimatorShard(start, stop, total_estimators, world_size)
+
+
+def _slice_batch_estimators(
+    batch: ClassifierBatch | RegressorBatch,
+    shard: _EstimatorShard,
+) -> ClassifierBatch | RegressorBatch:
+    """Keep only this rank's estimator inputs in a collated fine-tuning batch."""
+    estimator_slice = slice(shard.start, shard.stop)
+    # After meta_dataset_collator, cat_indices is [dataset batch][estimator][column].
+    cat_indices = [items[estimator_slice] for items in batch.cat_indices]
+    return replace(
+        batch,
+        X_context=batch.X_context[estimator_slice],
+        X_query=batch.X_query[estimator_slice],
+        y_context=batch.y_context[estimator_slice],
+        cat_indices=cat_indices,
+        configs=batch.configs[estimator_slice],
+    )
+
+
 @dataclass
 class EvalResult:
     """Container for evaluation results.
@@ -322,6 +379,11 @@ class FinetunedTabPFNBase(BaseEstimator, ABC):
             Defaults to 2.
         use_activation_checkpointing: Whether to use activation checkpointing to
             reduce memory usage. Defaults to True.
+        shard_estimators_across_gpus: When True under DDP, every rank processes the
+            same data chunk but only a shard of the fine-tuning estimators. DDP then
+            averages gradients across estimator shards. This reduces per-rank
+            activation memory instead of only distributing data chunks. Defaults to
+            False.
         save_checkpoint_interval: Number of epochs between checkpoint saves. This
             only has an effect if `output_dir` is provided during the `fit()` call.
             If None, no intermediate checkpoints are saved. The best model checkpoint
@@ -366,6 +428,7 @@ class FinetunedTabPFNBase(BaseEstimator, ABC):
         n_estimators_validation: int = 2,
         n_estimators_final_inference: int = 2,
         use_activation_checkpointing: bool = True,
+        shard_estimators_across_gpus: bool = False,
         save_checkpoint_interval: int | None = 10,
         use_fixed_preprocessing_seed: bool = True,
         experiment_logger: FinetuningLogger | None = None,
@@ -395,10 +458,13 @@ class FinetunedTabPFNBase(BaseEstimator, ABC):
         self.n_estimators_validation = n_estimators_validation
         self.n_estimators_final_inference = n_estimators_final_inference
         self.use_activation_checkpointing = use_activation_checkpointing
+        self.shard_estimators_across_gpus = shard_estimators_across_gpus
         self.save_checkpoint_interval = save_checkpoint_interval
         self.meta_batch_size = META_BATCH_SIZE
         self.use_fixed_preprocessing_seed = use_fixed_preprocessing_seed
         self._ddp_module_: DistributedDataParallel | None = None
+        self._local_n_estimators_ = n_estimators_finetune
+        self._estimator_gradient_scale_ = 1.0
 
         if self.use_fixed_preprocessing_seed and not (
             self.n_estimators_finetune
@@ -677,6 +743,32 @@ class FinetunedTabPFNBase(BaseEstimator, ABC):
         if using_ddp:
             self.device = device_str
 
+        self._local_n_estimators_ = self.n_estimators_finetune
+        self._estimator_gradient_scale_ = 1.0
+        estimator_shard: _EstimatorShard | None = None
+        if self.shard_estimators_across_gpus:
+            if not using_ddp:
+                warnings.warn(
+                    "`shard_estimators_across_gpus=True` has no effect without DDP.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            else:
+                estimator_shard = _get_estimator_shard(
+                    self.n_estimators_finetune,
+                    dist.get_rank(),
+                    dist.get_world_size(),
+                )
+                self._local_n_estimators_ = estimator_shard.size
+                self._estimator_gradient_scale_ = estimator_shard.gradient_scale
+                logger.info(
+                    "Rank %d fine-tuning estimator shard [%d:%d] of %d",
+                    dist.get_rank(),
+                    estimator_shard.start,
+                    estimator_shard.stop,
+                    estimator_shard.total_estimators,
+                )
+
         _logger = self.experiment_logger or NullLogger()
         global_step = 0
 
@@ -903,6 +995,7 @@ class FinetunedTabPFNBase(BaseEstimator, ABC):
             y_train=y_train,
         )
         for epoch in range(epoch_to_start_from, self.epochs):
+            epoch_start_time = _synchronize_epoch_timer()
             # Per-epoch aggregates for cleaner learning curves.
             epoch_loss_sum = 0.0
             epoch_batches = 0
@@ -929,7 +1022,7 @@ class FinetunedTabPFNBase(BaseEstimator, ABC):
                 preprocessing_random_state=preprocessing_random_state,
             )
 
-            if using_ddp:
+            if using_ddp and estimator_shard is None:
                 sampler = DistributedSampler(
                     training_datasets,
                     num_replicas=dist.get_world_size(),
@@ -945,6 +1038,8 @@ class FinetunedTabPFNBase(BaseEstimator, ABC):
                     sampler=sampler,
                 )
             else:
+                # Estimator sharding requires identical data and ordering on every
+                # rank; only the estimator dimension differs between ranks.
                 dataloader_generator = torch.Generator().manual_seed(epoch_random_state)
                 finetuning_dataloader = DataLoader(
                     training_datasets,
@@ -1003,7 +1098,13 @@ class FinetunedTabPFNBase(BaseEstimator, ABC):
             for batch in progress_bar:
                 optimizer.zero_grad()
 
-                should_skip = self._should_skip_batch(batch)
+                rank_batch = (
+                    _slice_batch_estimators(batch, estimator_shard)
+                    if estimator_shard is not None
+                    else batch
+                )
+
+                should_skip = self._should_skip_batch(rank_batch)
                 if using_ddp:
                     # All ranks must agree — if any rank skips, all skip,
                     # otherwise DDP all-reduce in backward will deadlock.
@@ -1013,13 +1114,13 @@ class FinetunedTabPFNBase(BaseEstimator, ABC):
                 if should_skip:
                     continue
 
-                self._setup_batch(batch)
+                self._setup_batch(rank_batch)
 
                 self.finetuned_estimator_.fit_from_preprocessed(
-                    batch.X_context,
-                    batch.y_context,
-                    batch.cat_indices,
-                    batch.configs,
+                    rank_batch.X_context,
+                    rank_batch.y_context,
+                    rank_batch.cat_indices,
+                    rank_batch.configs,
                     performance_options=finetuning_performance_options,
                 )
 
@@ -1031,7 +1132,11 @@ class FinetunedTabPFNBase(BaseEstimator, ABC):
                 use_scaler = use_amp and scaler is not None
 
                 with autocast(enabled=use_scaler), sdpa_kernel_context():  # type: ignore
-                    loss = self._forward_with_loss(batch)
+                    loss = self._forward_with_loss(rank_batch)
+                    # DDP averages rank gradients. Correct the local estimator-mean
+                    # loss so that uneven shards still produce the global
+                    # estimator-mean gradient after that averaging.
+                    loss = loss * self._estimator_gradient_scale_
 
                 if use_scaler:
                     with sdpa_kernel_context():
@@ -1101,6 +1206,15 @@ class FinetunedTabPFNBase(BaseEstimator, ABC):
             mean_train_loss = (
                 epoch_loss_sum / epoch_batches if epoch_batches > 0 else None
             )
+            epoch_train_time = time.monotonic() - epoch_start_time
+            if is_main_process:
+                logger.info(
+                    "Fine-tuning epoch %d/%d took %.2fs (%d batches across ranks)",
+                    epoch + 1,
+                    self.epochs,
+                    epoch_train_time,
+                    epoch_batches,
+                )
 
             # --- Validation (rank 0 only), broadcast metric ---
             run_validation = do_validation and (epoch + 1) % validation_frequency == 0

--- a/src/tabpfn/finetuning/finetuned_classifier.py
+++ b/src/tabpfn/finetuning/finetuned_classifier.py
@@ -118,6 +118,9 @@ class FinetunedTabPFNClassifier(FinetunedTabPFNBase, ClassifierMixin):
             Defaults to 8.
         use_activation_checkpointing: Whether to use activation checkpointing to
             reduce memory usage. Defaults to True.
+        shard_estimators_across_gpus: When True under DDP, shard the fine-tuning
+            estimators across ranks to reduce per-rank activation memory. Defaults
+            to False.
         save_checkpoint_interval: Number of epochs between checkpoint saves. This
             only has an effect if `output_dir` is provided during the `fit()` call.
             If None, no intermediate checkpoints are saved. The best model checkpoint
@@ -161,6 +164,7 @@ class FinetunedTabPFNClassifier(FinetunedTabPFNBase, ClassifierMixin):
         n_estimators_validation: int = 2,
         n_estimators_final_inference: int = 8,
         use_activation_checkpointing: bool = True,
+        shard_estimators_across_gpus: bool = False,
         save_checkpoint_interval: int | None = 10,
         use_fixed_preprocessing_seed: bool = True,
         experiment_logger: FinetuningLogger | None = None,
@@ -190,6 +194,7 @@ class FinetunedTabPFNClassifier(FinetunedTabPFNBase, ClassifierMixin):
             n_estimators_validation=n_estimators_validation,
             n_estimators_final_inference=n_estimators_final_inference,
             use_activation_checkpointing=use_activation_checkpointing,
+            shard_estimators_across_gpus=shard_estimators_across_gpus,
             save_checkpoint_interval=save_checkpoint_interval,
             use_fixed_preprocessing_seed=use_fixed_preprocessing_seed,
             experiment_logger=experiment_logger,
@@ -284,13 +289,13 @@ class FinetunedTabPFNClassifier(FinetunedTabPFNBase, ClassifierMixin):
         Q, B, E, L = logits_QBEL.shape
         assert y_query_batch.shape[1] == Q
         assert B == 1
-        assert self.n_estimators_finetune == E
+        assert self._local_n_estimators_ == E
         assert self.finetuned_estimator_.n_classes_ == L
 
         # Reshape for CE loss: treat estimator dim as batch dim
         # permute to shape (B, E, L, Q) then reshape to (B*E, L, Q)
         logits_BLQ = logits_QBEL.permute(1, 2, 3, 0).reshape(B * E, L, Q)
-        targets_BQ = y_query_batch.repeat(B * self.n_estimators_finetune, 1).to(
+        targets_BQ = y_query_batch.repeat(B * self._local_n_estimators_, 1).to(
             self.device
         )
 

--- a/src/tabpfn/finetuning/finetuned_regressor.py
+++ b/src/tabpfn/finetuning/finetuned_regressor.py
@@ -284,6 +284,9 @@ class FinetunedTabPFNRegressor(FinetunedTabPFNBase, RegressorMixin):
             Defaults to 8.
         use_activation_checkpointing: Whether to use activation checkpointing to
             reduce memory usage. Defaults to True.
+        shard_estimators_across_gpus: When True under DDP, shard the fine-tuning
+            estimators across ranks to reduce per-rank activation memory. Defaults
+            to False.
         save_checkpoint_interval: Number of epochs between checkpoint saves. This
             only has an effect if `output_dir` is provided during the `fit()` call.
             If None, no intermediate checkpoints are saved. The best model checkpoint
@@ -343,6 +346,7 @@ class FinetunedTabPFNRegressor(FinetunedTabPFNBase, RegressorMixin):
         n_estimators_validation: int = 2,
         n_estimators_final_inference: int = 8,
         use_activation_checkpointing: bool = True,
+        shard_estimators_across_gpus: bool = False,
         save_checkpoint_interval: int | None = 10,
         use_fixed_preprocessing_seed: bool = True,
         experiment_logger: FinetuningLogger | None = None,
@@ -379,6 +383,7 @@ class FinetunedTabPFNRegressor(FinetunedTabPFNBase, RegressorMixin):
             n_estimators_validation=n_estimators_validation,
             n_estimators_final_inference=n_estimators_final_inference,
             use_activation_checkpointing=use_activation_checkpointing,
+            shard_estimators_across_gpus=shard_estimators_across_gpus,
             save_checkpoint_interval=save_checkpoint_interval,
             use_fixed_preprocessing_seed=use_fixed_preprocessing_seed,
             experiment_logger=experiment_logger,
@@ -463,14 +468,14 @@ class FinetunedTabPFNRegressor(FinetunedTabPFNBase, RegressorMixin):
         num_bars = bardist_loss_fn.num_bars
         assert y_query_batch.shape[1] == Q
         assert B == 1
-        assert self.n_estimators_finetune == E
+        assert self._local_n_estimators_ == E
         assert num_bars == L
 
         # Reshape for bar distribution loss: treat estimator dim as batch dim
         # permute to shape (B, E, Q, L) then reshape to (B*E, Q, L)
         logits_BQL = logits_QBEL.permute(1, 2, 0, 3).reshape(B * E, Q, L)
 
-        targets_BQ = y_query_batch.repeat(B * self.n_estimators_finetune, 1).to(
+        targets_BQ = y_query_batch.repeat(B * self._local_n_estimators_, 1).to(
             self.device
         )
 

--- a/tests/test_finetuning_classifier.py
+++ b/tests/test_finetuning_classifier.py
@@ -305,6 +305,24 @@ def test__slice_batch_estimators__slices_only_estimator_fields() -> None:
     assert sharded.configs == [["config-2"], ["config-3"]]
 
 
+def test__should_skip_batch__uses_full_estimator_label_union() -> None:
+    """Per-estimator label permutations must not cause a sharded batch skip."""
+    batch = ClassifierBatch(
+        X_context=[torch.tensor([0]), torch.tensor([1])],
+        X_query=[torch.tensor([0]), torch.tensor([1])],
+        y_context=[torch.tensor([0, 0]), torch.tensor([1, 1])],
+        y_query=torch.tensor([[0, 1]]),
+        cat_indices=[[[], []]],
+        configs=[["config-0"], ["config-1"]],  # type: ignore[list-item]
+    )
+    classifier = FinetunedTabPFNClassifier(n_estimators_final_inference=2)
+
+    assert not classifier._should_skip_batch(batch)
+    assert classifier._should_skip_batch(
+        _slice_batch_estimators(batch, _get_estimator_shard(2, 0, 2))
+    )
+
+
 def _state_dicts_equal(a: dict[str, torch.Tensor], b: dict[str, torch.Tensor]) -> bool:
     """Return True iff two state dicts have identical keys and tensor values."""
     if a.keys() != b.keys():

--- a/tests/test_finetuning_classifier.py
+++ b/tests/test_finetuning_classifier.py
@@ -37,7 +37,11 @@ from tabpfn.finetuning.data_util import (
     get_preprocessed_dataset_chunks,
     meta_dataset_collator,
 )
-from tabpfn.finetuning.finetuned_base import EvalResult
+from tabpfn.finetuning.finetuned_base import (
+    EvalResult,
+    _get_estimator_shard,
+    _slice_batch_estimators,
+)
 from tabpfn.finetuning.finetuned_classifier import FinetunedTabPFNClassifier
 from tabpfn.finetuning.finetuned_regressor import FinetunedTabPFNRegressor
 from tabpfn.finetuning.train_util import get_checkpoint_path_and_epoch_from_output_dir
@@ -256,6 +260,49 @@ def make_param_dependent_loss_side_effect() -> Callable[..., torch.Tensor]:
         return 1e-2 * sum((p**2).sum() for p in params if p.requires_grad)
 
     return _loss
+
+
+def test__get_estimator_shard__covers_estimators_and_scales_gradients() -> None:
+    """Uneven shards cover each estimator and preserve a global-mean gradient."""
+    shards = [_get_estimator_shard(10, rank, 4) for rank in range(4)]
+
+    assert [(shard.start, shard.stop) for shard in shards] == [
+        (0, 3),
+        (3, 6),
+        (6, 8),
+        (8, 10),
+    ]
+    assert [shard.gradient_scale for shard in shards] == pytest.approx(
+        [1.2, 1.2, 0.8, 0.8]
+    )
+    assert sum(shard.size for shard in shards) == 10
+
+
+def test__get_estimator_shard__rejects_empty_rank_shards() -> None:
+    """Every DDP rank must run a forward/backward to avoid collective deadlock."""
+    with pytest.raises(ValueError, match="n_estimators_finetune >= world_size"):
+        _get_estimator_shard(2, rank=0, world_size=4)
+
+
+def test__slice_batch_estimators__slices_only_estimator_fields() -> None:
+    """Estimator sharding retains shared query targets and slices nested metadata."""
+    batch = ClassifierBatch(
+        X_context=[torch.tensor([i]) for i in range(4)],
+        X_query=[torch.tensor([10 + i]) for i in range(4)],
+        y_context=[torch.tensor([20 + i]) for i in range(4)],
+        y_query=torch.tensor([[0, 1]]),
+        cat_indices=[[[0], [1], [2], [3]]],
+        configs=[[f"config-{i}"] for i in range(4)],  # type: ignore[list-item]
+    )
+
+    sharded = _slice_batch_estimators(batch, _get_estimator_shard(4, 1, 2))
+
+    assert [tensor.item() for tensor in sharded.X_context] == [2, 3]
+    assert [tensor.item() for tensor in sharded.X_query] == [12, 13]
+    assert [tensor.item() for tensor in sharded.y_context] == [22, 23]
+    assert torch.equal(sharded.y_query, batch.y_query)
+    assert sharded.cat_indices == [[[2], [3]]]
+    assert sharded.configs == [["config-2"], ["config-3"]]
 
 
 def _state_dicts_equal(a: dict[str, torch.Tensor], b: dict[str, torch.Tensor]) -> bool:

--- a/tests/test_finetuning_classifier.py
+++ b/tests/test_finetuning_classifier.py
@@ -40,6 +40,7 @@ from tabpfn.finetuning.data_util import (
 from tabpfn.finetuning.finetuned_base import (
     EvalResult,
     _get_estimator_shard,
+    _get_loss_for_logging,
     _slice_batch_estimators,
 )
 from tabpfn.finetuning.finetuned_classifier import FinetunedTabPFNClassifier
@@ -282,6 +283,34 @@ def test__get_estimator_shard__rejects_empty_rank_shards() -> None:
     """Every DDP rank must run a forward/backward to avoid collective deadlock."""
     with pytest.raises(ValueError, match="n_estimators_finetune >= world_size"):
         _get_estimator_shard(2, rank=0, world_size=4)
+
+
+def test__get_loss_for_logging__reports_global_estimator_mean() -> None:
+    """Reporting reverses DDP gradient scaling, including for uneven shards."""
+    shards = [_get_estimator_shard(10, rank, 4) for rank in range(4)]
+    local_means = [1.0, 2.0, 3.0, 4.0]
+    scaled_losses = [
+        mean * shard.gradient_scale
+        for mean, shard in zip(local_means, shards, strict=True)
+    ]
+    reduced_loss = sum(scaled_losses) / len(shards)
+
+    def fake_all_reduce(tensor: torch.Tensor, **_: Any) -> None:
+        tensor.fill_(reduced_loss)
+
+    with patch(
+        "tabpfn.finetuning.finetuned_base.dist.all_reduce",
+        side_effect=fake_all_reduce,
+    ):
+        logged_loss = _get_loss_for_logging(
+            torch.tensor(scaled_losses[0]),
+            shards[0],
+        )
+
+    expected_loss = sum(
+        mean * shard.size for mean, shard in zip(local_means, shards, strict=True)
+    ) / sum(shard.size for shard in shards)
+    assert logged_loss == pytest.approx(expected_loss)
 
 
 def test__slice_batch_estimators__slices_only_estimator_fields() -> None:


### PR DESCRIPTION
## Issue + Motivation
Running into OOMs doing DDP fine-tuning for 8 estimators, 4 M rows, 1M susbample, 200 features, 20k and 10k chunks, on A100 and H100.

- In the current set up, each GPU holds the activation of all estimators, generating OOMs
- The change I want to propose is for each GPU to process one estimator/divide the number of estimators among them

This will enable us to run finetuning on larger data and smaller GPU. It now works
---

## Public API Changes

-   [x] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?
Locally and with GPUs on the cluster. Ran some parity tests to ensure we got the same outputs.

---

## Checklist

-   [x] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [ ] A changelog entry has been added (see `changelog/README.md`), or "no changelog needed" label requested.
-   [x] The code follows the project's style guidelines.
-   [x] I have considered the impact of these changes on the public API.

---
