### PR TITLE
Reduce peak memory during KV cache construction

### DIFF
--- a/changelog/1183.changed.md
+++ b/changelog/1183.changed.md
@@ -1,0 +1,1 @@
+Reduce peak GPU memory during KV-cache construction by quantizing layers as they are built and temporarily staging completed estimator caches on CPU in memory-saving mode.

--- a/src/tabpfn/architectures/interface.py
+++ b/src/tabpfn/architectures/interface.py
@@ -10,6 +10,7 @@ from dataclasses import asdict
 from typing import Any, Literal, Protocol, overload
 from typing_extensions import override
 
+import torch
 from pydantic.dataclasses import dataclass
 from torch import Tensor, nn
 
@@ -106,6 +107,14 @@ class PerformanceOptions:
     result in longer inference time for the first forward pass, during which
     compile and autotune will be run. Tuning results are cached, so should
     persist across runs."""
+
+    kv_cache_dtype: torch.dtype | None = None
+    """Quantize each KV-cache layer to this dtype as it is constructed.
+
+    ``None`` keeps the model's compute dtype. Architectures that support explicit
+    KV-cache quantization can use this to avoid retaining a complete full-precision
+    cache before converting it to its storage dtype.
+    """
 
 
 class ArchitectureModule(Protocol):

--- a/src/tabpfn/architectures/tabpfn_v3.py
+++ b/src/tabpfn/architectures/tabpfn_v3.py
@@ -1808,7 +1808,6 @@ class TabPFNV3(Architecture):
         task_type: str | None = None,
         kv_cache: TabPFNV3Cache | None = None,
         return_kv_cache: bool = False,
-        kv_cache_dtype: torch.dtype | None = None,
         x_is_test_only: bool = False,
         # TODO: test_targets_MB needed because model_loading has a condition
         # on its presence. Clean this up.
@@ -1819,10 +1818,6 @@ class TabPFNV3(Architecture):
         | tuple[torch.Tensor | dict[str, torch.Tensor], TabPFNV3Cache | None]
     ):
         """Main forward pass for TabPFN v3.
-
-        When building a KV cache, ``kv_cache_dtype`` quantizes each layer's entry
-        immediately after it is produced. This avoids retaining the complete
-        full-precision cache until the forward pass finishes.
 
         When a KV cache is provided, ``x_is_test_only=True`` lets the
         caller pass only the test rows (shape ``(num_test, 1, D)``) instead
@@ -1920,8 +1915,8 @@ class TabPFNV3(Architecture):
                     )
                     assert kv_entry.key is not None
                     kv_compute_dtype = kv_entry.key.dtype
-                    if kv_cache_dtype is not None:
-                        kv_entry = kv_entry.quantize(kv_cache_dtype)
+                    if performance_options.kv_cache_dtype is not None:
+                        kv_entry = kv_entry.quantize(performance_options.kv_cache_dtype)
                     kv_out[layer_idx] = kv_entry
             else:
                 for block in self.icl_blocks:

--- a/src/tabpfn/architectures/tabpfn_v3.py
+++ b/src/tabpfn/architectures/tabpfn_v3.py
@@ -1808,6 +1808,7 @@ class TabPFNV3(Architecture):
         task_type: str | None = None,
         kv_cache: TabPFNV3Cache | None = None,
         return_kv_cache: bool = False,
+        kv_cache_dtype: torch.dtype | None = None,
         x_is_test_only: bool = False,
         # TODO: test_targets_MB needed because model_loading has a condition
         # on its presence. Clean this up.
@@ -1818,6 +1819,10 @@ class TabPFNV3(Architecture):
         | tuple[torch.Tensor | dict[str, torch.Tensor], TabPFNV3Cache | None]
     ):
         """Main forward pass for TabPFN v3.
+
+        When building a KV cache, ``kv_cache_dtype`` quantizes each layer's entry
+        immediately after it is produced. This avoids retaining the complete
+        full-precision cache until the forward pass finishes.
 
         When a KV cache is provided, ``x_is_test_only=True`` lets the
         caller pass only the test rows (shape ``(num_test, 1, D)``) instead
@@ -1888,6 +1893,7 @@ class TabPFNV3(Architecture):
 
         # Per-layer KV entries collected when return_kv_cache is True.
         kv_out: dict[int, KVCacheEntry | QuantizedKVCacheEntry] = {}
+        kv_compute_dtype: torch.dtype | None = None
 
         if kv_cache is not None and not kv_cache.is_empty():
             # Cache path: no y_icl embedding; use cached K/V pairs
@@ -1912,6 +1918,10 @@ class TabPFNV3(Architecture):
                         performance_options.save_peak_memory_factor,
                         return_kv=True,
                     )
+                    assert kv_entry.key is not None
+                    kv_compute_dtype = kv_entry.key.dtype
+                    if kv_cache_dtype is not None:
+                        kv_entry = kv_entry.quantize(kv_cache_dtype)
                     kv_out[layer_idx] = kv_entry
             else:
                 for block in self.icl_blocks:
@@ -1951,11 +1961,12 @@ class TabPFNV3(Architecture):
                 # raw input, whose passed-through +/-inf would poison the mean/std
                 # and turn every standardised test cell into NaN at predict time.
                 assert kv_out
-                # Store train_embeddings at the ICL KV cache dtype.
-                cache_dtype = next(iter(kv_out.values())).key.dtype
+                # Store train_embeddings at the unquantized ICL compute dtype. The
+                # KV entries may already have been quantized layer by layer above.
+                assert kv_compute_dtype is not None
                 built_cache = TabPFNV3Cache(
                     kv=kv_out,
-                    train_embeddings=train_emb.detach().to(cache_dtype),
+                    train_embeddings=train_emb.detach().to(kv_compute_dtype),
                     train_shape=(B, num_train),
                     scaler_cache={k: v.detach() for k, v in scaler_stats.items()},
                     inducing_hidden=(

--- a/src/tabpfn/inference.py
+++ b/src/tabpfn/inference.py
@@ -1054,20 +1054,17 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
             save_peak_memory_factor=DEFAULT_SAVE_PEAK_MEMORY_FACTOR
             if save_peak_mem
             else None,
+            kv_cache_dtype=(
+                KV_CACHE_PRECISION_DTYPES[kv_cache_precision]
+                if kv_cache_precision != "auto"
+                else None
+            ),
         )
 
         with (
             get_autocast_context(device, enabled=autocast),
             torch.inference_mode(),
         ):
-            cache_dtype = (
-                KV_CACHE_PRECISION_DTYPES[kv_cache_precision]
-                if kv_cache_precision != "auto"
-                else None
-            )
-            cache_build_kwargs = {}
-            if "kv_cache_dtype" in signature(model.forward).parameters:
-                cache_build_kwargs["kv_cache_dtype"] = cache_dtype
             _, cache = model(
                 X,
                 y,
@@ -1075,12 +1072,9 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
                 categorical_inds=batched_cat_ix,
                 performance_options=performance_options,
                 return_kv_cache=True,
-                **cache_build_kwargs,
             )
 
         assert cache is not None
-        if kv_cache_precision != "auto" and not cache_build_kwargs:
-            cache = cache.quantize(KV_CACHE_PRECISION_DTYPES[kv_cache_precision])
         if not self.keep_cache_on_device or stage_cache_on_cpu:
             cache = cache.to("cpu")
         return cache, device

--- a/src/tabpfn/inference.py
+++ b/src/tabpfn/inference.py
@@ -955,6 +955,15 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
             time.perf_counter() - fit_preprocess_start
         )
 
+        save_peak_mem_during_build = should_save_peak_mem(
+            memory_saving_mode=save_peak_mem,
+            X_train_shape=tuple[int, int](X_train.shape),
+            X_test_shape=(0, X_train.shape[1]),
+            devices=devices,
+            dtype_byte_size=dtype_byte_size,
+        )
+        stage_caches_on_cpu = keep_cache_on_device and save_peak_mem_during_build
+
         # Build per-estimator caches in parallel across devices
         build_functions = (
             partial(
@@ -965,7 +974,8 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
                 model_index=ensemble_member.config._model_index,
                 gpu_preprocessor=ensemble_member.gpu_preprocessor,
                 autocast=autocast,
-                save_peak_mem=save_peak_mem,
+                save_peak_mem=save_peak_mem_during_build,
+                stage_cache_on_cpu=stage_caches_on_cpu,
             )
             for ensemble_member in self.ensemble_members
         )
@@ -977,7 +987,13 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
             ),
             devices,
         )
-        self.kv_caches: list = list(timed_caches)
+        built_caches = list(timed_caches)
+        if stage_caches_on_cpu:
+            # Keep already-built caches out of device memory while later ensemble
+            # members are constructed, then restore their original placement.
+            self.kv_caches: list = [cache.to(device) for cache, device in built_caches]
+        else:
+            self.kv_caches = [cache for cache, _device in built_caches]
         self._speed_metrics["fit_model_forward_seconds"] = timed_caches.elapsed_seconds
 
     def _build_cache(
@@ -991,7 +1007,8 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
         gpu_preprocessor: TorchPreprocessingPipeline | None,
         autocast: bool,
         save_peak_mem: bool,
-    ) -> KVCache:
+        stage_cache_on_cpu: bool,
+    ) -> tuple[KVCache, torch.device]:
         """Build KV cache for one ensemble member on the given device.
 
         Called via :func:`parallel_execute` — may run on different devices
@@ -1043,6 +1060,14 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
             get_autocast_context(device, enabled=autocast),
             torch.inference_mode(),
         ):
+            cache_dtype = (
+                KV_CACHE_PRECISION_DTYPES[kv_cache_precision]
+                if kv_cache_precision != "auto"
+                else None
+            )
+            cache_build_kwargs = {}
+            if "kv_cache_dtype" in signature(model.forward).parameters:
+                cache_build_kwargs["kv_cache_dtype"] = cache_dtype
             _, cache = model(
                 X,
                 y,
@@ -1050,14 +1075,15 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
                 categorical_inds=batched_cat_ix,
                 performance_options=performance_options,
                 return_kv_cache=True,
+                **cache_build_kwargs,
             )
 
         assert cache is not None
-        if kv_cache_precision != "auto":
+        if kv_cache_precision != "auto" and not cache_build_kwargs:
             cache = cache.quantize(KV_CACHE_PRECISION_DTYPES[kv_cache_precision])
-        if self.keep_cache_on_device:
-            return cache
-        return cache.to("cpu")
+        if not self.keep_cache_on_device or stage_cache_on_cpu:
+            cache = cache.to("cpu")
+        return cache, device
 
     @override
     def iter_outputs(

--- a/src/tabpfn/inference.py
+++ b/src/tabpfn/inference.py
@@ -989,8 +989,9 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
         )
         built_caches = list(timed_caches)
         if stage_caches_on_cpu:
-            # Keep already-built caches out of device memory while later ensemble
-            # members are constructed, then restore their original placement.
+            # Each completed cache was staged on CPU by _build_cache while the
+            # remaining ensemble members were being constructed. Now that every
+            # build has finished, move each cache back to its build device.
             self.kv_caches: list = [cache.to(device) for cache, device in built_caches]
         else:
             self.kv_caches = [cache for cache, _device in built_caches]
@@ -1013,6 +1014,13 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
 
         Called via :func:`parallel_execute` — may run on different devices
         in parallel threads.
+
+        Returns:
+            A tuple containing the completed cache and its build device. The
+            device is also the cache's destination for inference. The cache
+            tensors themselves are on CPU when ``stage_cache_on_cpu`` is true
+            (or when ``keep_cache_on_device`` is false); otherwise, they remain
+            on the returned device.
         """
         model = self.model_caches[model_index].get(device)
         kv_cache_precision = _resolve_kv_cache_precision(

--- a/tests/test_architectures/test_tabpfn_v3.py
+++ b/tests/test_architectures/test_tabpfn_v3.py
@@ -468,6 +468,40 @@ def test__kv_cache_entry__quantize_dequantize_roundtrip() -> None:
 
 
 @torch.no_grad()
+@pytest.mark.parametrize("cache_dtype", [torch.int8, FP8_KV_DTYPE])
+def test__kv_cache__layerwise_quantization_matches_post_forward(
+    cache_dtype: torch.dtype,
+) -> None:
+    """Quantizing during construction produces the same cache as afterward."""
+    arch = _get_model()
+    torch.manual_seed(42)
+    x = torch.randn(20, 1, 5, dtype=torch.float32) * 0.1
+    y = torch.randint(0, 10, (10,), dtype=torch.float32)
+
+    _, full_precision = arch(x, y, return_kv_cache=True)
+    _, layerwise = arch(
+        x,
+        y,
+        return_kv_cache=True,
+        kv_cache_dtype=cache_dtype,
+    )
+    assert full_precision is not None
+    assert layerwise is not None
+    post_forward = full_precision.quantize(cache_dtype)
+
+    assert layerwise.train_embeddings.dtype == full_precision.train_embeddings.dtype
+    for layer_idx in post_forward.kv:
+        expected = post_forward.kv[layer_idx]
+        actual = layerwise.kv[layer_idx]
+        assert isinstance(expected, QuantizedKVCacheEntry)
+        assert isinstance(actual, QuantizedKVCacheEntry)
+        assert torch.equal(actual.key, expected.key)
+        assert torch.equal(actual.value, expected.value)
+        assert torch.equal(actual.key_scale, expected.key_scale)
+        assert torch.equal(actual.value_scale, expected.value_scale)
+
+
+@torch.no_grad()
 @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16, torch.float16])
 def test__kv_cache_entry__quantize_all_zero_is_finite(dtype: torch.dtype) -> None:
     """All-zero inputs must round-trip without NaN/Inf across float dtypes.

--- a/tests/test_architectures/test_tabpfn_v3.py
+++ b/tests/test_architectures/test_tabpfn_v3.py
@@ -495,8 +495,10 @@ def test__kv_cache__layerwise_quantization_matches_post_forward(
         actual = layerwise.kv[layer_idx]
         assert isinstance(expected, QuantizedKVCacheEntry)
         assert isinstance(actual, QuantizedKVCacheEntry)
-        assert torch.equal(actual.key, expected.key)
-        assert torch.equal(actual.value, expected.value)
+        # torch.equal lacks CPU float8 support in the lowest supported PyTorch.
+        # Comparing after an exact float32 widening works for int8 and float8.
+        assert torch.equal(actual.key.float(), expected.key.float())
+        assert torch.equal(actual.value.float(), expected.value.float())
         assert torch.equal(actual.key_scale, expected.key_scale)
         assert torch.equal(actual.value_scale, expected.value_scale)
 

--- a/tests/test_architectures/test_tabpfn_v3.py
+++ b/tests/test_architectures/test_tabpfn_v3.py
@@ -483,7 +483,7 @@ def test__kv_cache__layerwise_quantization_matches_post_forward(
         x,
         y,
         return_kv_cache=True,
-        kv_cache_dtype=cache_dtype,
+        performance_options=PerformanceOptions(kv_cache_dtype=cache_dtype),
     )
     assert full_precision is not None
     assert layerwise is not None

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -522,7 +522,7 @@ def test__explicit_kv_cache__produces_outputs() -> None:
         devices=[torch.device("cpu")],
         dtype_byte_size=4,
         force_inference_dtype=None,
-        save_peak_mem="auto",
+        save_peak_mem=True,
         autocast=False,
     )
     # _build_cache runs once per ensemble member during engine construction.


### PR DESCRIPTION
## Issue + Motivation
- We observe a 50% peak GPU memory increase when building the cache
- This creates OOM when building large caches (e.g. 1M per estimator, 8 estimators, 33GB to 55 GB peak memory)
- This is inefficient and will put load on our servers too
- It increases hardware requirements of whoever uses the model

To fix this, we introduce two main changes:
- Quantize each layer at a time instead of materialising the full cache then compressing
- Save estimator cache to CPU after build, then load back to GPU to avoid having to maintain all estimator caches at the same time in memory


---

## Public API Changes

-   [x] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?

- Tested locally, removes the peak memory spike

---

## Checklist

-   [x] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [x] A changelog entry has been added (see `changelog/README.md`), or "no changelog needed" label requested.
-   [x] The code follows the project's style guidelines.
-   [x] I have considered the impact of these changes on the public API.

---

Closes [RES-2162](https://linear.app/priorlabs/issue/RES-2162/quantize-each-layers-kv-cache-directly-as-opposed-to-once-after-the)
