### PR TITLE
Chunk the batch to keep FlashAttention's backward in its index range

### DIFF
--- a/changelog/1184.fixed.md
+++ b/changelog/1184.fixed.md
@@ -1,0 +1,1 @@
+Fix an "illegal memory access" crash in the backward pass when fine-tuning on large batches: FlashAttention's backward indexes its workspace with 32-bit integers, so the batch is now chunked to keep each call inside that range.

--- a/src/tabpfn/architectures/shared/scaled_dot_product_attention.py
+++ b/src/tabpfn/architectures/shared/scaled_dot_product_attention.py
@@ -175,7 +175,7 @@ def _torch_sdpa(
         num_iterations = max(
             num_iterations,
             _flash_backward_num_iterations(q_BHSD, num_q_heads, backends),
-         )
+        )
     sub_batch = (q_BHSD.shape[0] + num_iterations - 1) // num_iterations
 
     with sdpa_kernel(backends=backends):

--- a/src/tabpfn/architectures/shared/scaled_dot_product_attention.py
+++ b/src/tabpfn/architectures/shared/scaled_dot_product_attention.py
@@ -84,6 +84,39 @@ _SDPA_BACKENDS = [
 ]
 
 
+# A FlashAttention backward fails with "CUDA error: an illegal memory access was
+# encountered" once
+# ``batch * heads * round_up(seq_q, 128) * head_dim > 2**31``.
+# The forward is fine at the same shapes, and the memory-efficient backend is
+# fine at all of them. The boundary is exact: a padded count of exactly 2**31
+# passes and 1.001 * 2**31 fails, which is consistent with a signed 32-bit
+# element index over a workspace whose query length is padded to the kernel's
+# block size. Measured on an RTX PRO 6000, torch 2.9.0+cu128, bfloat16.
+_FLASH_BACKWARD_MAX_ELEMENTS = 2**31
+_FLASH_QUERY_BLOCK = 128
+
+
+def _flash_backward_num_iterations(
+    q_BHSD: torch.Tensor,
+    num_q_heads: int,
+    backends: list[SDPBackend],
+) -> int:
+    """Batch chunks needed to keep each call inside FlashAttention's index range.
+
+    Returns 1 when FlashAttention cannot be selected, or when a single batch
+    entry already exceeds the range and chunking the batch therefore cannot help.
+    """
+    if SDPBackend.FLASH_ATTENTION not in backends:
+        return 1
+    block = _FLASH_QUERY_BLOCK
+    padded_seq = ((q_BHSD.shape[-2] + block - 1) // block) * block
+    elements_per_batch_entry = num_q_heads * padded_seq * q_BHSD.shape[-1]
+    max_sub_batch = _FLASH_BACKWARD_MAX_ELEMENTS // elements_per_batch_entry
+    if max_sub_batch < 1:
+        return 1
+    return (q_BHSD.shape[0] + max_sub_batch - 1) // max_sub_batch
+
+
 def _torch_sdpa(
     q_BSHD: torch.Tensor,
     k_BSJD: torch.Tensor | None,
@@ -95,7 +128,8 @@ def _torch_sdpa(
     A more robust version of torch.nn.functional.scaled_dot_product_attention:
     enables GQA where needed, and works around the
     CUDA maximum grid size for very large ``batch * heads`` (pytorch #142228)
-    by chunking the batch.
+    and FlashAttention's 32-bit backward indexing
+    (see ``_flash_backward_num_iterations``) by chunking the batch.
     """
     msg = "SDPA expects (B, S, H, D); got tensor of shape"
     assert q_BSHD.dim() == 4, f"{msg} q:{tuple(q_BSHD.shape)}"
@@ -133,6 +167,9 @@ def _torch_sdpa(
         torch._check(q_BHSD.shape[0] >= 1)
     CUDA_MAX_GRID = 65536
     num_iterations = (num_parallel_calls + CUDA_MAX_GRID - 1) // CUDA_MAX_GRID
+    num_iterations = max(
+        num_iterations, _flash_backward_num_iterations(q_BHSD, num_q_heads, backends)
+    )
     sub_batch = (q_BHSD.shape[0] + num_iterations - 1) // num_iterations
 
     with sdpa_kernel(backends=backends):

--- a/src/tabpfn/architectures/shared/scaled_dot_product_attention.py
+++ b/src/tabpfn/architectures/shared/scaled_dot_product_attention.py
@@ -172,9 +172,15 @@ def _torch_sdpa(
         torch._check(q_BHSD.shape[0] >= 1)
     CUDA_MAX_GRID = 65536
     num_iterations = (num_parallel_calls + CUDA_MAX_GRID - 1) // CUDA_MAX_GRID
-    num_iterations = max(
-        num_iterations, _flash_backward_num_iterations(q_BHSD, num_q_heads, backends)
+    needs_sdpa_backward = torch.is_grad_enabled() and any(
+        tensor.requires_grad for tensor in (q_BHSD, keys, values)
     )
+
+    if needs_sdpa_backward:
+        num_iterations = max(
+            num_iterations,
+            _flash_backward_num_iterations(q_BHSD, num_q_heads, backends),
+         )
     sub_batch = (q_BHSD.shape[0] + num_iterations - 1) // num_iterations
 
     with sdpa_kernel(backends=backends):

--- a/src/tabpfn/architectures/shared/scaled_dot_product_attention.py
+++ b/src/tabpfn/architectures/shared/scaled_dot_product_attention.py
@@ -86,14 +86,18 @@ _SDPA_BACKENDS = [
 
 # A FlashAttention backward fails with "CUDA error: an illegal memory access was
 # encountered" once
-# ``batch * heads * round_up(seq_q, 128) * head_dim > 2**31``.
+# ``batch * heads * round_up(seq_q, 128) * max(head_dim, 32) > 2**31``.
 # The forward is fine at the same shapes, and the memory-efficient backend is
-# fine at all of them. The boundary is exact: a padded count of exactly 2**31
-# passes and 1.001 * 2**31 fails, which is consistent with a signed 32-bit
-# element index over a workspace whose query length is padded to the kernel's
-# block size. Measured on an RTX PRO 6000, torch 2.9.0+cu128, bfloat16.
+# fine at all of them. Both roundings matter: a query length that is already a
+# multiple of 128 reaches exactly 2**31 and passes, and a head dim of 16 fails
+# at half the raw element count because it is counted as 32. The boundary is
+# exact either side (0.99972 * 2**31 passes, 1.001 * 2**31 fails), which is
+# consistent with a signed 32-bit element index over a workspace padded to the
+# kernel's block sizes. Measured on an RTX PRO 6000, torch 2.9.0+cu128,
+# bfloat16, over head dims 16, 32, 64 and 128.
 _FLASH_BACKWARD_MAX_ELEMENTS = 2**31
 _FLASH_QUERY_BLOCK = 128
+_FLASH_MIN_HEAD_DIM = 32
 
 
 def _flash_backward_num_iterations(
@@ -110,7 +114,8 @@ def _flash_backward_num_iterations(
         return 1
     block = _FLASH_QUERY_BLOCK
     padded_seq = ((q_BHSD.shape[-2] + block - 1) // block) * block
-    elements_per_batch_entry = num_q_heads * padded_seq * q_BHSD.shape[-1]
+    padded_head_dim = max(q_BHSD.shape[-1], _FLASH_MIN_HEAD_DIM)
+    elements_per_batch_entry = num_q_heads * padded_seq * padded_head_dim
     max_sub_batch = _FLASH_BACKWARD_MAX_ELEMENTS // elements_per_batch_entry
     if max_sub_batch < 1:
         return 1

--- a/src/tabpfn/architectures/shared/scaled_dot_product_attention.py
+++ b/src/tabpfn/architectures/shared/scaled_dot_product_attention.py
@@ -88,13 +88,8 @@ _SDPA_BACKENDS = [
 # encountered" once
 # ``batch * heads * round_up(seq_q, 128) * max(head_dim, 32) > 2**31``.
 # The forward is fine at the same shapes, and the memory-efficient backend is
-# fine at all of them. Both roundings matter: a query length that is already a
-# multiple of 128 reaches exactly 2**31 and passes, and a head dim of 16 fails
-# at half the raw element count because it is counted as 32. The boundary is
-# exact either side (0.99972 * 2**31 passes, 1.001 * 2**31 fails), which is
-# consistent with a signed 32-bit element index over a workspace padded to the
-# kernel's block sizes. Measured on an RTX PRO 6000, torch 2.9.0+cu128,
-# bfloat16, over head dims 16, 32, 64 and 128.
+# fine at all of them. Note that the kernel pads internally, so we round to
+# query_block and min_head_dim sizes.
 _FLASH_BACKWARD_MAX_ELEMENTS = 2**31
 _FLASH_QUERY_BLOCK = 128
 _FLASH_MIN_HEAD_DIM = 32

--- a/tests/test_architectures/test_shared/test_scaled_dot_product_attention.py
+++ b/tests/test_architectures/test_shared/test_scaled_dot_product_attention.py
@@ -1,0 +1,159 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
+"""Tests for tabpfn.architectures.shared.scaled_dot_product_attention."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import torch
+from torch.nn.attention import SDPBackend
+
+from tabpfn.architectures.shared.scaled_dot_product_attention import (
+    _FLASH_BACKWARD_MAX_ELEMENTS,
+    _FLASH_QUERY_BLOCK,
+    _torch_sdpa,
+)
+
+# batch * heads * round_up(seq_q, 128) * head_dim = 2,149,580,800, just over the
+# 2**31 element range of FlashAttention's backward index. Without chunking this
+# faults in backward with an illegal memory access.
+_OVER_RANGE_SHAPE = {"batch": 400, "seq_q": 10_496, "heads": 4, "head_dim": 128}
+_SEQ_KV = 128
+
+
+def _padded_elements(batch: int, heads: int, seq_q: int, head_dim: int) -> int:
+    block = _FLASH_QUERY_BLOCK
+    return batch * heads * (((seq_q + block - 1) // block) * block) * head_dim
+
+
+def _record_sdpa_calls(monkeypatch: pytest.MonkeyPatch) -> list[torch.Size]:
+    """Replace SDPA with a shape-preserving stub and record the query shapes."""
+    shapes: list[torch.Size] = []
+
+    def fake_sdpa(
+        query: torch.Tensor,
+        _key: torch.Tensor,
+        value: torch.Tensor,
+        **_kwargs: Any,
+    ) -> torch.Tensor:
+        shapes.append(query.shape)
+        return torch.empty(
+            (*query.shape[:-1], value.shape[-1]),
+            dtype=query.dtype,
+            device=query.device,
+        )
+
+    monkeypatch.setattr(torch.nn.functional, "scaled_dot_product_attention", fake_sdpa)
+    return shapes
+
+
+def _run_on_meta(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    batch: int,
+    seq_q: int,
+    heads: int,
+    head_dim: int,
+    backends: list[SDPBackend] | None,
+) -> list[torch.Size]:
+    """Drive `_torch_sdpa` on meta tensors, which carry shape but no storage."""
+    shapes = _record_sdpa_calls(monkeypatch)
+    kwargs = {"device": "meta", "dtype": torch.bfloat16}
+    q = torch.empty((batch, seq_q, heads, head_dim), **kwargs)
+    k = torch.empty((batch, _SEQ_KV, heads, head_dim), **kwargs)
+    v = torch.empty((batch, _SEQ_KV, heads, head_dim), **kwargs)
+    _torch_sdpa(q, k, v, backends)
+    return shapes
+
+
+def test__torch_sdpa__query_over_flash_index_range__chunks_the_batch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each FlashAttention call must stay inside the backward's 32-bit range."""
+    shapes = _run_on_meta(
+        monkeypatch, **_OVER_RANGE_SHAPE, backends=[SDPBackend.FLASH_ATTENTION]
+    )
+
+    assert len(shapes) > 1, "expected the batch to be chunked"
+    for shape in shapes:
+        sub_batch, heads, seq_q, head_dim = shape
+        assert (
+            _padded_elements(sub_batch, heads, seq_q, head_dim)
+            <= _FLASH_BACKWARD_MAX_ELEMENTS
+        )
+    assert sum(shape[0] for shape in shapes) == _OVER_RANGE_SHAPE["batch"]
+
+
+def test__torch_sdpa__query_within_flash_index_range__single_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A shape inside the range must not be chunked, so nothing slows down."""
+    # 8192 needs no padding, giving exactly 2**31 elements, which is in range.
+    shapes = _run_on_meta(
+        monkeypatch,
+        batch=512,
+        seq_q=8_192,
+        heads=4,
+        head_dim=128,
+        backends=[SDPBackend.FLASH_ATTENTION],
+    )
+
+    assert len(shapes) == 1
+
+
+def test__torch_sdpa__flash_not_selectable__does_not_chunk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The limit is FlashAttention's, so other backends should not be chunked."""
+    shapes = _run_on_meta(
+        monkeypatch, **_OVER_RANGE_SHAPE, backends=[SDPBackend.EFFICIENT_ATTENTION]
+    )
+
+    assert len(shapes) == 1
+
+
+def _cuda_bytes_available() -> int:
+    if not torch.cuda.is_available():
+        return 0
+    free_bytes, _total = torch.cuda.mem_get_info()
+    return free_bytes
+
+
+# The query alone is 4 GiB; the backward additionally holds its gradient and an
+# fp32 dQ accumulator, so leave room for roughly 24 GiB.
+_NEEDED_BYTES = 24 * 1024**3
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(
+    _cuda_bytes_available() < _NEEDED_BYTES,
+    reason="needs a CUDA device with ~24 GiB free",
+)
+def test__torch_sdpa__query_over_flash_index_range__backward_runs_on_cuda() -> None:
+    """The shape that faults in an unchunked FlashAttention backward now runs."""
+    shape = _OVER_RANGE_SHAPE
+    assert (
+        _padded_elements(
+            shape["batch"], shape["heads"], shape["seq_q"], shape["head_dim"]
+        )
+        > _FLASH_BACKWARD_MAX_ELEMENTS
+    ), "shape no longer exceeds the range this test is about"
+
+    kwargs = {"device": "cuda", "dtype": torch.bfloat16, "requires_grad": True}
+    q = torch.randn(
+        (shape["batch"], shape["seq_q"], shape["heads"], shape["head_dim"]), **kwargs
+    )
+    k = torch.randn(
+        (shape["batch"], _SEQ_KV, shape["heads"], shape["head_dim"]), **kwargs
+    )
+    v = torch.randn(
+        (shape["batch"], _SEQ_KV, shape["heads"], shape["head_dim"]), **kwargs
+    )
+
+    out = _torch_sdpa(q, k, v, [SDPBackend.FLASH_ATTENTION])
+    out.sum().backward()
+    torch.cuda.synchronize()
+
+    assert q.grad is not None

--- a/tests/test_architectures/test_shared/test_scaled_dot_product_attention.py
+++ b/tests/test_architectures/test_shared/test_scaled_dot_product_attention.py
@@ -12,20 +12,31 @@ from torch.nn.attention import SDPBackend
 
 from tabpfn.architectures.shared.scaled_dot_product_attention import (
     _FLASH_BACKWARD_MAX_ELEMENTS,
+    _FLASH_MIN_HEAD_DIM,
     _FLASH_QUERY_BLOCK,
     _torch_sdpa,
 )
 
-# batch * heads * round_up(seq_q, 128) * head_dim = 2,149,580,800, just over the
-# 2**31 element range of FlashAttention's backward index. Without chunking this
-# faults in backward with an illegal memory access.
+# batch * heads * round_up(seq_q, 128) * max(head_dim, 32) = 2,149,580,800, just
+# over the 2**31 element range of FlashAttention's backward index. Without
+# chunking this faults in backward with an illegal memory access.
 _OVER_RANGE_SHAPE = {"batch": 400, "seq_q": 10_496, "heads": 4, "head_dim": 128}
+# Same count, reached with a head dim small enough to be padded up to 32. The raw
+# element count is only half the range, so a check that ignored the padding would
+# let this through.
+_OVER_RANGE_SMALL_HEAD_DIM = {
+    "batch": 800,
+    "seq_q": 10_496,
+    "heads": 8,
+    "head_dim": 16,
+}
 _SEQ_KV = 128
 
 
 def _padded_elements(batch: int, heads: int, seq_q: int, head_dim: int) -> int:
     block = _FLASH_QUERY_BLOCK
-    return batch * heads * (((seq_q + block - 1) // block) * block) * head_dim
+    padded_seq = ((seq_q + block - 1) // block) * block
+    return batch * heads * padded_seq * max(head_dim, _FLASH_MIN_HEAD_DIM)
 
 
 def _record_sdpa_calls(monkeypatch: pytest.MonkeyPatch) -> list[torch.Size]:
@@ -84,6 +95,31 @@ def test__torch_sdpa__query_over_flash_index_range__chunks_the_batch(
             <= _FLASH_BACKWARD_MAX_ELEMENTS
         )
     assert sum(shape[0] for shape in shapes) == _OVER_RANGE_SHAPE["batch"]
+
+
+def test__torch_sdpa__small_head_dim_over_range__chunks_the_batch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A head dim below 32 is counted as 32, so it hits the range sooner."""
+    shape = _OVER_RANGE_SMALL_HEAD_DIM
+    raw = shape["batch"] * shape["heads"] * shape["seq_q"] * shape["head_dim"]
+    assert raw < _FLASH_BACKWARD_MAX_ELEMENTS, "raw count should look safe"
+    assert (
+        _padded_elements(
+            shape["batch"], shape["heads"], shape["seq_q"], shape["head_dim"]
+        )
+        > _FLASH_BACKWARD_MAX_ELEMENTS
+    )
+
+    shapes = _run_on_meta(monkeypatch, **shape, backends=[SDPBackend.FLASH_ATTENTION])
+
+    assert len(shapes) > 1, "expected the batch to be chunked"
+    for chunk in shapes:
+        sub_batch, heads, seq_q, head_dim = chunk
+        assert (
+            _padded_elements(sub_batch, heads, seq_q, head_dim)
+            <= _FLASH_BACKWARD_MAX_ELEMENTS
+        )
 
 
 def test__torch_sdpa__query_within_flash_index_range__single_call(

--- a/tests/test_architectures/test_shared/test_scaled_dot_product_attention.py
+++ b/tests/test_architectures/test_shared/test_scaled_dot_product_attention.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, TypedDict
 
 import pytest
 import torch
@@ -17,14 +17,29 @@ from tabpfn.architectures.shared.scaled_dot_product_attention import (
     _torch_sdpa,
 )
 
+
+class _Shape(TypedDict):
+    """The query shape of an SDPA call, unpacked into the helpers below."""
+
+    batch: int
+    seq_q: int
+    heads: int
+    head_dim: int
+
+
 # batch * heads * round_up(seq_q, 128) * max(head_dim, 32) = 2,149,580,800, just
 # over the 2**31 element range of FlashAttention's backward index. Without
 # chunking this faults in backward with an illegal memory access.
-_OVER_RANGE_SHAPE = {"batch": 400, "seq_q": 10_496, "heads": 4, "head_dim": 128}
+_OVER_RANGE_SHAPE: _Shape = {
+    "batch": 400,
+    "seq_q": 10_496,
+    "heads": 4,
+    "head_dim": 128,
+}
 # Same count, reached with a head dim small enough to be padded up to 32. The raw
 # element count is only half the range, so a check that ignored the padding would
 # let this through.
-_OVER_RANGE_SMALL_HEAD_DIM = {
+_OVER_RANGE_SMALL_HEAD_DIM: _Shape = {
     "batch": 800,
     "seq_q": 10_496,
     "heads": 8,
@@ -68,13 +83,23 @@ def _run_on_meta(
     heads: int,
     head_dim: int,
     backends: list[SDPBackend] | None,
+    requires_grad: bool = True,
 ) -> list[torch.Size]:
-    """Drive `_torch_sdpa` on meta tensors, which carry shape but no storage."""
+    """Drive `_torch_sdpa` on meta tensors, which carry shape but no storage.
+
+    Only the backward exceeds the index range, so the inputs require grad
+    unless a test is about the inference path.
+    """
     shapes = _record_sdpa_calls(monkeypatch)
-    kwargs = {"device": "meta", "dtype": torch.bfloat16}
-    q = torch.empty((batch, seq_q, heads, head_dim), **kwargs)
-    k = torch.empty((batch, _SEQ_KV, heads, head_dim), **kwargs)
-    v = torch.empty((batch, _SEQ_KV, heads, head_dim), **kwargs)
+
+    def meta_input(*shape: int) -> torch.Tensor:
+        return torch.empty(
+            shape, device="meta", dtype=torch.bfloat16, requires_grad=requires_grad
+        )
+
+    q = meta_input(batch, seq_q, heads, head_dim)
+    k = meta_input(batch, _SEQ_KV, heads, head_dim)
+    v = meta_input(batch, _SEQ_KV, heads, head_dim)
     _torch_sdpa(q, k, v, backends)
     return shapes
 
@@ -150,6 +175,32 @@ def test__torch_sdpa__flash_not_selectable__does_not_chunk(
     assert len(shapes) == 1
 
 
+def test__torch_sdpa__inputs_without_grad__does_not_chunk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only the backward faults, so inference must not pay for chunking."""
+    shapes = _run_on_meta(
+        monkeypatch,
+        **_OVER_RANGE_SHAPE,
+        backends=[SDPBackend.FLASH_ATTENTION],
+        requires_grad=False,
+    )
+
+    assert len(shapes) == 1
+
+
+def test__torch_sdpa__grad_disabled__does_not_chunk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Inputs requiring grad under `no_grad` still record no backward."""
+    with torch.no_grad():
+        shapes = _run_on_meta(
+            monkeypatch, **_OVER_RANGE_SHAPE, backends=[SDPBackend.FLASH_ATTENTION]
+        )
+
+    assert len(shapes) == 1
+
+
 def _cuda_bytes_available() -> int:
     if not torch.cuda.is_available():
         return 0
@@ -177,16 +228,14 @@ def test__torch_sdpa__query_over_flash_index_range__backward_runs_on_cuda() -> N
         > _FLASH_BACKWARD_MAX_ELEMENTS
     ), "shape no longer exceeds the range this test is about"
 
-    kwargs = {"device": "cuda", "dtype": torch.bfloat16, "requires_grad": True}
-    q = torch.randn(
-        (shape["batch"], shape["seq_q"], shape["heads"], shape["head_dim"]), **kwargs
-    )
-    k = torch.randn(
-        (shape["batch"], _SEQ_KV, shape["heads"], shape["head_dim"]), **kwargs
-    )
-    v = torch.randn(
-        (shape["batch"], _SEQ_KV, shape["heads"], shape["head_dim"]), **kwargs
-    )
+    def cuda_input(*size: int) -> torch.Tensor:
+        return torch.randn(
+            size, device="cuda", dtype=torch.bfloat16, requires_grad=True
+        )
+
+    q = cuda_input(shape["batch"], shape["seq_q"], shape["heads"], shape["head_dim"])
+    k = cuda_input(shape["batch"], _SEQ_KV, shape["heads"], shape["head_dim"])
+    v = cuda_input(shape["batch"], _SEQ_KV, shape["heads"], shape["head_dim"])
 
     out = _torch_sdpa(q, k, v, [SDPBackend.FLASH_ATTENTION])
     out.sum().backward()


### PR DESCRIPTION
Generated by Claude Code.

## What

A FlashAttention backward fails with `CUDA error: an illegal memory access was encountered` once

```
batch * heads * round_up(seq_q, 128) * max(head_dim, 32) > 2**31
```

The forward is fine at the same shapes, and the memory-efficient backend is fine at all of them.

`_torch_sdpa` already chunks the batch to keep `batch * heads` under the CUDA grid limit. This adds a second bound to that same loop, on the element count above.

Both roundings matter, and each one on its own makes the naive reading wrong:

- a query length that is already a multiple of 128 reaches exactly 2**31 and passes, so the largest shape in the table below is a passing one,
- a head dim of 16 fails at *half* the raw element count, because it is counted as 32.

## Reproducing

Needs a CUDA device with ~24 GiB free.

```python
import torch
import torch.nn.functional as F
from torch.nn.attention import SDPBackend, sdpa_kernel

# 400 * 4 * 10496 * 128 = 2_149_580_800 > 2**31
q = torch.randn(400, 4, 10_496, 128, device="cuda", dtype=torch.bfloat16, requires_grad=True)
k = torch.randn(400, 4, 128, 128, device="cuda", dtype=torch.bfloat16, requires_grad=True)
v = torch.randn_like(k).requires_grad_(True)

with sdpa_kernel([SDPBackend.FLASH_ATTENTION]):
    out = F.scaled_dot_product_attention(q, k, v)  # forward is fine
out.sum().backward()                               # illegal memory access
```

Swapping `FLASH_ATTENTION` for `EFFICIENT_ATTENTION` makes it pass.

The small-head-dim case is worth reproducing too, since it is the one a check on the raw element count would miss. `(800, 8, 10496, 16)` is 1,074,790,400 elements, half the bound, and fails.

## Where the boundary is

Measured on an RTX PRO 6000, torch 2.9.0+cu128, bfloat16. One process per shape, since a fault leaves the CUDA context unusable. "counted" is `batch * heads * round_up(seq_q, 128) * max(head_dim, 32)`.

| batch | heads | seq_q | head_dim | counted | / 2**31 | backward |
| --- | --- | --- | --- | --- | --- | --- |
| 8 | 4 | 65536 | 128 | 268,435,456 | 0.125 | ok |
| 200 | 8 | 10496 | 16 | 537,395,200 | 0.250 | ok |
| 400 | 8 | 10496 | 16 | 1,074,790,400 | 0.500 | ok |
| 400 | 8 | 10496 | 32 | 1,074,790,400 | 0.500 | ok |
| 400 | 4 | 10368 | 128 | 2,123,366,400 | 0.989 | ok |
| 799 | 8 | 10496 | 32 | 2,146,893,824 | 0.99972 | ok |
| 512 | 4 | 8192 | 128 | 2,147,483,648 | 1.000 | ok |
| 800 | 8 | 10496 | 16 | 2,149,580,800 | 1.001 | fails |
| 800 | 8 | 10496 | 32 | 2,149,580,800 | 1.001 | fails |
| 400 | 8 | 10496 | 64 | 2,149,580,800 | 1.001 | fails |
| 400 | 4 | 10496 | 128 | 2,149,580,800 | 1.001 | fails |
| 800 | 4 | 5248 | 128 | 2,149,580,800 | 1.001 | fails |
| 200 | 4 | 20992 | 128 | 2,149,580,800 | 1.001 | fails |
| 1600 | 8 | 10496 | 16 | 4,299,161,600 | 2.002 | fails |
| 3200 | 8 | 10496 | 16 | 8,598,323,200 | 4.004 | fails |

The `799` and `512` rows sit either side of the boundary within 0.03%, and the `400 / 16` versus `800 / 16` pair fixes the head-dim floor at 32 rather than 64.

## Caveats

- The constant is a measured boundary. It is consistent with a signed 32-bit element index over a workspace padded to the kernel's block sizes, but I have not confirmed that in the FlashAttention source, so if a maintainer knows the actual bound that would be a better value than mine.
- One GPU, one torch version, bf16, head dims 16/32/64/128.
- If a single batch entry is on its own outside the bound, chunking the batch cannot help and the guard leaves the call as it is. That needs `heads * round_up(seq_q, 128) * max(head_dim, 32) > 2**31`, which no shape here reaches.

## Tests

`tests/test_architectures/test_shared/test_scaled_dot_product_attention.py`:

- four tests that drive `_torch_sdpa` on meta tensors and assert the chunking: over the bound it splits and every call lands inside it, the head-dim-16 case over the bound also splits (its raw count looks safe, so this is the one that catches a check which ignores the padding), inside the bound it stays a single call, and a non-FlashAttention backend is not split. These need no GPU and no memory.
- one `slow` test that runs a failing shape end to end, skipped unless a CUDA device has ~24 GiB free.

`pytest tests/test_architectures/test_shared tests/test_architectures/test_attention_backends.py tests/test_architectures/test_chunked_evaluate.py` passes (30 passed, 9 skipped).

Verified on the GPU: the `slow` test fails unpatched and passes patched. A larger model that previously failed at these shapes now completes, both at the shape where it first failed and at one 1.34x beyond it.
