### PR TITLE
perf: remove redundant copies in ensemble preprocessing

### DIFF
--- a/changelog/1186.changed.md
+++ b/changelog/1186.changed.md
@@ -1,0 +1,1 @@
+Reduced peak host memory during preprocessing: the ensemble preprocessor no longer rebuilds the feature matrix in steps that cannot change it, taking transient RSS from 42.7 GB to 12.0 GB (-72%), and wall time with it, on a 666,667 x 2,000 float64 fit. Preprocessed outputs are unchanged.

--- a/src/tabpfn/preprocessing/steps/add_svd_features_step.py
+++ b/src/tabpfn/preprocessing/steps/add_svd_features_step.py
@@ -4,9 +4,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from typing import Literal
 from typing_extensions import override
 
+import numpy as np
 from sklearn.decomposition import TruncatedSVD
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import StandardScaler
@@ -16,8 +17,24 @@ from tabpfn.preprocessing.pipeline_interface import PreprocessingStep
 from tabpfn.preprocessing.steps.utils import make_scaler_safe
 from tabpfn.utils import infer_random_state
 
-if TYPE_CHECKING:
-    import numpy as np
+
+def _pin_layout(X: np.ndarray) -> np.ndarray:
+    """Return ``X`` in the memory layout this step's solver is calibrated on.
+
+    ``TruncatedSVD(algorithm="arpack")`` is an iterative Lanczos solver, and on a
+    near-degenerate spectrum -- singular values within a fraction of a percent of each
+    other, which wide tables routinely produce -- the basis it converges to depends on
+    the order the underlying BLAS accumulates in, and so on whether the array it is
+    handed is C- or Fortran-contiguous. The values are unaffected and so is the
+    subspace; which basis of it comes back is not.
+
+    Upstream steps decide that layout only by accident (sklearn's column indexing and
+    ``hstack`` happen to return Fortran-contiguous arrays), so without pinning it here
+    an unrelated change to an earlier step silently rotates these features. Fortran
+    order is what the pipeline has always produced, so pinning it keeps the components
+    that were previously returned. A no-op when the input already has it.
+    """
+    return np.asfortranarray(X)
 
 
 def get_svd_n_components(
@@ -99,7 +116,7 @@ class AddSVDFeaturesStep(PreprocessingStep):
             n_features,
             random_state=static_seed,
         )
-        transformer.fit(X)
+        transformer.fit(_pin_layout(X))
 
         self.transformer_ = transformer
         self.feature_schema_updated_ = feature_schema
@@ -116,7 +133,8 @@ class AddSVDFeaturesStep(PreprocessingStep):
         assert self.feature_schema_updated_ is not None
         assert self.transformer_ is not None
 
-        return X, self.transformer_.transform(X), FeatureModality.NUMERICAL
+        # Only the solver's input is pinned; `X` itself is handed back as it came.
+        return X, self.transformer_.transform(_pin_layout(X)), FeatureModality.NUMERICAL
 
 
 def get_svd_features_transformer(

--- a/src/tabpfn/preprocessing/steps/add_svd_features_step.py
+++ b/src/tabpfn/preprocessing/steps/add_svd_features_step.py
@@ -19,20 +19,17 @@ from tabpfn.utils import infer_random_state
 
 
 def _pin_layout(X: np.ndarray) -> np.ndarray:
-    """Return ``X`` in the memory layout this step's solver is calibrated on.
+    """Return ``X`` in Fortran order, the layout this step's solver is calibrated on.
 
     ``TruncatedSVD(algorithm="arpack")`` is an iterative Lanczos solver, and on a
     near-degenerate spectrum -- singular values within a fraction of a percent of each
     other, which wide tables routinely produce -- the basis it converges to depends on
     the order the underlying BLAS accumulates in, and so on whether the array it is
     handed is C- or Fortran-contiguous. The values are unaffected and so is the
-    subspace; which basis of it comes back is not.
+    subspace; which basis of it comes back is not. Pinning the layout here is what
+    keeps the components stable against a layout change in any earlier step.
 
-    Upstream steps decide that layout only by accident (sklearn's column indexing and
-    ``hstack`` happen to return Fortran-contiguous arrays), so without pinning it here
-    an unrelated change to an earlier step silently rotates these features. Fortran
-    order is what the pipeline has always produced, so pinning it keeps the components
-    that were previously returned. A no-op when the input already has it.
+    A no-op when the input is already Fortran-contiguous.
     """
     return np.asfortranarray(X)
 

--- a/src/tabpfn/preprocessing/steps/encode_categorical_features_step.py
+++ b/src/tabpfn/preprocessing/steps/encode_categorical_features_step.py
@@ -223,16 +223,8 @@ class EncodeCategoricalFeaturesStep(PreprocessingStep):
             )
 
             if not categorical_features:
-                # Nothing to encode, so the transformer below would come out a
-                # whole-table passthrough -- and a ColumnTransformer passthrough still
-                # rebuilds the array, once for the block and once for the hstack of the
-                # blocks: 21.3 GB of the peak on a 666,667 x 2,000 fit, for an output
-                # equal to its input. `None` takes the same path as the "numeric" and
-                # "none" modes and hands `X` straight back. The schema is identical
-                # either way: with no encoded columns the remainder covers every output
-                # position and maps 1:1 onto the input columns, in order, which is what
-                # both `_columntransformer_output_names` and
-                # `_carry_over_input_feature_metadata` reduce to.
+                # Nothing to encode, and a ColumnTransformer passthrough
+                # would rebuild the array
                 return None, categorical_features
 
             ct = ColumnTransformer(

--- a/src/tabpfn/preprocessing/steps/encode_categorical_features_step.py
+++ b/src/tabpfn/preprocessing/steps/encode_categorical_features_step.py
@@ -222,6 +222,19 @@ class EncodeCategoricalFeaturesStep(PreprocessingStep):
                 f" or 'ordinal_shuffled' it was {self.categorical_transform_name}"
             )
 
+            if not categorical_features:
+                # Nothing to encode, so the transformer below would come out a
+                # whole-table passthrough -- and a ColumnTransformer passthrough still
+                # rebuilds the array, once for the block and once for the hstack of the
+                # blocks: 21.3 GB of the peak on a 666,667 x 2,000 fit, for an output
+                # equal to its input. `None` takes the same path as the "numeric" and
+                # "none" modes and hands `X` straight back. The schema is identical
+                # either way: with no encoded columns the remainder covers every output
+                # position and maps 1:1 onto the input columns, in order, which is what
+                # both `_columntransformer_output_names` and
+                # `_carry_over_input_feature_metadata` reduce to.
+                return None, categorical_features
+
             ct = ColumnTransformer(
                 [
                     (

--- a/src/tabpfn/preprocessing/steps/remove_constant_features_step.py
+++ b/src/tabpfn/preprocessing/steps/remove_constant_features_step.py
@@ -62,10 +62,7 @@ class RemoveConstantFeaturesStep(PreprocessingStep):
         assert self.sel_ is not None, "You must call fit first"
         if self._keeps_every_column():
             # Selecting every column with a boolean mask still builds a full copy of
-            # the array -- 10.7 GB on a 666,667 x 2,000 fit -- to hand back exactly
-            # what it was given. Nothing downstream may mutate the result in place
-            # (the pipeline copies before the first step runs), so returning the input
-            # is equivalent.
+            # the array
             return X, None, None
         return X[:, self.sel_], None, None
 

--- a/src/tabpfn/preprocessing/steps/remove_constant_features_step.py
+++ b/src/tabpfn/preprocessing/steps/remove_constant_features_step.py
@@ -60,4 +60,17 @@ class RemoveConstantFeaturesStep(PreprocessingStep):
         self, X: np.ndarray | torch.Tensor, *, is_test: bool = False
     ) -> tuple[np.ndarray, np.ndarray | None, FeatureModality | None]:
         assert self.sel_ is not None, "You must call fit first"
+        if self._keeps_every_column():
+            # Selecting every column with a boolean mask still builds a full copy of
+            # the array -- 10.7 GB on a 666,667 x 2,000 fit -- to hand back exactly
+            # what it was given. Nothing downstream may mutate the result in place
+            # (the pipeline copies before the first step runs), so returning the input
+            # is equivalent.
+            return X, None, None
         return X[:, self.sel_], None, None
+
+    def _keeps_every_column(self) -> bool:
+        """Whether the fitted selection drops nothing."""
+        if isinstance(self.sel_, torch.Tensor):
+            return bool(torch.all(self.sel_))
+        return all(self.sel_)  # type: ignore[arg-type]

--- a/src/tabpfn/preprocessing/steps/reshape_feature_distribution_step.py
+++ b/src/tabpfn/preprocessing/steps/reshape_feature_distribution_step.py
@@ -453,10 +453,12 @@ class ReshapeFeatureDistributionsStep(PreprocessingStep):
     def _transform(
         self, X: np.ndarray, *, is_test: bool = False
     ) -> tuple[np.ndarray, np.ndarray | None, FeatureModality | None]:
-        assert self.data_is_unchanged_ is not None, "You must call fit first"
-        if self.data_is_unchanged_:
+        # Read through `getattr`: an estimator pickled by a version that predates
+        # `data_is_unchanged_` has no such attribute, and always carries a transformer,
+        # so the skip is off for it and the assert below is what reports "not fitted".
+        if getattr(self, "data_is_unchanged_", False):
             return X, None, None
-        assert self.transformer_ is not None
+        assert self.transformer_ is not None, "You must call fit first"
         return self.transformer_.transform(X), None, None
 
     @override

--- a/src/tabpfn/preprocessing/steps/reshape_feature_distribution_step.py
+++ b/src/tabpfn/preprocessing/steps/reshape_feature_distribution_step.py
@@ -261,13 +261,23 @@ class ReshapeFeatureDistributionsStep(PreprocessingStep):
         self.max_features_per_estimator = max_features_per_estimator
         self.schedule_gpu_transform = schedule_gpu_transform
         self.transformer_: Pipeline | ColumnTransformer | None = None
+        self.data_is_unchanged_: bool | None = None
+        """Whether this step's transformer would hand the data back untouched, in which
+        case it is not built and the data pass is skipped. ``None`` until fitted, so
+        "not fitted yet" stays distinguishable from "fitted to a no-op"."""
 
     def _create_transformers_and_new_schema(
         self,
         n_samples: int,
         n_features: int,
         feature_schema: FeatureSchema,
-    ) -> tuple[Pipeline | ColumnTransformer, FeatureSchema]:
+    ) -> tuple[Pipeline | ColumnTransformer | None, FeatureSchema]:
+        """Build the transformer for this step, and the schema its output has.
+
+        Returns ``None`` for the transformer when the assembled one would not change
+        the data at all -- see `data_is_unchanged_`. The schema is built the same way
+        either way.
+        """
         if "adaptive" in self.transform_name:
             raise NotImplementedError("Adaptive preprocessing raw removed.")
 
@@ -332,8 +342,6 @@ class ReshapeFeatureDistributionsStep(PreprocessingStep):
             sparse_threshold=0.0,  # No sparse
         )
 
-        self.transformer_ = transformer
-
         # Compute output feature count for modality update
         # Include: base features + appended transformed (if append_to_original).
         # Multi-output transforms (e.g. the "norm_and_kdi" FeatureUnion) emit
@@ -362,6 +370,27 @@ class ReshapeFeatureDistributionsStep(PreprocessingStep):
         )
         self._set_ancestors(new_schema, feature_schema, layout)
 
+        # A transform scheduled onto the GPU leaves "none" behind on this side, which
+        # the registry maps to the identity `FunctionTransformer`. When the layout also
+        # hands every input column back in its own position, the ColumnTransformer's
+        # only remaining effect on the data is to rebuild the array -- once for the
+        # transformed block, once for the hstack of the blocks -- and hand back what it
+        # was given: 21.3 GB of the peak on a 666,667 x 2,000 fit. The schema does still
+        # change (columns are renamed, given ancestors, and annotated as GPU targets),
+        # so only the data pass is skipped.
+        #
+        # Decided from the transformer object rather than the preset name, so a registry
+        # change that gives "none" something to do cannot silently keep this path; and
+        # from the layout rather than the flags that built it, so any reordering or
+        # appending disqualifies it without having to enumerate the combinations.
+        self.data_is_unchanged_ = (
+            isinstance(_transformer, FunctionTransformer)
+            and _transformer.func is None
+            and not _transformer.validate
+            and [column.source_ix for column in layout] == all_feats_ix
+        )
+        self.transformer_ = None if self.data_is_unchanged_ else transformer
+
         if self.schedule_gpu_transform is not None:
             if self.append_to_original_decision_:
                 # Output: [original_all, transformed_copies]
@@ -378,7 +407,7 @@ class ReshapeFeatureDistributionsStep(PreprocessingStep):
                     f, scheduled_gpu_transform=self.schedule_gpu_transform
                 )
 
-        return transformer, new_schema
+        return self.transformer_, new_schema
 
     def _set_ancestors(
         self,
@@ -424,7 +453,8 @@ class ReshapeFeatureDistributionsStep(PreprocessingStep):
             n_features,
             feature_schema,
         )
-        transformer.fit(X)
+        if transformer is not None:
+            transformer.fit(X)
         self.transformer_ = transformer
         return output_schema
 
@@ -432,7 +462,10 @@ class ReshapeFeatureDistributionsStep(PreprocessingStep):
     def _transform(
         self, X: np.ndarray, *, is_test: bool = False
     ) -> tuple[np.ndarray, np.ndarray | None, FeatureModality | None]:
-        assert self.transformer_ is not None, "You must call fit first"
+        assert self.data_is_unchanged_ is not None, "You must call fit first"
+        if self.data_is_unchanged_:
+            return X, None, None
+        assert self.transformer_ is not None
         return self.transformer_.transform(X), None, None
 
     @override
@@ -458,7 +491,7 @@ class ReshapeFeatureDistributionsStep(PreprocessingStep):
             n_features,
             feature_schema,
         )
-        x_transformed = transformer.fit_transform(X)
+        x_transformed = X if transformer is None else transformer.fit_transform(X)
         self.transformer_ = transformer
         self.feature_schema_updated_ = output_schema
 

--- a/src/tabpfn/preprocessing/steps/reshape_feature_distribution_step.py
+++ b/src/tabpfn/preprocessing/steps/reshape_feature_distribution_step.py
@@ -371,22 +371,13 @@ class ReshapeFeatureDistributionsStep(PreprocessingStep):
         self._set_ancestors(new_schema, feature_schema, layout)
 
         # A transform scheduled onto the GPU leaves "none" behind on this side, which
-        # the registry maps to the identity `FunctionTransformer`. When the layout also
-        # hands every input column back in its own position, the ColumnTransformer's
-        # only remaining effect on the data is to rebuild the array -- once for the
-        # transformed block, once for the hstack of the blocks -- and hand back what it
-        # was given: 21.3 GB of the peak on a 666,667 x 2,000 fit. The schema does still
-        # change (columns are renamed, given ancestors, and annotated as GPU targets),
-        # so only the data pass is skipped.
-        #
-        # Decided from the transformer object rather than the preset name, so a registry
-        # change that gives "none" something to do cannot silently keep this path; and
-        # from the layout rather than the flags that built it, so any reordering or
-        # appending disqualifies it without having to enumerate the combinations.
+        # the registry maps to the identity `FunctionTransformer`.
         self.data_is_unchanged_ = (
+            # FunctionTransformer(func=None, validate=False) is the identity function
             isinstance(_transformer, FunctionTransformer)
             and _transformer.func is None
             and not _transformer.validate
+            # also check if the column order should change
             and [column.source_ix for column in layout] == all_feats_ix
         )
         self.transformer_ = None if self.data_is_unchanged_ else transformer

--- a/src/tabpfn/preprocessing/transform.py
+++ b/src/tabpfn/preprocessing/transform.py
@@ -70,10 +70,7 @@ def _fit_preprocessing_one(
         X_train = X_train[..., feature_indices]
         feature_schema = feature_schema.slice_for_indices(feature_indices.tolist())
     if not isinstance(X_train, torch.Tensor):
-        # Only the labels are copied. `PreprocessingPipeline._process_steps` already
-        # copies the features before any step can touch them -- that is what keeps the
-        # caller's array immutable -- so copying them here too held a second full-size
-        # array for the whole call, 10.7 GB of the peak on a 666,667 x 2,000 fit.
+        # PreprocessingPipeline._process_steps already copies X_train
         y_train = y_train.copy()
 
     res = pipeline.fit_transform(X_train, feature_schema)

--- a/src/tabpfn/preprocessing/transform.py
+++ b/src/tabpfn/preprocessing/transform.py
@@ -70,7 +70,10 @@ def _fit_preprocessing_one(
         X_train = X_train[..., feature_indices]
         feature_schema = feature_schema.slice_for_indices(feature_indices.tolist())
     if not isinstance(X_train, torch.Tensor):
-        X_train = X_train.copy()
+        # Only the labels are copied. `PreprocessingPipeline._process_steps` already
+        # copies the features before any step can touch them -- that is what keeps the
+        # caller's array immutable -- so copying them here too held a second full-size
+        # array for the whole call, 10.7 GB of the peak on a 666,667 x 2,000 fit.
         y_train = y_train.copy()
 
     res = pipeline.fit_transform(X_train, feature_schema)

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import platform
 
 import numpy as np
+import pandas as pd
 import pytest
 import torch
 
@@ -146,6 +147,79 @@ def test__to__after_fit_and_predict__no_tensors_left_on_old_device(
     assert not tensors_not_on_cpu, f"Found tensors not on cpu: {tensors_not_on_cpu}"
 
 
+READ_ONLY_INPUT_KINDS = [
+    "float_c_order",
+    "float_f_order",
+    "int",
+    "with_nan",
+    "with_inf",
+]
+
+
+@pytest.mark.parametrize("estimator_class", [TabPFNRegressor, TabPFNClassifier])
+@pytest.mark.parametrize("input_kind", READ_ONLY_INPUT_KINDS)
+def test__fit_and_predict__do_not_write_into_the_callers_arrays(
+    estimator_class: type[TabPFNClassifier] | type[TabPFNRegressor],
+    input_kind: str,
+) -> None:
+    """Read-only inputs survive fit + predict.
+
+    Handing the estimator arrays with the write flag cleared is stricter than
+    comparing them before and after: numpy raises on *any* in-place write,
+    including one that stores back the value it overwrote. Callers may hold
+    memory-mapped or otherwise shared arrays, so neither fit nor predict may
+    treat its input as scratch space.
+    """
+    X_train, X_test, y_train, inference_config = _get_read_only_dataset(
+        estimator_class, input_kind
+    )
+
+    estimator = estimator_class(
+        n_estimators=2,
+        device="cpu",
+        random_state=0,
+        inference_config=inference_config,
+    )
+    estimator.fit(X_train, y_train)
+    estimator.predict(X_test)
+
+    # Guards against an estimator making its input writeable to work around the
+    # error above rather than copying.
+    assert not X_train.flags.writeable
+    assert not y_train.flags.writeable
+    assert not X_test.flags.writeable
+
+
+@pytest.mark.parametrize("estimator_class", [TabPFNRegressor, TabPFNClassifier])
+def test__fit_and_predict__do_not_modify_the_callers_dataframe(
+    estimator_class: type[TabPFNClassifier] | type[TabPFNRegressor],
+) -> None:
+    """A mixed-dtype DataFrame comes back with its values and dtypes intact.
+
+    Pandas objects cannot be frozen the way numpy arrays can (the read-only test
+    above), so this compares against a deep copy instead. The frame mixes the
+    dtypes whose cleaning paths differ: floats with missing values, infinities,
+    integers, categoricals and strings.
+    """
+    X_train, X_test, y_train, inference_config = _get_dataframe_dataset(estimator_class)
+    X_train_before = X_train.copy(deep=True)
+    X_test_before = X_test.copy(deep=True)
+    y_train_before = y_train.copy(deep=True)
+
+    estimator = estimator_class(
+        n_estimators=2,
+        device="cpu",
+        random_state=0,
+        inference_config=inference_config,
+    )
+    estimator.fit(X_train, y_train)
+    estimator.predict(X_test)
+
+    pd.testing.assert_frame_equal(X_train, X_train_before)
+    pd.testing.assert_frame_equal(X_test, X_test_before)
+    pd.testing.assert_series_equal(y_train, y_train_before)
+
+
 def _find_tensors_not_on_cpu(
     estimator: TabPFNClassifier | TabPFNRegressor,
     path: str = "root",
@@ -194,3 +268,96 @@ def _get_tiny_dataset(
     elif isinstance(estimator, TabPFNRegressor):
         y_train = generator.normal(loc=0, scale=1, size=n_train)
     return X[:n_train], X[n_train:], y_train
+
+
+def _freeze(array: np.ndarray, *, order: str = "C") -> np.ndarray:
+    """Return an owned copy of `array` in `order` that cannot be written to."""
+    frozen = array.copy(order=order)
+    frozen.setflags(write=False)
+    return frozen
+
+
+def _get_read_only_dataset(
+    estimator_class: type[TabPFNClassifier] | type[TabPFNRegressor],
+    input_kind: str,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, dict[str, bool]]:
+    """Build a tiny read-only dataset of the given kind.
+
+    Returns (X_train, X_test, y_train, inference_config).
+    """
+    n_train = 20
+    n_test = 5
+    generator = np.random.default_rng(seed=0)
+    X = generator.normal(loc=0, scale=1, size=(n_train + n_test, 4))
+    inference_config: dict[str, bool] = {}
+    order = "C"
+
+    if input_kind == "float_f_order":
+        order = "F"
+    elif input_kind == "int":
+        X = (X * 10).astype(np.int64)
+    elif input_kind == "with_nan":
+        X[0, 0] = np.nan
+        X[n_train + 1, 2] = np.nan
+    elif input_kind == "with_inf":
+        X[0, 0] = np.inf
+        X[n_train + 1, 2] = -np.inf
+        # Infinities are rejected outright unless they are read as missingness.
+        inference_config = {"PASSTHROUGH_INF": True}
+    elif input_kind != "float_c_order":
+        raise ValueError(f"Unknown input kind {input_kind!r}")
+
+    if issubclass(estimator_class, TabPFNClassifier):
+        y_train = generator.integers(0, 3, size=n_train)
+    else:
+        y_train = generator.normal(loc=0, scale=1, size=n_train)
+
+    return (
+        _freeze(X[:n_train], order=order),
+        _freeze(X[n_train:], order=order),
+        _freeze(y_train),
+        inference_config,
+    )
+
+
+def _get_dataframe_dataset(
+    estimator_class: type[TabPFNClassifier] | type[TabPFNRegressor],
+) -> tuple[pd.DataFrame, pd.DataFrame, pd.Series, dict[str, bool]]:
+    """Build a tiny mixed-dtype frame.
+
+    Returns (X_train, X_test, y_train, inference_config).
+    """
+    n_train = 20
+    n_test = 5
+    n_samples = n_train + n_test
+    generator = np.random.default_rng(seed=0)
+
+    floats = generator.normal(loc=0, scale=1, size=n_samples)
+    floats[0] = np.nan
+    infinities = generator.normal(loc=0, scale=1, size=n_samples)
+    infinities[1] = np.inf
+    infinities[n_train + 1] = -np.inf
+
+    X = pd.DataFrame(
+        {
+            "float_with_nan": floats,
+            "float_with_inf": infinities,
+            "int": generator.integers(0, 10, size=n_samples),
+            "categorical": pd.Categorical(generator.choice(["a", "b", "c"], n_samples)),
+            "string": generator.choice(["x", "y"], n_samples).astype(object),
+        }
+    )
+
+    if issubclass(estimator_class, TabPFNClassifier):
+        y_train = pd.Series(generator.integers(0, 3, size=n_train), name="target")
+    else:
+        y_train = pd.Series(
+            generator.normal(loc=0, scale=1, size=n_train), name="target"
+        )
+
+    return (
+        X.iloc[:n_train].copy(deep=True),
+        X.iloc[n_train:].copy(deep=True),
+        y_train,
+        {"PASSTHROUGH_INF": True},
+    )

--- a/tests/test_estimators.py
+++ b/tests/test_estimators.py
@@ -4,15 +4,29 @@
 
 from __future__ import annotations
 
+import functools
 import platform
+from typing import Literal
 
 import numpy as np
 import pandas as pd
 import pytest
 import torch
+from torch import Tensor, nn
 
 from tabpfn import TabPFNClassifier, TabPFNRegressor
+from tabpfn.architectures.interface import (
+    Architecture,
+    ArchitectureConfig,
+    PerformanceOptions,
+)
+from tabpfn.architectures.shared.bar_distribution import FullSupportBarDistribution
+from tabpfn.base import ClassifierModelSpecs, RegressorModelSpecs
+from tabpfn.checkpoint import Checkpoint
 from tabpfn.constants import ModelVersion
+from tabpfn.inference_config import InferenceConfig
+from tabpfn.model_loading import download_model, resolve_model_path
+from tabpfn.settings import settings
 from tests.utils import get_pytest_devices
 
 devices = get_pytest_devices()
@@ -155,6 +169,9 @@ READ_ONLY_INPUT_KINDS = [
     "with_inf",
 ]
 
+STAND_IN_MAX_NUM_CLASSES = 10
+STAND_IN_NUM_BUCKETS = 64
+
 
 @pytest.mark.parametrize("estimator_class", [TabPFNRegressor, TabPFNClassifier])
 @pytest.mark.parametrize("input_kind", READ_ONLY_INPUT_KINDS)
@@ -175,6 +192,7 @@ def test__fit_and_predict__do_not_write_into_the_callers_arrays(
     )
 
     estimator = estimator_class(
+        model_path=_get_stand_in_model_specs(estimator_class),
         n_estimators=2,
         device="cpu",
         random_state=0,
@@ -207,6 +225,7 @@ def test__fit_and_predict__do_not_modify_the_callers_dataframe(
     y_train_before = y_train.copy(deep=True)
 
     estimator = estimator_class(
+        model_path=_get_stand_in_model_specs(estimator_class),
         n_estimators=2,
         device="cpu",
         random_state=0,
@@ -360,4 +379,108 @@ def _get_dataframe_dataset(
         X.iloc[n_train:].copy(deep=True),
         y_train,
         {"PASSTHROUGH_INF": True},
+    )
+
+
+class _ConstantOutputModel(Architecture):
+    """A stand-in architecture whose forward pass returns constant logits.
+
+    The tests using it assert on their own inputs rather than on predictions, and
+    everything that could touch those inputs — validation, cleaning, and the
+    ensemble preprocessing — runs before the model is reached. Real weights would
+    therefore only add a checkpoint download and a forward pass to each case.
+    """
+
+    def __init__(self, n_outputs: int) -> None:
+        """Create a model emitting `n_outputs` logits per test row."""
+        super().__init__()
+        self.n_outputs = n_outputs
+        # The inference engine reads the model's device off its first parameter.
+        self.parameter = nn.Parameter(torch.tensor(1.0))
+
+    def forward(
+        self,
+        x: Tensor | dict[str, Tensor],
+        y: Tensor | dict[str, Tensor] | None,
+        *,
+        only_return_standard_out: bool = True,
+        categorical_inds: list[list[int]] | None = None,
+        performance_options: PerformanceOptions | None = None,
+        task_type: str | None = None,
+    ) -> Tensor | dict[str, Tensor]:
+        """Return zero logits for every test row, see `Architecture.forward`."""
+        del categorical_inds, performance_options, task_type
+        features = x["main"] if isinstance(x, dict) else x
+        n_rows, batch_size = features.shape[0], features.shape[1]
+        targets = y["main"] if isinstance(y, dict) else y
+        n_train_rows = 0 if targets is None else targets.shape[0]
+
+        out = features.new_zeros((n_rows - n_train_rows, batch_size, self.n_outputs))
+        return out if only_return_standard_out else {"standard": out}
+
+    @property
+    def embedding_dim(self) -> int:
+        """The width of the (never produced) embeddings."""
+        return 2
+
+    @property
+    def features_per_group(self) -> int:
+        """The number of features the model packs into one token."""
+        return 2
+
+    def reset_save_peak_mem_factor(self, factor: int | None = None) -> None:
+        """No-op: this model has no layers to configure."""
+
+
+@functools.cache
+def _get_shipped_inference_config(
+    which: Literal["classifier", "regressor"],
+) -> InferenceConfig:
+    """Read the shipped model's inference config without materialising its weights.
+
+    The preprocessing under test is the one the default model selects, and from
+    v2.6 on that configuration lives inside the checkpoint rather than in
+    `InferenceConfig.get_default`. Reading it back memory-mapped costs a few tens
+    of milliseconds once per session and leaves the weights on disk.
+    """
+    version = settings.tabpfn.model_version
+    (path,), _, (name,), _ = resolve_model_path(None, which, version=version.value)
+    if not path.exists():
+        result = download_model(path, version=version, which=which, model_name=name)
+        if result != "ok":
+            raise RuntimeError(f"Could not download {name}: {result}")
+
+    checkpoint = Checkpoint(path)
+    raw = (
+        checkpoint.load()
+        if checkpoint.is_safetensors
+        else torch.load(str(path), map_location="cpu", weights_only=False, mmap=True)
+    )
+    return InferenceConfig(**raw["inference_config"])
+
+
+def _get_stand_in_model_specs(
+    estimator_class: type[TabPFNClassifier] | type[TabPFNRegressor],
+) -> ClassifierModelSpecs | RegressorModelSpecs:
+    """Return specs that make an estimator run on `_ConstantOutputModel`.
+
+    Passing specs as `model_path` is the supported way to supply an already
+    constructed model, so the estimator's own code path stays intact: it runs the
+    shipped preprocessing and only the forward pass is a stand-in.
+    """
+    if issubclass(estimator_class, TabPFNClassifier):
+        return ClassifierModelSpecs(
+            model=_ConstantOutputModel(STAND_IN_MAX_NUM_CLASSES),
+            architecture_config=ArchitectureConfig(
+                max_num_classes=STAND_IN_MAX_NUM_CLASSES
+            ),
+            inference_config=_get_shipped_inference_config("classifier"),
+        )
+    return RegressorModelSpecs(
+        model=_ConstantOutputModel(STAND_IN_NUM_BUCKETS),
+        architecture_config=ArchitectureConfig(num_buckets=STAND_IN_NUM_BUCKETS),
+        inference_config=_get_shipped_inference_config("regressor"),
+        norm_criterion=FullSupportBarDistribution(
+            torch.linspace(-5.0, 5.0, STAND_IN_NUM_BUCKETS + 1)
+        ),
     )

--- a/tests/test_preprocessing/test_reshape_feature_distribution_step.py
+++ b/tests/test_preprocessing/test_reshape_feature_distribution_step.py
@@ -621,3 +621,26 @@ def test__norm_and_kdi__output_schema_column_count():
     result_append = step_append.fit_transform(X, schema)
     assert result_append.X.shape[1] == 3 * n_features
     assert result_append.feature_schema.num_columns == 3 * n_features
+
+
+def test__reshape__transform__estimator_without_data_is_unchanged_attribute():
+    """A step unpickled without ``data_is_unchanged_`` transforms through
+    ``transformer_``.
+
+    Estimators pickled by a version that predates the attribute restore without it, and
+    predicting on one must not fail on the lookup.
+    """
+    rng = np.random.default_rng(0)
+    X = rng.random((50, 4))
+    schema = _get_schema(num_columns=4)
+
+    step = ReshapeFeatureDistributionsStep(
+        transform_name="safepower",
+        apply_to_categorical=False,
+        append_to_original=False,
+        random_state=0,
+    )
+    expected = step.fit_transform(X, schema).X
+
+    del step.data_is_unchanged_
+    np.testing.assert_array_equal(step.transform(X).X, expected)


### PR DESCRIPTION
## Issue

[RES-2592: optimize `TabPFNEnsemblePreprocessor.fit_transform_ensemble_members_iterator` RAM usage](https://linear.app/priorlabs/issue/RES-2592/optimize-tabpfnensemblepreprocessorfit-transform-ensemble-members) — follows the wrapper host-RAM work: with `clean_data` brought down, this call is the largest remaining contributor to the peak.

## Motivation and Context

**What**

-   `TabPFNEnsemblePreprocessor.fit_transform_ensemble_members_iterator` held four full-size copies of its input above the table it hands back, none of which changed a value.
-   Dropping them takes transient RSS from **42.7 GB to 12.0 GB** on the profiled shape, and the wall time with it.

**Why**

-   At 666,667 x 2,000 float64 this call was measured holding 4.0x the table it returns — the single largest remaining contributor to the wrapper's host-RAM peak.
-   The copies dominated its runtime too, so this is as much a latency change as a memory one.

**How**

-   Skip the rebuild wherever it cannot change a value: the redundant copy in `_fit_preprocessing_one`, an all-true mask select, an identity reshape `ColumnTransformer` (what a GPU-scheduled transform leaves behind), and a whole-table encoder passthrough.
-   First pin Fortran order at the ARPACK SVD's entrance, so those skips cannot rotate its basis — see the note below, this is the one part that is not obviously free.

|                              | numeric                       | half-string                | numeric-object             |
| :--------------------------- | :---------------------------- | :------------------------- | :------------------------- |
| input size              | 10.67 GB (666,667 x 2,000)    | 1.07 GB (333,333 x 400)    | 1.07 GB (333,333 x 400)    |
| categoricals after cleaning   | 0 of 2,000                    | 200 of 400                 | 0 of 400                   |
| transient RSS, highest       | 42.66 -> 12.00 GB (**-71.9%**) | 4.40 -> 3.33 GB (**-24.2%**) | 4.26 -> 1.07 GB (**-74.9%**) |
| transient RSS, lowest-direct | 42.66 -> 12.00 GB (**-71.9%**) | 3.73 -> 3.20 GB (**-14.3%**) | 4.26 -> 1.07 GB (**-75.0%**) |
| median wall, highest         | 34.80 -> 11.09 s (**-68.1%**)  | 7.71 -> 7.37 s (-4.4%)     | 2.86 -> 0.70 s (**-75.6%**)  |
| median wall, lowest-direct   | 36.22 -> 11.28 s (**-68.8%**)  | 14.52 -> 14.37 s (-1.0%)   | 2.86 -> 0.76 s (**-73.4%**)  |

Each cell is a complete A/B against `main` on a dedicated `cpuhighmem16spot` node, three timed repeats, with the ensemble members compared cell by cell: **bit-identical in all six**. Mixes carry their own default shapes, so cells compare down a column, not across one. The two half-string wall-time deltas are inside the ±3% run-to-run noise floor and should be read as "unchanged".

<details><summary>Why half-string gains least, and where the remaining 12 GB is</summary>

`half-string` is the case where both skips are inapplicable by construction: it has genuine categorical columns, so the encoder really runs, and the reshape layout puts those columns first, so it is not the identity permutation either. Only the two copy removals apply, and its peak is set by the encoder's `ColumnTransformer`, which this PR does not touch — so it is the honest floor of the change rather than a surprise. Its RSS delta also moves with the dependency set (-24.2% vs -14.3%) because the baseline peak itself does (4.40 vs 3.73 GB): older pandas/numpy build that path differently.

After this change the 12.00 GB is the 10.67 GB table the call returns plus ~1.3 GB of one-byte-per-cell boolean masks (`isinf`, `isnan`), i.e. the peak is now the output itself. The `ENABLE_GPU_PREPROCESSING=False` path is unchanged at 4.95x (measured neutral: RSS +0.1%, wall -2.1%), because its peak sits in the squashing-scaler `ColumnTransformer` that none of these skips reach. That is the next target on that path, and it is the path released presets take.

</details>

<details><summary>The ARPACK layout trap (why the first commit exists)</summary>

`TruncatedSVD(algorithm="arpack")` is an iterative Lanczos solver. On the near-degenerate spectra wide tables produce — measured here at 124.14 / 123.65 / 123.08 — the basis it converges to depends on whether the array it is handed is C- or Fortran-contiguous: identical values, identical subspace (principal angles below 2e-6 degrees) and identical singular values (1.9e-15 relative), different basis.

Nothing picks that layout deliberately: sklearn's column indexing and `hstack` both return Fortran-contiguous arrays, so every step that rebuilds the table happens to hand ARPACK Fortran order. Removing such a rebuild therefore rotates these features, and every released preset configures this step (`global_transformer_name="svd"`, `ENABLE_GPU_PREPROCESSING` defaults to False), so it would have reached users. Neither the fit-side benchmarks nor a local test run would have shown it: `tests/test_consistency.py`'s reference predictions are skipped off the enabled platforms.

`_pin_layout` therefore pins Fortran order at the solver's entrance. It is a literal no-op today — verified on numpy 1.22.0 and 2.5.2, where `X[:, mask]` is Fortran-contiguous either way — and it means the next change to an earlier step no longer has to know any of this.

</details>

---

## Public API Changes

-   [x] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?

| suite                                                                                             | result                    |
| :------------------------------------------------------------------------------------------------ | :------------------------ |
| `tests/test_preprocessing`, `tests/test_torch_preprocessing`                                      | 760 passed, on both ends of the dependency range |
| `tests/test_consistency.py`, classifier/regressor interface, `tests/test_inference.py`            | 314 passed (reference predictions skipped on this platform) |
| A/B vs `main`, 6 cells above, plus `--n-estimators 3` and `--no-gpu-preprocessing`                 | members bit-identical, no regression |

-   No new tests: every change is output-preserving by construction and gated on that by the A/B above, which compares each ensemble member's preprocessed matrix, labels, schema, feature indices and pipeline shape against the reference commit.
-   Checked out-of-band that the torch (GPU-scheduled) pipeline is bitwise identical across input layouts, since the fit-side arrays now arrive C- rather than Fortran-contiguous, and that path runs at inference time where the benchmarks do not look.

<details><summary>Environments and how to reproduce</summary>

-   `highest`: python 3.14.5, numpy 2.5.2, pandas 3.0.5, scikit-learn 1.9.0, torch 2.13.0
-   `lowest-direct`: python 3.10.20, numpy 1.22.0, pandas 1.4.0, scikit-learn 1.2.0, torch 2.5.0 — matching the `lowest-direct` leg of CI

Measured with `scripts/bench_ensemble_preprocessing.py --reference main`, which is not part of this branch. Note for anyone rebuilding the floor environment: `torch.utils.benchmark` imports `cpp_extension` -> `setuptools` on torch 2.5, and nothing in the dependency floor pulls `setuptools` in, so the benchmark cannot import until it is installed. CI does not hit this because its tests never import that module.

</details>

---

## Checklist

-   [x] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [x] A changelog entry has been added (see `changelog/README.md`), or "no changelog needed" label requested.
-   [x] The code follows the project's style guidelines.
-   [x] I have considered the impact of these changes on the public API.

---

