### PR TITLE
perf: reduce peak memory on string categoricals

### DIFF
--- a/changelog/1187.changed.md
+++ b/changelog/1187.changed.md
@@ -1,0 +1,1 @@
+Reduced peak host memory during preprocessing for tables with categorical columns: the reshape and ordinal-encoding steps no longer rebuild the feature matrix to reorder it or to encode part of it, taking transient RSS from 3.33 GB to 2.80 GB (-16%) on a 333,333 x 400 half-categorical fit. Preprocessed outputs are unchanged.

--- a/src/tabpfn/preprocessing/clean.py
+++ b/src/tabpfn/preprocessing/clean.py
@@ -18,7 +18,10 @@ from packaging.version import Version
 
 from tabpfn.constants import NA_PLACEHOLDER
 from tabpfn.preprocessing.datamodel import FeatureModality
-from tabpfn.preprocessing.steps.preprocessing_helpers import get_ordinal_encoder
+from tabpfn.preprocessing.steps.preprocessing_helpers import (
+    get_ordinal_encoder,
+    to_numpy_may_alias,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -45,8 +48,6 @@ PANDAS_FASTER_THAN_MIXED_PATH = Version(pd.__version__) < Version("3.0.0")
 _ASTYPE_KEEPS_UNCAST_COLUMNS = (
     {"copy": False} if Version(pd.__version__) < Version("3.0.0") else {}
 )
-
-_FLOAT64 = np.dtype(np.float64)
 
 
 def _cast_columns_share_a_block(
@@ -455,148 +456,6 @@ else:
     inf_masks_dataframe = _inf_masks_dataframe
 
 
-def _encoding_is_identity(
-    X: pd.DataFrame,
-    ord_encoder: OrderPreservingColumnTransformer | None,
-    *,
-    fit_encoder: bool,
-) -> bool:
-    """Whether the ordinal-encoding step provably cannot change any value.
-
-    The encoder selects columns by dtype (``category``/``string``), so a frame of
-    plain float64 columns leaves it with nothing to select: the transformer reduces
-    to its passthrough remainder and the whole step is the float64 cast it ends
-    with. Plain float64 specifically, not merely numeric -- a nullable ``Float64``
-    holds ``pd.NA``, which only survives the trip through pandas.
-
-    A *frozen* encoder does not re-select, it reuses the columns it saw at fit, so
-    that selection has to be empty as well -- and the frame has to be one sklearn
-    would have accepted, since skipping `transform` skips its checks along with it.
-    """
-    return (
-        # only passthrough non-nullable all-fp64 dataframes
-        all(dtype == _FLOAT64 for dtype in X.dtypes)
-        and (
-            # trainable encoders are ok
-            fit_encoder
-            or ord_encoder is None
-            or (
-                # condition 1: the ordinal encoder has been fitted and needs to
-                # be reducible to its passthrough remainder
-                all(
-                    len(columns) == 0
-                    for name, _, columns in ord_encoder.transformers_
-                    if name != "remainder"
-                )
-                # condition 2: X needs to line up with what the encoder was fitted on
-                # condition 2.1: encoder needs to have the same input feature shape
-                and getattr(ord_encoder, "n_features_in_", None) == X.shape[1]
-                # condition 2.2: either no fitted feature names, or they match 1:1
-                and (
-                    getattr(ord_encoder, "feature_names_in_", None) is None
-                    or not all(isinstance(col, str) for col in X.columns)
-                    # compared as plain lists to be dtype-insensitive:
-                    or list(X.columns) == list(ord_encoder.feature_names_in_)  # ty: ignore[unresolved-attribute]
-                )
-            )
-        )
-    )
-
-
-def _to_numpy_may_alias(X: pd.DataFrame) -> bool:
-    """Whether ``X.to_numpy()`` can hand back a view of the frame's own buffer.
-
-    A single-block frame is handed out as that block: read-only under copy-on-write,
-    writeable and aliasing whatever the frame was built from without it (pandas < 3),
-    which for a numeric ndarray input is the caller's own array. Anything wider has
-    to be materialised into a new array first, so what comes back is private.
-
-    Defensively ``True`` when the block internals are unavailable, so an unrecognised
-    layout is copied rather than handed out.
-    """
-    blocks = getattr(getattr(X, "_mgr", None), "blocks", None)
-    return blocks is None or len(blocks) <= 1
-
-
-def _owned_float64_values(X: pd.DataFrame) -> np.ndarray:
-    """`X`'s values as a writeable float64 array that the caller owns.
-
-    One full-size allocation, whichever pandas is installed. What it cannot be is
-    `to_numpy`'s result handed straight back, for a different reason per shape:
-
-    * A single-block frame is handed out as that block, so `to_numpy` allocates
-      nothing at all. That one is copied -- see `_to_numpy_may_alias`.
-    * A frame of many blocks pandas 3 materialises into a private array, which could
-      be taken as it is. Earlier pandas instead consolidates the frame *in place*
-      first and returns a view of the block it just built: taking that would write
-      through into the frame, and copying it costs a second full-size buffer on top
-      of the consolidation. Measured at 200,000 x 300 float64, that pair peaks at
-      twice the frame's size on pandas 1.4 against once on pandas 3.
-
-    So a many-block frame is assembled column by column into an array preallocated
-    here, which nothing else has ever referenced and which costs one buffer on every
-    version. It also leaves the frame's own blocks alone, where `to_numpy` would
-    consolidate them out from under a caller still holding it.
-
-    Column-major because that is what the encoder path has always returned -- its
-    `hstack` builds an F-ordered array and the closing `astype` preserves layout --
-    and downstream preprocessing is column-wise. Pinning the order here keeps this a
-    change of cost only, not of what callers receive.
-    """
-    if _to_numpy_may_alias(X):
-        return np.array(X.to_numpy(dtype=np.float64, copy=False), order="F", copy=True)
-
-    out = np.empty(X.shape, dtype=np.float64, order="F")
-    for position in range(X.shape[1]):
-        # Positional throughout: a duplicate column name makes `X[label]` a frame.
-        out[:, position] = X.iloc[:, position].to_numpy(dtype=np.float64, copy=False)
-    return out
-
-
-def _apply_ordinal_encoder(
-    X: pd.DataFrame,
-    ord_encoder: OrderPreservingColumnTransformer | None,
-    *,
-    fit_encoder: bool,
-) -> np.ndarray:
-    """Run the ordinal-encoding step, or skip it where it cannot change anything.
-
-    Every branch returns an array the caller owns, which is what lets it write the
-    placeholder and +/-inf cells in place and cast to float64 with ``copy=False``.
-    Three of the four allocate outright -- the copy, the encoder's own preallocated
-    output, its hstack where that output cannot be assembled. The fourth,
-    `X.to_numpy()`, does not: for a single-block frame pandas hands back the block
-    itself, read-only under copy-on-write and aliasing the caller's ndarray without it.
-
-    What keeps that branch honest is the identity check above: it takes every frame
-    whose columns are all plain float64, so the frames that reach `to_numpy()` are
-    never float64 throughout and the caller's `astype` has real work to do, which
-    allocates. Widen `_encoding_is_identity` to accept a dtype it does not convert --
-    a nullable ``Float64``, say -- and a view starts escaping. The caller asserts on
-    it rather than leaving that to be noticed downstream.
-    """
-    if _encoding_is_identity(X, ord_encoder, fit_encoder=fit_encoder):
-        if fit_encoder and ord_encoder is not None:
-            # Fitting still has to happen -- the caller keeps the encoder for
-            # predict -- but with no column selected it learns nothing from the
-            # values, so a single row settles the column bookkeeping and spares us
-            # the transform this branch exists to avoid.
-            ord_encoder.fit(X.iloc[:1])
-        return _owned_float64_values(X)
-    if ord_encoder is None:
-        return X.to_numpy()
-    if fit_encoder:
-        # `EfficientColumnTransformer` writes each column straight to its place in the
-        # output rather than stacking its transformers' results and reordering them,
-        # and falls back to sklearn's own path for a frame it cannot place that way.
-        return ord_encoder.fit_transform(X)
-    # `transform` is sklearn's, deliberately: it also validates the frame against the
-    # one seen at fit -- column count, names, order -- which the fit-time assembly does
-    # not, so bypassing it would trade a real check for memory the wrapper has already
-    # validated by other means.
-    return ord_encoder.transform(X)
-
-
 def process_text_na_dataframe(
     X: pd.DataFrame,
     placeholder: str = NA_PLACEHOLDER,
@@ -647,12 +506,24 @@ def process_text_na_dataframe(
             X = X.copy()
         X[string_cols] = X[string_cols].fillna(placeholder)
 
-    X_encoded = _apply_ordinal_encoder(X, ord_encoder, fit_encoder=fit_encoder)
+    if ord_encoder is None:
+        # No encoding step at all, so the frame's own values are the output. Copied
+        # where `to_numpy` may hand back one of the frame's blocks rather than a private
+        # array, since the writes below are the caller's to make; taken as it is
+        # otherwise, which costs the one full-size buffer either way.
+        X_encoded = X.to_numpy()
+        if to_numpy_may_alias(X):
+            X_encoded = X_encoded.copy(order="K")
+    elif fit_encoder:
+        X_encoded = ord_encoder.fit_transform(X)
+    else:
+        X_encoded = ord_encoder.transform(X)
+
     # Everything below writes into this array and then hands it to the caller, so it
     # has to be one no one else holds. Read-only means pandas handed back a view of a
-    # frame's block instead: see `_apply_ordinal_encoder` for how that is kept from
-    # happening, and note that on pandas 2 such a view is writeable and would pass
-    # this while quietly writing through to whatever the frame was built from.
+    # frame's block instead, and note that on pandas 2 such a view is writeable and
+    # would pass this while quietly writing through to whatever the frame was built
+    # from.
     assert X_encoded.flags.writeable, (
         "the ordinal-encoding step returned an array it does not own"
     )

--- a/src/tabpfn/preprocessing/clean.py
+++ b/src/tabpfn/preprocessing/clean.py
@@ -275,14 +275,6 @@ def _column_kind(dtype: Any) -> str:
     return dtype.kind
 
 
-def _encoder_selection(ord_encoder: OrderPreservingColumnTransformer) -> list[Any]:
-    """The columns a fitted encoder takes, in the order it holds them."""
-    return next(
-        (cols for name, _, cols in ord_encoder.transformers_ if name == "encoder"),
-        [],
-    )
-
-
 def _is_single_float_block(X: pd.DataFrame) -> bool:
     """True if ``X`` is backed by a single contiguous numpy float block.
 
@@ -321,7 +313,7 @@ def _align_columns_to_fitted_dtypes(
     encoder = ord_encoder.named_transformers_.get("encoder")
     if encoder is None or not hasattr(encoder, "categories_"):
         return X
-    selected = _encoder_selection(ord_encoder)
+    selected = ord_encoder.selected_columns()
     to_string, to_numeric = [], []
     for col, categories in zip(selected, encoder.categories_, strict=True):
         fit_kind = categories.dtype.kind
@@ -561,63 +553,6 @@ def _owned_float64_values(X: pd.DataFrame) -> np.ndarray:
     return out
 
 
-def _can_write_encoded_columns(X: pd.DataFrame, selected: list[Any]) -> bool:
-    """Whether the encoded array can be assembled column by column.
-
-    Two things have to hold. Every column the encoder does *not* take must already be
-    plain float64, so writing it into a float64 output is a copy and not a conversion
-    that could differ from the one `ColumnTransformer` would have done -- notably an
-    `object` column, which the encoder's dtype selector skips and the old path carried
-    through as objects until the closing cast. And the column names must be unique,
-    since each column is placed by name.
-    """
-    if X.columns.has_duplicates:
-        return False
-    taken = set(selected)
-    return all(
-        dtype == _FLOAT64
-        for column, dtype in zip(X.columns, X.dtypes, strict=True)
-        if column not in taken
-    )
-
-
-def _encode_into_preallocated(
-    X: pd.DataFrame,
-    ord_encoder: OrderPreservingColumnTransformer,
-    selected: list[Any],
-) -> np.ndarray:
-    """Assemble the encoded array by writing each column straight to its final place.
-
-    `ColumnTransformer` gets the same result in three full-size arrays: one per
-    transformer, a second from stacking them, and a third from the gather
-    `_preserve_order` needs to undo the stacking's column order. A mixed-column clean
-    reaches its RAM peak twice inside that -- once in the stack, once in the gather --
-    which is why removing either one alone changes nothing. Writing into the output
-    costs one array, plus the block of codes the encoder returns.
-
-    Column order is the frame's own, so no reordering is needed afterwards, and the
-    layout is column-major to match what the stack used to produce.
-    """
-    positions = {column: index for index, column in enumerate(X.columns)}
-    taken = set(selected)
-    out = np.empty(X.shape, dtype=np.float64, order="F")
-
-    if selected:
-        # One call rather than one per column: the encoder validates against the
-        # column count it was fitted on, so its codes come as a single block.
-        codes = ord_encoder.named_transformers_["encoder"].transform(X[selected])
-        out[:, [positions[column] for column in selected]] = codes
-        del codes
-
-    # Per column, so no full-width temporary is built for the passthrough half; each
-    # write is a copy out of the frame's block, which `_can_write_encoded_columns` has
-    # established is already float64.
-    for column, index in positions.items():
-        if column not in taken:
-            out[:, index] = X[column].to_numpy(dtype=np.float64, copy=False)
-    return out
-
-
 def _apply_ordinal_encoder(
     X: pd.DataFrame,
     ord_encoder: OrderPreservingColumnTransformer | None,
@@ -628,10 +563,10 @@ def _apply_ordinal_encoder(
 
     Every branch returns an array the caller owns, which is what lets it write the
     placeholder and +/-inf cells in place and cast to float64 with ``copy=False``.
-    Three of the four allocate outright -- the copy, the preallocated output, the
-    encoder's own hstack. The fourth, `X.to_numpy()`, does not: for a single-block
-    frame pandas hands back the block itself, read-only under copy-on-write and
-    aliasing the caller's ndarray without it.
+    Three of the four allocate outright -- the copy, the encoder's own preallocated
+    output, its hstack where that output cannot be assembled. The fourth,
+    `X.to_numpy()`, does not: for a single-block frame pandas hands back the block
+    itself, read-only under copy-on-write and aliasing the caller's ndarray without it.
 
     What keeps that branch honest is the identity check above: it takes every frame
     whose columns are all plain float64, so the frames that reach `to_numpy()` are
@@ -648,29 +583,18 @@ def _apply_ordinal_encoder(
             # the transform this branch exists to avoid.
             ord_encoder.fit(X.iloc[:1])
         return _owned_float64_values(X)
-    if fit_encoder and ord_encoder is not None:
-        # `ColumnTransformer.fit` is implemented as `fit_transform`, so fitting on the
-        # whole frame would run the very transform the assembly below replaces. Fit on
-        # one row for the column bookkeeping instead -- widths and output indices do
-        # not depend on the row count for a one-to-one encoder -- and then teach the
-        # inner encoder its categories from every row.
-        ord_encoder.fit(X.iloc[:1])
-        selected = _encoder_selection(ord_encoder)
-        if not _can_write_encoded_columns(X, selected):
-            # Bail before learning any categories: `fit_transform` learns them again
-            # from scratch, so doing it first would be a wasted pass over the data.
-            # Only the one-row fit above is lost, which costs no pass at all.
-            return ord_encoder.fit_transform(X)
-        if selected:
-            ord_encoder.named_transformers_["encoder"].fit(X[selected])
-        return _encode_into_preallocated(X, ord_encoder, selected)
-    if ord_encoder is not None:
-        # Left on sklearn deliberately. `transform` also validates the frame against
-        # the one seen at fit -- column count, names, order -- and the assembly above
-        # does not, so using it here would trade a real check for memory the wrapper
-        # has already validated by other means.
-        return ord_encoder.transform(X)
-    return X.to_numpy()
+    if ord_encoder is None:
+        return X.to_numpy()
+    if fit_encoder:
+        # `EfficientColumnTransformer` writes each column straight to its place in the
+        # output rather than stacking its transformers' results and reordering them,
+        # and falls back to sklearn's own path for a frame it cannot place that way.
+        return ord_encoder.fit_transform(X)
+    # `transform` is sklearn's, deliberately: it also validates the frame against the
+    # one seen at fit -- column count, names, order -- which the fit-time assembly does
+    # not, so bypassing it would trade a real check for memory the wrapper has already
+    # validated by other means.
+    return ord_encoder.transform(X)
 
 
 def process_text_na_dataframe(

--- a/src/tabpfn/preprocessing/steps/encode_categorical_features_step.py
+++ b/src/tabpfn/preprocessing/steps/encode_categorical_features_step.py
@@ -170,19 +170,16 @@ def _encode_into_preallocated(
 ) -> np.ndarray:
     """Assemble the ordinal-encoded array by writing each part to its final place.
 
-    `ColumnTransformer` reaches the same result through three full-size allocations'
-    worth of array: the block of codes, the passthrough block, and the hstack of the
-    two. Writing into one preallocated output costs the output plus the codes, which on
-    a half-categorical table takes a third off this step's peak.
+    `codes` takes the leading columns, in `categorical_features` order; the columns of
+    `X` those codes stand for are dropped, and every other column follows in input
+    order. The dtype is the promotion of the two blocks' dtypes, so the writes below
+    are the only cast, and the memory order is Fortran when both blocks are already
+    Fortran-contiguous and C otherwise.
 
-    Column order, dtype and memory layout are all the ones `ColumnTransformer`
-    produces: encoded columns first, then the remainder in input order; the dtype its
-    hstack would have promoted to, so a write here is the same cast it would have made;
-    and the layout its hstack would have chosen, which depends on the blocks (see
-    below). The layout is not cosmetic -- the sklearn SVD that can run downstream
-    converges to a different basis on a C- than on a Fortran-contiguous input -- and
-    matching it costs nothing: filling a row-major output column by column measured
-    218 ms at 100,000 x 400, against 220 ms for the hstack.
+    This function matches `ColumnTransformer` outputs, dtype and matrix layout;
+    C vs Fortran layout is important to any downstream sklearn SVD.
+
+    Only the output and `codes` are ever held at once, never a full-size intermediate.
     """
     taken = set(categorical_features)
     remainder = [index for index in range(X.shape[1]) if index not in taken]

--- a/src/tabpfn/preprocessing/steps/encode_categorical_features_step.py
+++ b/src/tabpfn/preprocessing/steps/encode_categorical_features_step.py
@@ -22,6 +22,9 @@ from tabpfn.preprocessing.pipeline_interface import (
     PreprocessingStep,
     PreprocessingStepResult,
 )
+from tabpfn.preprocessing.steps.preprocessing_helpers import (
+    EfficientColumnTransformer,
+)
 from tabpfn.utils import infer_random_state
 
 ONE_HOT_ENCODER_NAME = "one_hot_encoder"
@@ -163,45 +166,6 @@ def _carry_over_input_feature_metadata(
     return FeatureSchema(features=new_features)
 
 
-def _encode_into_preallocated(
-    X: np.ndarray,
-    codes: np.ndarray,
-    categorical_features: list[int],
-) -> np.ndarray:
-    """Assemble the ordinal-encoded array by writing each part to its final place.
-
-    `codes` takes the leading columns, in `categorical_features` order; the columns of
-    `X` those codes stand for are dropped, and every other column follows in input
-    order. The dtype is the promotion of the two blocks' dtypes, so the writes below
-    are the only cast, and the memory order is Fortran when both blocks are already
-    Fortran-contiguous and C otherwise.
-
-    This function matches `ColumnTransformer` outputs, dtype and matrix layout;
-    C vs Fortran layout is important to any downstream sklearn SVD.
-
-    Only the output and `codes` are ever held at once, never a full-size intermediate.
-    """
-    taken = set(categorical_features)
-    remainder = [index for index in range(X.shape[1]) if index not in taken]
-
-    # `np.concatenate` returns Fortran order only when every block it stacks is already
-    # Fortran-contiguous, and otherwise row-major, so the blocks decide. The remainder's
-    # layout is read off a two-row slice rather than the full-size block this exists not
-    # to build; column selection gives the same answer at either height.
-    stacks_fortran = codes.flags.f_contiguous and X[:2, remainder].flags.f_contiguous
-    out = np.empty(
-        X.shape,
-        dtype=np.result_type(codes.dtype, X.dtype),
-        order="F" if stacks_fortran else "C",
-    )
-    out[:, : len(categorical_features)] = codes
-
-    # Per column, so the passthrough half never needs a full-width temporary of its own.
-    for position, source in enumerate(remainder, start=len(categorical_features)):
-        out[:, position] = X[:, source]
-    return out
-
-
 class EncodeCategoricalFeaturesStep(PreprocessingStep):
     """Encode categorical features using ordinal or one-hot encoding.
 
@@ -266,7 +230,11 @@ class EncodeCategoricalFeaturesStep(PreprocessingStep):
                 # would rebuild the array
                 return None, categorical_features
 
-            ct = ColumnTransformer(
+            # `EfficientColumnTransformer` rather than a plain `ColumnTransformer`:
+            # ordinal encoding is one-to-one over a subset of the columns with the rest
+            # handed through, which it assembles into one array instead of stacking
+            # each transformer's full-size output.
+            ct = EfficientColumnTransformer(
                 [
                     (
                         "ordinal_encoder",
@@ -402,21 +370,7 @@ class EncodeCategoricalFeaturesStep(PreprocessingStep):
 
         categorical_features = ct_cat_features
         if self.categorical_transform_name.startswith("ordinal"):
-            # `ColumnTransformer.fit` is implemented as `fit_transform`, so fitting on
-            # the whole array would run the very transform the assembly below replaces.
-            # One row settles the column bookkeeping -- widths and output indices do not
-            # depend on the row count for a one-to-one encoder -- and the inner encoder
-            # then learns its categories from every row.
-            ct.fit(X[:1])
-            # `fit_transform` rather than a fit followed by a transform: it is one pass
-            # over one slice of the categorical half, which is what the
-            # ColumnTransformer did, and holding the slice for a second pass would cost
-            # the peak the assembly below saves.
-            codes = ct.named_transformers_["ordinal_encoder"].fit_transform(
-                X[:, ct_cat_features]
-            )
-            Xt = _encode_into_preallocated(X, codes, ct_cat_features)
-            del codes
+            Xt = ct.fit_transform(X)
             categorical_features = list(range(len(ct_cat_features)))
 
             self.random_mappings_ = {}

--- a/src/tabpfn/preprocessing/steps/encode_categorical_features_step.py
+++ b/src/tabpfn/preprocessing/steps/encode_categorical_features_step.py
@@ -163,6 +163,48 @@ def _carry_over_input_feature_metadata(
     return FeatureSchema(features=new_features)
 
 
+def _encode_into_preallocated(
+    X: np.ndarray,
+    codes: np.ndarray,
+    categorical_features: list[int],
+) -> np.ndarray:
+    """Assemble the ordinal-encoded array by writing each part to its final place.
+
+    `ColumnTransformer` reaches the same result through three full-size allocations'
+    worth of array: the block of codes, the passthrough block, and the hstack of the
+    two. Writing into one preallocated output costs the output plus the codes, which on
+    a half-categorical table takes a third off this step's peak.
+
+    Column order, dtype and memory layout are all the ones `ColumnTransformer`
+    produces: encoded columns first, then the remainder in input order; the dtype its
+    hstack would have promoted to, so a write here is the same cast it would have made;
+    and the layout its hstack would have chosen, which depends on the blocks (see
+    below). The layout is not cosmetic -- the sklearn SVD that can run downstream
+    converges to a different basis on a C- than on a Fortran-contiguous input -- and
+    matching it costs nothing: filling a row-major output column by column measured
+    218 ms at 100,000 x 400, against 220 ms for the hstack.
+    """
+    taken = set(categorical_features)
+    remainder = [index for index in range(X.shape[1]) if index not in taken]
+
+    # `np.concatenate` returns Fortran order only when every block it stacks is already
+    # Fortran-contiguous, and otherwise row-major, so the blocks decide. The remainder's
+    # layout is read off a two-row slice rather than the full-size block this exists not
+    # to build; column selection gives the same answer at either height.
+    stacks_fortran = codes.flags.f_contiguous and X[:2, remainder].flags.f_contiguous
+    out = np.empty(
+        X.shape,
+        dtype=np.result_type(codes.dtype, X.dtype),
+        order="F" if stacks_fortran else "C",
+    )
+    out[:, : len(categorical_features)] = codes
+
+    # Per column, so the passthrough half never needs a full-width temporary of its own.
+    for position, source in enumerate(remainder, start=len(categorical_features)):
+        out[:, position] = X[:, source]
+    return out
+
+
 class EncodeCategoricalFeaturesStep(PreprocessingStep):
     """Encode categorical features using ordinal or one-hot encoding.
 
@@ -363,7 +405,21 @@ class EncodeCategoricalFeaturesStep(PreprocessingStep):
 
         categorical_features = ct_cat_features
         if self.categorical_transform_name.startswith("ordinal"):
-            Xt = ct.fit_transform(X)
+            # `ColumnTransformer.fit` is implemented as `fit_transform`, so fitting on
+            # the whole array would run the very transform the assembly below replaces.
+            # One row settles the column bookkeeping -- widths and output indices do not
+            # depend on the row count for a one-to-one encoder -- and the inner encoder
+            # then learns its categories from every row.
+            ct.fit(X[:1])
+            # `fit_transform` rather than a fit followed by a transform: it is one pass
+            # over one slice of the categorical half, which is what the
+            # ColumnTransformer did, and holding the slice for a second pass would cost
+            # the peak the assembly below saves.
+            codes = ct.named_transformers_["ordinal_encoder"].fit_transform(
+                X[:, ct_cat_features]
+            )
+            Xt = _encode_into_preallocated(X, codes, ct_cat_features)
+            del codes
             categorical_features = list(range(len(ct_cat_features)))
 
             self.random_mappings_ = {}

--- a/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
+++ b/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
@@ -59,84 +59,62 @@ def _column_values(X: XType, position: int) -> np.ndarray:
 def to_numpy_may_alias(X: pd.DataFrame) -> bool:
     """Whether `X.to_numpy()` can hand back a view of the frame's own buffer.
 
-    A single-block frame is handed out as that block: read-only under copy-on-write,
-    writeable and aliasing whatever the frame was built from without it (pandas < 3),
-    which for a numeric ndarray input is the caller's own array. Anything wider has to
-    be materialised into a new array first, so what comes back is private.
-
-    Defensively `True` when the block internals are unavailable, so an unrecognised
-    layout is copied rather than handed out.
+    `True` when the frame's layout cannot be read, so that an unknown one is copied.
     """
+    # a single-block frame is handed out as that block -- writeable and pointing at
+    # whatever the frame was built from before pandas 3, which for a numeric array
+    # input is the caller's own. Anything wider is built fresh, so it is private.
     blocks = getattr(getattr(X, "_mgr", None), "blocks", None)
     return blocks is None or len(blocks) <= 1
 
 
 def _converts_in_one_call(X: XType) -> bool:
-    """Whether `X` can hand out every column at once more cheaply than one at a time.
-
-    An array can, trivially. A frame only when `to_numpy` would hand back a block it
-    already holds, so that copying it is the single allocation -- not when it would
-    have to materialise one, and above all not when it would consolidate the frame in
-    place to do so, which is what pandas before 3 does and what costs a second
-    full-size buffer on top.
-    """
+    """Whether `X` can hand out every column at once for a single allocation."""
+    # a frame only when `to_numpy` hands back a block it already holds: otherwise it
+    # builds one, and before pandas 3 rearranges the frame in place to do so, which
+    # costs a second full-size buffer on top
     return not isinstance(X, pd.DataFrame) or to_numpy_may_alias(X)
 
 
 class EfficientColumnTransformer(ColumnTransformer):
     """A `ColumnTransformer` that assembles its output into one preallocated array.
 
-    `ColumnTransformer` reaches its result through three full-size arrays: one per
-    transformer, a second from stacking them, and (when preserving column order)
-    a third from the gather that reorders. A wide input reaches its RAM peak twice
-    inside that, once in the stack and once in the gather, which is why removing either
-    one alone changes nothing. This class writes every column straight to its final
-    place instead, so only the output and the named transformer's own block are ever
-    held at once.
+    Saves the two extra full-size arrays its parent reaches a result through -- the
+    stack and, when preserving column order, the reorder -- by writing every column
+    straight to its final place. `fit` goes further and builds no output at all.
 
-    That is only possible for the narrow shape this codebase needs: at most one named
-    transformer, one-to-one, over a subset of the columns, plus a remainder that hands
-    the rest through untouched. Anything else -- a transformer that expands its columns
-    or is fed a `y`, a sparse result, a `set_output` asking for a frame, a frame whose
-    passthrough columns are not already float64 -- falls back to `ColumnTransformer`,
-    so this stays a drop-in replacement for it.
+    Only the narrow shape this codebase needs can be assembled: at most one named
+    transformer, one-to-one, over a subset of the columns, plus
+    a remainder that hands the rest through untouched. Anything else falls back to
+    `ColumnTransformer`, so this stays a drop-in replacement for it.
 
-    `fit` goes one further and builds no output at all, where `ColumnTransformer.fit`
-    -- implemented as `fit_transform` -- pays for a full-size result and discards it.
-
-    `transform` stays on sklearn, which validates the input against the one seen at fit
-    -- column count, names, order -- where the assembly makes no such check. The one
-    exception is the input for which those checks are settled in advance and the fitted
-    transformer provably changes nothing: there the step is a cast, and the cast is
-    assembled.
+    `transform` is left to `ColumnTransformer` for its checks against the input seen at
+    fit, except where those are settled in advance and there is provably nothing to do.
     """
 
     # Whether the output keeps the input's column order rather than
-    # `ColumnTransformer`'s `[transformed, remainder]` one. A class attribute
-    # rather than a constructor parameter, so sklearn's parameter introspection --
-    # and with it `clone` and `get_params` -- stays exactly its parent's.
+    # `ColumnTransformer`'s `[transformed, remainder]` one. A class attribute rather
+    # than a constructor parameter, so sklearn's `clone` and `get_params` stay exactly
+    # its parent's.
     preserves_column_order: ClassVar[bool] = False
 
     @override
     def fit(self, X: XType, y: YType = None, **params: Any) -> Self:
         """Fit without building the transformed array `ColumnTransformer.fit` builds.
 
-        All the fitted state consists of is the column bookkeeping and the named
-        transformer. The bookkeeping comes from one row -- widths and output positions
-        do not depend on the row count for a one-to-one transformer -- and the
-        transformer then learns from every row, in one pass, with no full-size result
-        stacked or discarded on the way.
-
-        Decided on the same conditions as the assembly, so that the state left here is
-        either sklearn's own or one those conditions vouch for.
+        Decided on the same conditions as the assembly, so the state left here is either
+        sklearn's own or one those conditions vouch for.
         """
         if not (y is None and self._is_one_to_one and self._may_assemble(X, params)):
             return super().fit(X, y, **params)
+        # widths and output positions do not depend on the row count here, so one row
+        # settles all of the bookkeeping
         probe = self._fit_column_bookkeeping(X)
         name, selected = self._named_selection()
         if not self._can_assemble(X, probe, selected):
             return super().fit(X, y, **params)
         if selected:
+            # the values are all that is left to learn, in one pass, nothing stacked
             self.named_transformers_[name].fit(_column_subset(X, selected))
         return self
 
@@ -153,9 +131,8 @@ class EfficientColumnTransformer(ColumnTransformer):
         name, selected = self._named_selection()
         if not self._can_assemble(X, probe, selected):
             # Bail before the named transformer has learned anything from the values:
-            # the fallback learns them again from scratch, so doing it first would be a
-            # wasted pass over the data. Only the one-row fit is lost, which costs no
-            # pass at all.
+            # the fallback learns them again anyway, so a pass over the data here would
+            # be wasted. Only the one-row fit is lost, which costs no pass at all.
             return self._maybe_in_input_order(
                 super().fit_transform(X, y, **params), original_columns
             )
@@ -167,8 +144,7 @@ class EfficientColumnTransformer(ColumnTransformer):
         """Left to `ColumnTransformer`, unless it provably cannot change a value.
 
         Its checks against the input seen at fit -- width, names, order -- are why it is
-        left there at all: the assembly makes none of them. So the one case taken here
-        is the one where they are settled in advance, by `_changes_no_value`.
+        left there at all: the assembly makes none of them.
         """
         if self._changes_no_value(X, params):
             return self._assemble(X, None, [])
@@ -180,53 +156,38 @@ class EfficientColumnTransformer(ColumnTransformer):
     def selected_columns(self) -> list[Any]:
         """The columns the named transformer holds, in the order it holds them.
 
-        Empty when it selected nothing, when only a remainder is configured, or when
-        the selection is not a list of column keys at all.
+        Empty when it holds none, when only a remainder is configured, or when the
+        selection is not a list of column keys at all.
         """
         _, selected = self._named_selection()
         return selected or []
 
     def _may_assemble(self, X: XType, params: dict[str, Any]) -> bool:
-        """Whether an output of this shape could be written into one array at all.
-
-        Routed metadata is declined outright: nothing with the shape assembled here has
-        any use for it. So is an input that is neither an array nor a frame -- a sparse
-        one would be densified by the array written into here, which is not what
-        `ColumnTransformer` hands back -- and a `set_output` asking for a frame, which
-        this returns none of.
-        """
+        """Whether an output of this shape could be written into one array at all."""
+        # Routed metadata is declined outright: nothing assembled here has any use for
+        # it. So is an input that is neither an array nor a frame -- a sparse one would
+        # come back dense, which is not what `ColumnTransformer` hands back.
         if params or not isinstance(X, (np.ndarray, pd.DataFrame)):
             return False
         output_config = getattr(self, "_sklearn_output_config", {}).get(
             "transform", get_config()["transform_output"]
         )
+        # a `set_output` asking for a frame gets none from here
         return is_identity_transformer(self.remainder) and output_config == "default"
 
     @property
     def _is_one_to_one(self) -> bool:
-        """Whether at most one transformer is configured, and it maps column to column.
-
-        Read off the specification rather than a fitted state, so that a transformer
-        this rejects never sees the one-row fit below -- which for one that cannot be
-        fitted on a single row, a quantile transform say, is the difference between a
-        fallback and a crash.
-        """
+        """Whether at most one transformer is configured, and it is one-to-one."""
+        # read off the specification rather than a fitted state, so a transformer this
+        # rejects never sees the one-row fit below -- which for one that needs many
+        # rows, a quantile transform say, would crash instead of falling back
         named = [t for name, t, _ in self.transformers if name != "remainder"]
         return len(named) <= 1 and all(
             isinstance(transformer, OneToOneFeatureMixin) for transformer in named
         )
 
     def _changes_no_value(self, X: XType, params: dict[str, Any]) -> bool:
-        """Whether transforming `X` provably leaves every value where it was.
-
-        Three things have to hold. The fitted transformer must have selected nothing, so
-        the step is its passthrough remainder and there is no code to compute. `X` must
-        be one the columns can be written out of. And it must line up with the input
-        seen at fit -- same width, same names in the same order -- because sklearn lines
-        a reordered frame back up with the fit-time order where the assembly would keep
-        the input's own, and because skipping `transform` skips the checks that would
-        have caught a frame not lining up at all.
-        """
+        """Whether transforming `X` provably leaves every value where it was."""
         if not hasattr(self, "transformers_"):
             # Unfitted. `transform` is the one that should say so.
             return False
@@ -241,6 +202,9 @@ class EfficientColumnTransformer(ColumnTransformer):
             or not self._can_place_columns(X, [])
         ):
             return False
+        # The names too, in order: sklearn lines a reordered frame back up with the
+        # fit-time order where the assembly would keep the input's own, and skipping
+        # `transform` skips the check that would reject a frame not lining up at all.
         names = getattr(self, "feature_names_in_", None)
         return (
             names is None
@@ -250,20 +214,18 @@ class EfficientColumnTransformer(ColumnTransformer):
         )
 
     def _fit_column_bookkeeping(self, X: XType) -> XType:
-        """Fit everything but the values, and return the one-row result that took.
-
-        `ColumnTransformer.fit` is implemented as `fit_transform`, so fitting on the
-        whole input would run the very transform this class replaces. Taken up the chain
-        rather than through `self.fit`, which would land back in the override above.
-        """
+        """Fit everything but the values, and return the one-row result that took."""
+        # Up the chain, not through `self.fit`: `ColumnTransformer.fit` is implemented
+        # as `fit_transform`, so fitting on the whole input would run the very transform
+        # this class replaces, and `self.fit` would land back in the override above.
         return super().fit_transform(_head(X, 1), None)
 
     def _named_selection(self) -> tuple[str | None, list[Any] | None]:
         """The named transformer's name and the columns it holds, in its own order.
 
         `None` for the columns when the selection is not a list of keys -- a `slice`
-        or a bare label -- which cannot be placed one column at a time. Both entries are
-        empty when only a remainder is configured.
+        or a bare label -- which cannot be placed one column at a time. Both entries
+        are empty when only a remainder is configured.
         """
         for name, _, columns in self.transformers_:
             if name == "remainder":
@@ -275,30 +237,19 @@ class EfficientColumnTransformer(ColumnTransformer):
         return None, []
 
     def _can_assemble(self, X: XType, probe: XType, selected: list[Any] | None) -> bool:
-        """Whether the layout just fitted is one that can be written column by column.
-
-        The one-row `probe` is the fit's own answer on the output's width, so
-        one-to-oneness is checked rather than taken on the mixin's word: every input
-        column has to reach exactly one output column, or the array the assembly
-        allocates is the wrong shape and the bookkeeping around it is wrong too.
-        """
+        """Whether the layout just fitted can be written out column by column."""
         return (
             selected is not None
             and not self.sparse_output_
+            # the one-row `probe` is the fit's own answer on the output's width: every
+            # input column has to reach exactly one output column, or the array
+            # allocated below is the wrong shape and the bookkeeping around it wrong too
             and probe.shape[1] == X.shape[1]
             and self._can_place_columns(X, selected)
         )
 
     def _can_place_columns(self, X: XType, selected: list[Any]) -> bool:
-        """Whether `X`'s columns can be written verbatim into the output.
-
-        Args:
-            X (XType): Input.
-            selected (list[Any]): Columns to be processed by the transformer.
-
-        Returns:
-            bool
-        """
+        """Whether `X`'s columns can be written verbatim into the output."""
         if not isinstance(X, pd.DataFrame):
             # arrays are always ok
             return True
@@ -322,13 +273,11 @@ class EfficientColumnTransformer(ColumnTransformer):
 
         `None` when there is nothing selected, without touching the transformer -- which
         is the only case `transform` reaches this through, so nothing is fitted there.
-
-        `fit_transform` rather than a fit and then a transform: it is one pass over one
-        slice of the selected columns, where a second pass would have to hold that slice
-        for the whole of it.
         """
         if not selected:
             return None
+        # fit_transform rather than a fit and then a transform: one pass over one slice
+        # of the selected columns, where a second pass would hold that slice throughout
         codes = self.named_transformers_[name].fit_transform(
             _column_subset(X, selected)
         )
@@ -340,22 +289,10 @@ class EfficientColumnTransformer(ColumnTransformer):
         """Write the transformer's block and every other column to its final place.
 
         The array returned is one nothing else has ever referenced, which is what lets a
-        caller write into what it gets back. Notably it is never `to_numpy`'s result as
-        it stands: pandas 3 materialises a many-block frame into a private array, which
-        could be taken as it is, but earlier versions consolidate the frame *in place*
-        first and return a view of the block they just built -- taking that would write
-        through into the frame, and copying it costs a second full-size buffer on top of
-        the consolidation. Going column by column costs one buffer on every version, and
-        leaves the frame's own blocks alone.
-
-        The transformer's block is computed here rather than handed in so that it can be
-        dropped the moment it is written. `np.empty` faults a page in only when it is
-        written to, so the output appears in RSS as its columns are filled: a caller
-        still holding the block while the passthrough half fills the rest would have the
-        whole output *and* the block resident at once, which the block dying first
-        avoids.
+        caller write into what it gets back.
         """
         destination, passthrough = self._output_positions(X, name, selected)
+        # computed here rather than handed in, so it can be dropped once written
         codes = self._transformed_block(X, name, selected)
         dtype = self._assembled_dtype(X, codes, passthrough)
         order = self._assembled_order(X, codes, passthrough)
@@ -363,11 +300,10 @@ class EfficientColumnTransformer(ColumnTransformer):
         if codes is None and _converts_in_one_call(X):
             # Nothing was transformed, so the output is the whole input converted, in
             # input order -- which both layouts agree on when the selection is empty.
-            # One call for all of it where that is the cheaper way to reach the same
-            # single allocation. What it saves is per-column overhead, so it grows with
-            # the column count: measured against the loop below, interleaved so that
-            # neither order is favoured, nothing at 200,000 x 300, 12% of the wall time
-            # at 50,000 x 2,000 and 26% at 20,000 x 5,000.
+            # One call for all of it saves the per-column overhead of the loop below,
+            # which grows with the column count: nothing at 300 columns, 12% of the wall
+            # time at 2,000 and 26% at 5,000. Copied because `to_numpy` can hand back a
+            # view of a block the frame itself still holds.
             values = (
                 X.to_numpy(dtype=dtype, copy=False)
                 if isinstance(X, pd.DataFrame)
@@ -378,9 +314,12 @@ class EfficientColumnTransformer(ColumnTransformer):
         out = np.empty(X.shape, dtype=dtype, order=order)
         if codes is not None:
             out[:, destination] = codes
+            # `np.empty` takes memory only as it is written to, so dropping the block
+            # here keeps the peak at one full-size array rather than one plus a block
             del codes
         # Per column, so the passthrough half never needs a full-width temporary of its
-        # own; each write is a copy out of the container's own buffer.
+        # own, and the frame's own blocks are left alone -- `to_numpy` would rearrange
+        # them in place before pandas 3, and hand back a view of what it just built.
         for position, source in passthrough:
             out[:, position] = _column_values(X, source)
         return out
@@ -388,13 +327,14 @@ class EfficientColumnTransformer(ColumnTransformer):
     def _output_positions(
         self, X: XType, name: str | None, selected: list[Any]
     ) -> tuple[Any, list[tuple[int, int]]]:
-        """Where the transformer's block, and each column it left, land in the output.
+        """Where the block, and the columns the transformer left, land in the output.
 
-        Two layouts. Preserving the input order, every column stays where it came from,
-        so the block is scattered back over the positions it was taken from. Otherwise
-        it is `ColumnTransformer`'s, read off the fit's own `output_indices_`: the
-        block takes its slice, and the columns the transformer did not take follow in
-        input order.
+        Returns:
+            destination: Where the transformer's block goes, in the order it holds its
+                columns -- a `slice` of the output, or the list of positions to scatter
+                them over. Selects nothing when nothing was selected.
+            passthrough: One `(output position, input position)` pair for every column
+                the transformer did not take, in input order.
         """
         positions = {column: index for index, column in enumerate(_input_columns(X))}
         taken = set(selected)
@@ -402,10 +342,14 @@ class EfficientColumnTransformer(ColumnTransformer):
             index for column, index in positions.items() if column not in taken
         ]
         if self.preserves_column_order:
+            # every column stays where it came from, so the block is scattered back
+            # over the positions it was taken from
             return (
                 [positions[column] for column in selected],
                 [(index, index) for index in remainder],
             )
+        # `ColumnTransformer`'s layout, read off the fit's own `output_indices_`: the
+        # block takes its slice, and the columns it did not take follow in input order
         destination = slice(0, 0) if name is None else self.output_indices_[name]
         start = self.output_indices_["remainder"].start
         return destination, list(enumerate(remainder, start=start))
@@ -413,19 +357,16 @@ class EfficientColumnTransformer(ColumnTransformer):
     def _assembled_dtype(
         self, X: XType, codes: np.ndarray | None, passthrough: list[tuple[int, int]]
     ) -> np.dtype:
-        """The dtype `ColumnTransformer` would have stacked its way to.
-
-        `np.concatenate` promotes across the blocks it stacks, so the columns handed
-        through only weigh in when there are any: an input whose every column is
-        transformed comes out as the transformer's own dtype. A frame weighs in as
-        float64, which `_can_assemble` has established every one of its passthrough
-        columns already is.
-        """
+        """The dtype `ColumnTransformer` would have stacked its way to."""
+        # a frame weighs in as float64, which `_can_assemble` has established every one
+        # of its passthrough columns already is
         input_dtype = _FLOAT64 if isinstance(X, pd.DataFrame) else X.dtype
         if codes is None:
             return input_dtype
         if not passthrough:
+            # every column was transformed, so nothing else weighs in
             return codes.dtype
+        # `np.concatenate` promotes across the blocks it stacks
         return np.result_type(codes.dtype, input_dtype)
 
     def _assembled_order(
@@ -433,24 +374,20 @@ class EfficientColumnTransformer(ColumnTransformer):
     ) -> Literal["C", "F"]:
         """The memory layout `ColumnTransformer` would have arrived at.
 
-        Not cosmetic: the sklearn SVD that can run downstream of these steps converges
-        to a different basis on a C- than on a Fortran-contiguous input, so a drift here
-        would quietly rotate those features.
-
-        Preserving the input order, the layout is the one the gather in
-        `_preserve_order` produced, which numpy makes column-major for any output
-        wider than the single column where the two orders coincide. Otherwise it is
-        `np.concatenate`'s: Fortran only when every block it stacks already is, and
-        row-major otherwise -- so the blocks decide. The passthrough block's layout is
-        read off a two-row slice rather than the full-size block this exists not to
-        build; column selection gives the same answer at either height.
+        Not cosmetic: the sklearn SVD that can run downstream of these steps settles on
+        a different answer per layout, so a drift here would quietly rotate features.
         """
         if self.preserves_column_order:
+            # what the reorder in `_in_input_order` leaves, for any output wider than
+            # the single column where the two layouts coincide
             return "F"
         blocks = [] if codes is None else [codes]
         if passthrough:
             sources = [source for _, source in passthrough]
+            # read off two rows rather than the full-size block this exists not to
+            # build; selecting columns gives the same layout at either height
             blocks.append(np.asarray(_columns_at(_head(X, 2), sources)))
+        # `np.concatenate`'s answer: column-major only when every block it stacks is
         return "F" if all(block.flags.f_contiguous for block in blocks) else "C"
 
     def _maybe_in_input_order(
@@ -464,11 +401,7 @@ class EfficientColumnTransformer(ColumnTransformer):
     def _in_input_order(
         self, X: XType, original_columns: list | range | pd.Index
     ) -> XType:
-        """`X` with the columns back where the input had them.
-
-        Every column is somewhere in `ColumnTransformer`'s two blocks: at its rank in
-        the selection, or, unselected, at the next place after that block.
-        """
+        """`X` with the columns back where the input had them."""
         check_is_fitted(self)
         assert X.ndim == 2, f"Expected 2D input, got {X.ndim}D (shape={X.shape})"
         name, selected = self._named_selection()
@@ -477,9 +410,9 @@ class EfficientColumnTransformer(ColumnTransformer):
                 f"The {name!r} transformer selects its columns by something other than "
                 "a list of keys, which cannot be placed back in the input's order."
             )
-        # where each processed column landed in X
+        # Every column is somewhere in `ColumnTransformer`'s two blocks: at its rank in
+        # the selection, or, unselected, at the next place after that block.
         rank = {column: index for index, column in enumerate(selected)}
-        # next free index to use for untransformed columns
         next_index = len(selected)
         # indices[i] is the column index in X corresponding to input column i
         indices = []
@@ -510,12 +443,12 @@ class OrderPreservingColumnTransformer(EfficientColumnTransformer):
     def _validate_transformers(self) -> None:
         """What restoring the input order needs of the transformers, checked at fit.
 
-        Where `__init__` used to assert it. `set_params` writes `transformers` straight
-        onto the estimator, so a contract checked at construction is one every sklearn
-        caller that tunes a parameter steps around without seeing it -- and each of
-        these, unchecked, has the reorder returning columns in the wrong order rather
-        than failing.
+        Each of these, unchecked, has the reorder returning columns in the wrong order
+        rather than failing.
         """
+        # At fit rather than in `__init__`: `set_params` writes `transformers` straight
+        # onto the estimator, so a contract checked at construction is one every sklearn
+        # caller that tunes a parameter steps around without seeing it.
         super()._validate_transformers()
         named = [
             (name, transformer, columns)

--- a/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
+++ b/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
@@ -476,11 +476,15 @@ class EfficientColumnTransformer(ColumnTransformer):
                 and name != "remainder"
             ):
                 col_subset_list = list(col_subset)
+                col_subset_set = set(col_subset)
                 # Map original columns to indices in the transformed array
                 transformed_columns = col_subset_list + [
-                    c for c in original_columns if c not in col_subset_list
+                    c for c in original_columns if c not in col_subset_set
                 ]
-                indices = [transformed_columns.index(c) for c in original_columns]
+                transformed_col2idx = {
+                    c: idx for idx, c in enumerate(transformed_columns)
+                }
+                indices = [transformed_col2idx[c] for c in original_columns]
                 # restore the column order from before the transfomer has been applied
                 X = X.iloc[:, indices] if isinstance(X, pd.DataFrame) else X[:, indices]
         return X

--- a/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
+++ b/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
@@ -398,12 +398,15 @@ class EfficientColumnTransformer(ColumnTransformer):
             return Xt
         return self._in_input_order(X=Xt, original_columns=original_columns)
 
-    def _in_input_order(
-        self, X: XType, original_columns: list | range | pd.Index
-    ) -> XType:
-        """`X` with the columns back where the input had them."""
-        check_is_fitted(self)
-        assert X.ndim == 2, f"Expected 2D input, got {X.ndim}D (shape={X.shape})"
+    def _stacked_positions(
+        self, original_columns: list | range | pd.Index
+    ) -> list[int]:
+        """Where each input column sits in the output `ColumnTransformer` stacked.
+
+        Returns:
+            indices (list[int]): `indices[i]` is the column index in the output
+                corresponding to input column i.
+        """
         name, selected = self._named_selection()
         if selected is None:
             raise TypeError(
@@ -414,7 +417,6 @@ class EfficientColumnTransformer(ColumnTransformer):
         # the selection, or, unselected, at the next place after that block.
         rank = {column: index for index, column in enumerate(selected)}
         next_index = len(selected)
-        # indices[i] is the column index in X corresponding to input column i
         indices = []
         for column in original_columns:
             index = rank.get(column)
@@ -422,6 +424,15 @@ class EfficientColumnTransformer(ColumnTransformer):
                 # column wasn't input to the transformer
                 index, next_index = next_index, next_index + 1
             indices.append(index)
+        return indices
+
+    def _in_input_order(
+        self, X: XType, original_columns: list | range | pd.Index
+    ) -> XType:
+        """`X` with the columns back where the input had them."""
+        check_is_fitted(self)
+        assert X.ndim == 2, f"Expected 2D input, got {X.ndim}D (shape={X.shape})"
+        indices = self._stacked_positions(original_columns)
         # Nothing moved, and the gather below is a full-size copy -- but only skipped
         # where it would also leave the layout alone, since it hands back a
         # Fortran-contiguous array whatever it was given and `_assembled_order` says
@@ -504,6 +515,22 @@ class OrderPreservingColumnTransformer(EfficientColumnTransformer):
                 f"{self.remainder!r} does not. Note that `ColumnTransformer`'s default "
                 "is 'drop': pass `remainder=FunctionTransformer()` to keep them."
             )
+
+    @override
+    def get_feature_names_out(self, input_features: Any = None) -> np.ndarray:
+        """The names of the output's columns, in the order the output has them.
+
+        `ColumnTransformer` names its two blocks in the order it stacked them, which is
+        the order the reorder above undoes. Left as it is, the name a column is given
+        is the one belonging to whatever used to sit at its position -- silently, since
+        sklearn's `set_output` wrapper labels a pandas output with exactly this.
+        """
+        names = super().get_feature_names_out(input_features)
+        # the input's own keys, which is what the selection is expressed in
+        original_columns = getattr(self, "feature_names_in_", None)
+        if original_columns is None:
+            original_columns = range(self.n_features_in_)
+        return names[self._stacked_positions(list(original_columns))]
 
 
 def get_ordinal_encoder(

--- a/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
+++ b/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
@@ -369,8 +369,10 @@ class EfficientColumnTransformer(ColumnTransformer):
             # Nothing was transformed, so the output is the whole input converted, in
             # input order -- which both layouts agree on when the selection is empty.
             # One call for all of it where that is the cheaper way to reach the same
-            # single allocation: measured at 50,000 x 2,000, going column by column
-            # instead costs 46% more wall time.
+            # single allocation. What it saves is per-column overhead, so it grows with
+            # the column count: measured against the loop below, interleaved so that
+            # neither order is favoured, nothing at 200,000 x 300, 12% of the wall time
+            # at 50,000 x 2,000 and 26% at 20,000 x 5,000.
             values = (
                 X.to_numpy(dtype=dtype, copy=False)
                 if isinstance(X, pd.DataFrame)

--- a/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
+++ b/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
@@ -270,7 +270,9 @@ class EfficientColumnTransformer(ColumnTransformer):
                 continue
             if isinstance(columns, (list, np.ndarray, pd.Index)):
                 return name, list(columns)
+            # slow path: can't identify the column order
             return name, None
+        # fast path: nothing gets transformed
         return None, []
 
     def _can_assemble(self, X: XType, probe: XType, selected: list[Any] | None) -> bool:

--- a/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
+++ b/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
@@ -525,30 +525,43 @@ class OrderPreservingColumnTransformer(EfficientColumnTransformer):
         """
         super().__init__(transformers=transformers, **kwargs)
 
-        # Check if there is a single transformer, of subtype OneToOneFeatureMixin
-        assert all(
-            isinstance(t, OneToOneFeatureMixin)
-            for name, t, _ in transformers
-            if name != "remainder"
-        ), (
-            "OrderPreservingColumnTransformer currently only supports transformers "
-            "that are instances of OneToOneFeatureMixin."
-        )
+    @override
+    def _validate_transformers(self) -> None:
+        """What restoring the input order needs of the transformers, checked at fit.
 
-        assert len([t for name, _, t in transformers if name != "remainder"]) <= 1, (
-            "OrderPreservingColumnTransformer only supports up to one transformer."
-        )
-
-        # Restoring the input order places one column at a time, by key
-        assert all(
-            callable(columns) or isinstance(columns, (list, np.ndarray, pd.Index))
-            for name, _, columns in transformers
+        Where `__init__` used to assert it. `set_params` writes `transformers` straight
+        onto the estimator, so a contract checked at construction is one every sklearn
+        caller that tunes a parameter steps around without seeing it -- and each of
+        these, unchecked, has the reorder returning columns in the wrong order rather
+        than failing.
+        """
+        super()._validate_transformers()
+        named = [
+            (name, transformer, columns)
+            for name, transformer, columns in self.transformers
             if name != "remainder"
-        ), (
-            "OrderPreservingColumnTransformer only supports selecting columns by a "
-            "list of keys, or a callable returning one -- not by a slice or a single "
-            "label."
-        )
+        ]
+        if len(named) > 1:
+            raise ValueError(
+                "OrderPreservingColumnTransformer only supports up to one transformer, "
+                f"got {[name for name, _, _ in named]}."
+            )
+        for name, transformer, columns in named:
+            if not isinstance(transformer, OneToOneFeatureMixin):
+                raise ValueError(
+                    "OrderPreservingColumnTransformer only supports transformers that "
+                    f"are instances of OneToOneFeatureMixin, which {name!r} "
+                    f"({type(transformer).__name__}) is not."
+                )
+            # the reorder places one column at a time, by key
+            if not callable(columns) and not isinstance(
+                columns, (list, np.ndarray, pd.Index)
+            ):
+                raise ValueError(
+                    "OrderPreservingColumnTransformer only supports selecting columns "
+                    "by a list of keys, or a callable returning one -- not by a slice "
+                    f"or a single label, as {name!r} selects by {columns!r}."
+                )
 
 
 def get_ordinal_encoder(

--- a/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
+++ b/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
@@ -147,7 +147,7 @@ class EfficientColumnTransformer(ColumnTransformer):
         """Fit and transform, writing each column straight to its final place."""
         original_columns = _input_columns(X)
         if not (y is None and self._is_one_to_one and self._may_assemble(X, params)):
-            return self._in_input_order(
+            return self._maybe_in_input_order(
                 super().fit_transform(X, y, **params), original_columns
             )
 
@@ -158,7 +158,7 @@ class EfficientColumnTransformer(ColumnTransformer):
             # the fallback learns them again from scratch, so doing it first would be a
             # wasted pass over the data. Only the one-row fit is lost, which costs no
             # pass at all.
-            return self._in_input_order(
+            return self._maybe_in_input_order(
                 super().fit_transform(X, y, **params), original_columns
             )
 
@@ -175,7 +175,9 @@ class EfficientColumnTransformer(ColumnTransformer):
         if self._changes_no_value(X, params):
             return self._assemble(X, None, [])
         original_columns = _input_columns(X)
-        return self._in_input_order(super().transform(X, **params), original_columns)
+        return self._maybe_in_input_order(
+            super().transform(X, **params), original_columns
+        )
 
     def selected_columns(self) -> list[Any]:
         """The columns the named transformer holds, in the order it holds them.
@@ -454,13 +456,15 @@ class EfficientColumnTransformer(ColumnTransformer):
             blocks.append(np.asarray(_columns_at(_head(X, 2), sources)))
         return "F" if all(block.flags.f_contiguous for block in blocks) else "C"
 
-    def _in_input_order(self, Xt: XType, original_columns: pd.Index | range) -> XType:
+    def _maybe_in_input_order(
+        self, Xt: XType, original_columns: pd.Index | range
+    ) -> XType:
         """`Xt` with the input's column order restored, if this class preserves it."""
         if not self.preserves_column_order:
             return Xt
-        return self._preserve_order(X=Xt, original_columns=original_columns)
+        return self._in_input_order(X=Xt, original_columns=original_columns)
 
-    def _preserve_order(
+    def _in_input_order(
         self, X: XType, original_columns: list | range | pd.Index
     ) -> XType:
         check_is_fitted(self)

--- a/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
+++ b/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
@@ -192,9 +192,9 @@ class EfficientColumnTransformer(ColumnTransformer):
     @property
     def _is_one_to_one(self) -> bool:
         """Whether at most one transformer is configured, and it is one-to-one."""
-        # read off the specification rather than a fitted state, so a transformer this
-        # rejects never sees the one-row fit below -- which for one that needs many
-        # rows, a quantile transform say, would crash instead of falling back
+        # Being one-to-one does not make the probing one-row `transformer.fit` correct,
+        # but the fast path refits on every row, so nothing the probe learned survives
+        # into the output.
         named = [t for name, t, _ in self.transformers if name != "remainder"]
         return len(named) <= 1 and all(
             isinstance(transformer, OneToOneFeatureMixin) for transformer in named

--- a/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
+++ b/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
@@ -172,19 +172,7 @@ class EfficientColumnTransformer(ColumnTransformer):
                 super().fit_transform(X, y, **params), original_columns
             )
 
-        codes = None
-        if selected:
-            # `fit_transform` rather than a fit and then a transform: it is one pass
-            # over one slice of the selected columns, where the second pass would have
-            # to hold that slice for the whole of it.
-            codes = self.named_transformers_[name].fit_transform(
-                _column_subset(X, selected)
-            )
-            # What `_hstack` does with a sparse block whose density beat
-            # `sparse_threshold`, and what a `set_output` on the transformer itself
-            # would otherwise leave here.
-            codes = np.asarray(codes.toarray() if sparse.issparse(codes) else codes)
-        return self._assemble(X, name, codes, selected)
+        return self._assemble(X, name, selected)
 
     @override
     def transform(self, X: XType, **params: Any) -> XType:
@@ -195,7 +183,7 @@ class EfficientColumnTransformer(ColumnTransformer):
         is the one where they are settled in advance, by `_changes_no_value`.
         """
         if self._changes_no_value(X, params):
-            return self._assemble(X, None, None, [])
+            return self._assemble(X, None, [])
         original_columns = _input_columns(X)
         return self._in_input_order(super().transform(X, **params), original_columns)
 
@@ -332,13 +320,28 @@ class EfficientColumnTransformer(ColumnTransformer):
             if column not in taken
         )
 
-    def _assemble(
-        self,
-        X: XType,
-        name: str | None,
-        codes: np.ndarray | None,
-        selected: list[Any],
-    ) -> np.ndarray:
+    def _transformed_block(
+        self, X: XType, name: str | None, selected: list[Any]
+    ) -> np.ndarray | None:
+        """The named transformer's own output over the columns it selected.
+
+        `None` when there is nothing selected, without touching the transformer -- which
+        is the only case `transform` reaches this through, so nothing is fitted there.
+
+        `fit_transform` rather than a fit and then a transform: it is one pass over one
+        slice of the selected columns, where a second pass would have to hold that slice
+        for the whole of it.
+        """
+        if not selected:
+            return None
+        codes = self.named_transformers_[name].fit_transform(
+            _column_subset(X, selected)
+        )
+        # What `_hstack` does with a sparse block whose density beat `sparse_threshold`,
+        # and what a `set_output` on the transformer itself would otherwise leave here.
+        return np.asarray(codes.toarray() if sparse.issparse(codes) else codes)
+
+    def _assemble(self, X: XType, name: str | None, selected: list[Any]) -> np.ndarray:
         """Write the transformer's block and every other column to its final place.
 
         The array returned is one nothing else has ever referenced, which is what lets a
@@ -349,8 +352,16 @@ class EfficientColumnTransformer(ColumnTransformer):
         through into the frame, and copying it costs a second full-size buffer on top of
         the consolidation. Going column by column costs one buffer on every version, and
         leaves the frame's own blocks alone.
+
+        The transformer's block is computed here rather than handed in so that it can be
+        dropped the moment it is written. `np.empty` faults a page in only when it is
+        written to, so the output appears in RSS as its columns are filled: a caller
+        still holding the block while the passthrough half fills the rest would have the
+        whole output *and* the block resident at once, which the block dying first
+        avoids.
         """
         destination, passthrough = self._output_positions(X, name, selected)
+        codes = self._transformed_block(X, name, selected)
         dtype = self._assembled_dtype(X, codes, passthrough)
         order = self._assembled_order(X, codes, passthrough)
 
@@ -370,6 +381,7 @@ class EfficientColumnTransformer(ColumnTransformer):
         out = np.empty(X.shape, dtype=dtype, order=order)
         if codes is not None:
             out[:, destination] = codes
+            del codes
         # Per column, so the passthrough half never needs a full-width temporary of its
         # own; each write is a copy out of the container's own buffer.
         for position, source in passthrough:

--- a/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
+++ b/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
@@ -467,6 +467,29 @@ class OrderPreservingColumnTransformer(EfficientColumnTransformer):
                     f"or a single label, as {name!r} selects by {columns!r}."
                 )
 
+    @override
+    def _validate_remainder(self, X: XType) -> None:
+        """The remainder has to hand back every column it holds, checked at fit.
+
+        The reorder puts each input column back where it came from, so one that never
+        reached the output has no place to go: the gather runs off the end of the
+        result, or -- where the two orders happen to coincide -- silently returns a
+        narrower array as though it were in input order.
+        """
+        super()._validate_remainder(X)
+        # One-to-one for the same reason the named transformer is, plus the identity
+        # `FunctionTransformer` this codebase passes, which is not one.
+        if not (
+            is_identity_transformer(self.remainder)
+            or isinstance(self.remainder, OneToOneFeatureMixin)
+        ):
+            raise ValueError(
+                "OrderPreservingColumnTransformer only supports a remainder that hands "
+                "every column it holds back, and "
+                f"{self.remainder!r} does not. Note that `ColumnTransformer`'s default "
+                "is 'drop': pass `remainder=FunctionTransformer()` to keep them."
+            )
+
 
 def get_ordinal_encoder(
     *,

--- a/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
+++ b/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
@@ -270,26 +270,30 @@ class EfficientColumnTransformer(ColumnTransformer):
             return None
         # fit_transform rather than a fit and then a transform: one pass over one slice
         # of the selected columns, where a second pass would hold that slice throughout
-        codes = self.named_transformers_[name].fit_transform(
+        transformed = self.named_transformers_[name].fit_transform(
             _column_subset(X, selected)
         )
         # What `_hstack` does with a sparse block whose density beat `sparse_threshold`,
         # and what a `set_output` on the transformer itself would otherwise leave here.
-        return np.asarray(codes.toarray() if sparse.issparse(codes) else codes)
+        return np.asarray(
+            transformed.toarray() if sparse.issparse(transformed) else transformed
+        )
 
     def _assemble(self, X: XType, name: str | None, selected: list[Any]) -> np.ndarray:
-        """Write the transformer's block and every other column to its final place.
+        """Write the transformed columns and all the others to their final place.
 
         The array returned is one nothing else has ever referenced, which is what lets a
         caller write into what it gets back.
         """
         destination, passthrough = self._output_positions(X, name, selected)
         # computed here rather than handed in, so it can be dropped once written
-        codes = self._transformed_block(X, name, selected)
-        dtype = self._assembled_dtype(X, codes, passthrough)
-        order = self._assembled_order(X, codes, passthrough)
+        transformed = self._transformed_block(X, name, selected)
+        dtype = self._assembled_dtype(X, transformed, passthrough)
+        order = self._assembled_order(X, transformed, passthrough)
 
-        if codes is None and (not isinstance(X, pd.DataFrame) or to_numpy_may_alias(X)):
+        if transformed is None and (
+            not isinstance(X, pd.DataFrame) or to_numpy_may_alias(X)
+        ):
             # Nothing was transformed, so the output is the whole input converted, in
             # input order -- which both layouts agree on when the selection is empty.
             # Copied because `to_numpy` can hand back a view of a block the frame
@@ -302,11 +306,11 @@ class EfficientColumnTransformer(ColumnTransformer):
             return np.array(values, dtype=dtype, order=order, copy=True)
 
         out = np.empty(X.shape, dtype=dtype, order=order)
-        if codes is not None:
-            out[:, destination] = codes
-            # `np.empty` takes memory only as it is written to, so dropping the block
-            # here keeps the peak at one full-size array rather than one plus a block
-            del codes
+        if transformed is not None:
+            out[:, destination] = transformed
+            # `np.empty` takes memory only as it is written to, so dropping this here
+            # keeps the peak at one full-size array rather than one plus a block
+            del transformed
         # Per column, so the passthrough half never needs a full-width temporary of its
         # own, and the frame's own blocks are left alone -- `to_numpy` would rearrange
         # them in place before pandas 3, and hand back a view of what it just built.
@@ -317,12 +321,12 @@ class EfficientColumnTransformer(ColumnTransformer):
     def _output_positions(
         self, X: XType, name: str | None, selected: list[Any]
     ) -> tuple[Any, list[tuple[int, int]]]:
-        """Where the block, and the columns the transformer left, land in the output.
+        """Where the transformed columns, and all the others, land in the output.
 
         Returns:
-            destination: Where the transformer's block goes, in the order it holds its
-                columns -- a `slice` of the output, or the list of positions to scatter
-                them over. Selects nothing when nothing was selected.
+            destination: Where the transformed columns go, in the order the transformer
+                holds them -- a `slice` of the output, or the list of positions to
+                scatter them over. Selects nothing when nothing was selected.
             passthrough: One `(output position, input position)` pair for every column
                 the transformer did not take, in input order.
         """
@@ -332,35 +336,41 @@ class EfficientColumnTransformer(ColumnTransformer):
             index for column, index in positions.items() if column not in taken
         ]
         if self.preserves_column_order:
-            # every column stays where it came from, so the block is scattered back
-            # over the positions it was taken from
+            # every column stays where it came from, so the transformed ones are
+            # scattered back over the positions they were taken from
             return (
                 [positions[column] for column in selected],
                 [(index, index) for index in remainder],
             )
         # `ColumnTransformer`'s layout, read off the fit's own `output_indices_`: the
-        # block takes its slice, and the columns it did not take follow in input order
+        # transformed columns take their slice, and the rest follow in input order
         destination = slice(0, 0) if name is None else self.output_indices_[name]
         start = self.output_indices_["remainder"].start
         return destination, list(enumerate(remainder, start=start))
 
     def _assembled_dtype(
-        self, X: XType, codes: np.ndarray | None, passthrough: list[tuple[int, int]]
+        self,
+        X: XType,
+        transformed: np.ndarray | None,
+        passthrough: list[tuple[int, int]],
     ) -> np.dtype:
         """The dtype `ColumnTransformer` would have stacked its way to."""
         # a frame weighs in as float64, which `_can_assemble` has established every one
         # of its passthrough columns already is
         input_dtype = _FLOAT64 if isinstance(X, pd.DataFrame) else X.dtype
-        if codes is None:
+        if transformed is None:
             return input_dtype
         if not passthrough:
             # every column was transformed, so nothing else weighs in
-            return codes.dtype
+            return transformed.dtype
         # `np.concatenate` promotes across the blocks it stacks
-        return np.result_type(codes.dtype, input_dtype)
+        return np.result_type(transformed.dtype, input_dtype)
 
     def _assembled_order(
-        self, X: XType, codes: np.ndarray | None, passthrough: list[tuple[int, int]]
+        self,
+        X: XType,
+        transformed: np.ndarray | None,
+        passthrough: list[tuple[int, int]],
     ) -> Literal["C", "F"]:
         """The memory layout `ColumnTransformer` would have arrived at.
 
@@ -371,7 +381,7 @@ class EfficientColumnTransformer(ColumnTransformer):
             # what the reorder in `_in_input_order` leaves, for any output wider than
             # the single column where the two layouts coincide
             return "F"
-        blocks = [] if codes is None else [codes]
+        blocks = [] if transformed is None else [transformed]
         if passthrough:
             sources = [source for _, source in passthrough]
             # read off two rows rather than the full-size block this exists not to

--- a/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
+++ b/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
@@ -475,16 +475,19 @@ class EfficientColumnTransformer(ColumnTransformer):
                 and len(col_subset) < X.shape[-1]
                 and name != "remainder"
             ):
-                col_subset_list = list(col_subset)
-                col_subset_set = set(col_subset)
-                # Map original columns to indices in the transformed array
-                transformed_columns = col_subset_list + [
-                    c for c in original_columns if c not in col_subset_set
-                ]
-                transformed_col2idx = {
-                    c: idx for idx, c in enumerate(transformed_columns)
-                }
-                indices = [transformed_col2idx[c] for c in original_columns]
+                # Where each input column landed: the transformer's block first, in the
+                # order it selected, then the columns it left, in input order. So one
+                # lookup over the selection answers it -- what the selection does not
+                # hold follows in the order it is read here, which is the order those
+                # columns were handed through in.
+                rank = {column: index for index, column in enumerate(col_subset)}
+                next_index = len(col_subset)
+                indices = []
+                for column in original_columns:
+                    index = rank.get(column)
+                    if index is None:
+                        index, next_index = next_index, next_index + 1
+                    indices.append(index)
                 # restore the column order from before the transfomer has been applied
                 X = X.iloc[:, indices] if isinstance(X, pd.DataFrame) else X[:, indices]
         return X

--- a/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
+++ b/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
@@ -272,7 +272,6 @@ class EfficientColumnTransformer(ColumnTransformer):
                 continue
             if isinstance(columns, (list, np.ndarray, pd.Index)):
                 return name, list(columns)
-            # slow path: can't identify the column order
             return name, None
         # fast path: nothing gets transformed
         return None, []

--- a/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
+++ b/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
@@ -518,13 +518,7 @@ class OrderPreservingColumnTransformer(EfficientColumnTransformer):
 
     @override
     def get_feature_names_out(self, input_features: Any = None) -> np.ndarray:
-        """The names of the output's columns, in the order the output has them.
-
-        `ColumnTransformer` names its two blocks in the order it stacked them, which is
-        the order the reorder above undoes. Left as it is, the name a column is given
-        is the one belonging to whatever used to sit at its position -- silently, since
-        sklearn's `set_output` wrapper labels a pandas output with exactly this.
-        """
+        """The names of the output's columns, in the order the output has them."""
         names = super().get_feature_names_out(input_features)
         # the input's own keys, which is what the selection is expressed in
         original_columns = getattr(self, "feature_names_in_", None)

--- a/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
+++ b/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
@@ -291,21 +291,25 @@ class EfficientColumnTransformer(ColumnTransformer):
         )
 
     def _can_place_columns(self, X: XType, selected: list[Any]) -> bool:
-        """Whether `X`'s columns can be written out of it one at a time.
+        """Whether `X`'s columns can be written verbatim into the output.
 
-        Always, for an array. A frame carries two conditions. Every column the
-        transformer does *not* take has to be plain float64 already, so writing it into
-        the float64 output is a copy and not a conversion that could differ from the one
-        `ColumnTransformer` would have done -- notably an `object` column, which a dtype
-        selector skips and the stacking path carries through as objects until the
-        caller's closing cast. And the column keys have to be unique, since each column
-        is placed by key.
+        Args:
+            X (XType): Input.
+            selected (list[Any]): Columns to be processed by the transformer.
+
+        Returns:
+            bool
         """
         if not isinstance(X, pd.DataFrame):
+            # arrays are always ok
             return True
         if X.columns.has_duplicates:
+            # can't assign columns by key if multiple share the same key
             return False
         taken = set(selected)
+        # columns the transformer does *not* take need to already be float64,
+        # otherwise an assignment into the output would be a conversion that could
+        # differ from the one ColumnTransformer would have done
         return all(
             dtype == _FLOAT64
             for column, dtype in zip(X.columns, X.dtypes, strict=True)

--- a/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
+++ b/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
@@ -57,6 +57,33 @@ def _column_values(X: XType, position: int) -> np.ndarray:
     return X[:, position]
 
 
+def to_numpy_may_alias(X: pd.DataFrame) -> bool:
+    """Whether `X.to_numpy()` can hand back a view of the frame's own buffer.
+
+    A single-block frame is handed out as that block: read-only under copy-on-write,
+    writeable and aliasing whatever the frame was built from without it (pandas < 3),
+    which for a numeric ndarray input is the caller's own array. Anything wider has to
+    be materialised into a new array first, so what comes back is private.
+
+    Defensively `True` when the block internals are unavailable, so an unrecognised
+    layout is copied rather than handed out.
+    """
+    blocks = getattr(getattr(X, "_mgr", None), "blocks", None)
+    return blocks is None or len(blocks) <= 1
+
+
+def _converts_in_one_call(X: XType) -> bool:
+    """Whether `X` can hand out every column at once more cheaply than one at a time.
+
+    An array can, trivially. A frame only when `to_numpy` would hand back a block it
+    already holds, so that copying it is the single allocation -- not when it would
+    have to materialise one, and above all not when it would consolidate the frame in
+    place to do so, which is what pandas before 3 does and what costs a second
+    full-size buffer on top.
+    """
+    return not isinstance(X, pd.DataFrame) or to_numpy_may_alias(X)
+
+
 def _hands_columns_through(remainder: Any) -> bool:
     """Whether `remainder` returns the columns it is handed, untouched.
 
@@ -89,9 +116,11 @@ class EfficientColumnTransformer(ColumnTransformer):
     `fit` goes one further and builds no output at all, where `ColumnTransformer.fit`
     -- implemented as `fit_transform` -- pays for a full-size result and discards it.
 
-    `transform` is deliberately left on sklearn. It validates the input against the
-    one seen at fit -- column count, names, order -- which the assembly does not, so
-    replacing it would trade a real check for memory the fit path has already saved.
+    `transform` stays on sklearn, which validates the input against the one seen at fit
+    -- column count, names, order -- where the assembly makes no such check. The one
+    exception is the input for which those checks are settled in advance and the fitted
+    transformer provably changes nothing: there the step is a cast, and the cast is
+    assembled.
     """
 
     # Whether the output keeps the input's column order rather than
@@ -113,7 +142,7 @@ class EfficientColumnTransformer(ColumnTransformer):
         Decided on the same conditions as the assembly, so that the state left here is
         either sklearn's own or one those conditions vouch for.
         """
-        if not self._may_assemble(X, y, params):
+        if not (y is None and self._is_one_to_one and self._may_assemble(X, params)):
             return super().fit(X, y, **params)
         probe = self._fit_column_bookkeeping(X)
         name, selected = self._named_selection()
@@ -127,7 +156,7 @@ class EfficientColumnTransformer(ColumnTransformer):
     def fit_transform(self, X: XType, y: YType = None, **params: Any) -> XType:
         """Fit and transform, writing each column straight to its final place."""
         original_columns = _input_columns(X)
-        if not self._may_assemble(X, y, params):
+        if not (y is None and self._is_one_to_one and self._may_assemble(X, params)):
             return self._in_input_order(
                 super().fit_transform(X, y, **params), original_columns
             )
@@ -159,7 +188,14 @@ class EfficientColumnTransformer(ColumnTransformer):
 
     @override
     def transform(self, X: XType, **params: Any) -> XType:
-        """Left to `ColumnTransformer`; only the column order is restored after it."""
+        """Left to `ColumnTransformer`, unless it provably cannot change a value.
+
+        Its checks against the input seen at fit -- width, names, order -- are why it is
+        left there at all: the assembly makes none of them. So the one case taken here
+        is the one where they are settled in advance, by `_changes_no_value`.
+        """
+        if self._changes_no_value(X, params):
+            return self._assemble(X, None, None, [])
         original_columns = _input_columns(X)
         return self._in_input_order(super().transform(X, **params), original_columns)
 
@@ -172,35 +208,67 @@ class EfficientColumnTransformer(ColumnTransformer):
         _, selected = self._named_selection()
         return selected or []
 
-    def _may_assemble(self, X: XType, y: YType, params: dict[str, Any]) -> bool:
-        """Whether the transformers as configured could be written into one array.
+    def _may_assemble(self, X: XType, params: dict[str, Any]) -> bool:
+        """Whether an output of this shape could be written into one array at all.
+
+        Routed metadata is declined outright: nothing with the shape assembled here has
+        any use for it. So is an input that is neither an array nor a frame -- a sparse
+        one would be densified by the array written into here, which is not what
+        `ColumnTransformer` hands back -- and a `set_output` asking for a frame, which
+        this returns none of.
+        """
+        if params or not isinstance(X, (np.ndarray, pd.DataFrame)):
+            return False
+        output_config = getattr(self, "_sklearn_output_config", {}).get(
+            "transform", get_config()["transform_output"]
+        )
+        return _hands_columns_through(self.remainder) and output_config == "default"
+
+    @property
+    def _is_one_to_one(self) -> bool:
+        """Whether at most one transformer is configured, and it maps column to column.
 
         Read off the specification rather than a fitted state, so that a transformer
         this rejects never sees the one-row fit below -- which for one that cannot be
         fitted on a single row, a quantile transform say, is the difference between a
         fallback and a crash.
-
-        A `y` or routed metadata is declined outright: the one-row fit would have to
-        be given something to match it, and no transformer with the shape assembled here
-        has any use for either. So is an input that is neither an array nor a frame:
-        a sparse one would be densified by the array written into here, which is not
-        what `ColumnTransformer` hands back.
         """
-        if y is not None or params or not isinstance(X, (np.ndarray, pd.DataFrame)):
-            return False
-        named = [
-            (name, transformer)
-            for name, transformer, _ in self.transformers
-            if name != "remainder"
-        ]
-        output_config = getattr(self, "_sklearn_output_config", {}).get(
-            "transform", get_config()["transform_output"]
+        named = [t for name, t, _ in self.transformers if name != "remainder"]
+        return len(named) <= 1 and all(
+            isinstance(transformer, OneToOneFeatureMixin) for transformer in named
         )
+
+    def _changes_no_value(self, X: XType, params: dict[str, Any]) -> bool:
+        """Whether transforming `X` provably leaves every value where it was.
+
+        Three things have to hold. The fitted transformer must have selected nothing, so
+        the step is its passthrough remainder and there is no code to compute. `X` must
+        be one the columns can be written out of. And it must line up with the input
+        seen at fit -- same width, same names in the same order -- because sklearn lines
+        a reordered frame back up with the fit-time order where the assembly would keep
+        the input's own, and because skipping `transform` skips the checks that would
+        have caught a frame not lining up at all.
+        """
+        if not hasattr(self, "transformers_"):
+            # Unfitted. `transform` is the one that should say so.
+            return False
+        # An empty list, not merely a falsy one: a selection this cannot read is one
+        # whose columns might well be transformed.
+        if self._named_selection()[1] != []:
+            return False
+        if (
+            not self._may_assemble(X, params)
+            or self.sparse_output_
+            or self.n_features_in_ != X.shape[1]
+            or not self._can_place_columns(X, [])
+        ):
+            return False
+        names = getattr(self, "feature_names_in_", None)
         return (
-            len(named) <= 1
-            and all(isinstance(t, OneToOneFeatureMixin) for _, t in named)
-            and _hands_columns_through(self.remainder)
-            and output_config == "default"
+            names is None
+            or not isinstance(X, pd.DataFrame)
+            # Compared as plain lists to be dtype-insensitive.
+            or list(X.columns) == list(names)
         )
 
     def _fit_column_bookkeeping(self, X: XType) -> XType:
@@ -234,16 +302,25 @@ class EfficientColumnTransformer(ColumnTransformer):
         one-to-oneness is checked rather than taken on the mixin's word: every input
         column has to reach exactly one output column, or the array the assembly
         allocates is the wrong shape and the bookkeeping around it is wrong too.
-
-        A frame carries one more condition. Every column the transformer does *not*
-        take has to be plain float64 already, so writing it into the float64 output is a
-        copy and not a conversion that could differ from the one `ColumnTransformer`
-        would have done -- notably an `object` column, which a dtype selector skips
-        and the stacking path carries through as objects until the caller's closing
-        cast. And the column keys have to be unique, since each column is placed by key.
         """
-        if selected is None or self.sparse_output_ or probe.shape[1] != X.shape[1]:
-            return False
+        return (
+            selected is not None
+            and not self.sparse_output_
+            and probe.shape[1] == X.shape[1]
+            and self._can_place_columns(X, selected)
+        )
+
+    def _can_place_columns(self, X: XType, selected: list[Any]) -> bool:
+        """Whether `X`'s columns can be written out of it one at a time.
+
+        Always, for an array. A frame carries two conditions. Every column the
+        transformer does *not* take has to be plain float64 already, so writing it into
+        the float64 output is a copy and not a conversion that could differ from the one
+        `ColumnTransformer` would have done -- notably an `object` column, which a dtype
+        selector skips and the stacking path carries through as objects until the
+        caller's closing cast. And the column keys have to be unique, since each column
+        is placed by key.
+        """
         if not isinstance(X, pd.DataFrame):
             return True
         if X.columns.has_duplicates:
@@ -262,13 +339,35 @@ class EfficientColumnTransformer(ColumnTransformer):
         codes: np.ndarray | None,
         selected: list[Any],
     ) -> np.ndarray:
-        """Write the transformer's block and every other column to its final place."""
+        """Write the transformer's block and every other column to its final place.
+
+        The array returned is one nothing else has ever referenced, which is what lets a
+        caller write into what it gets back. Notably it is never `to_numpy`'s result as
+        it stands: pandas 3 materialises a many-block frame into a private array, which
+        could be taken as it is, but earlier versions consolidate the frame *in place*
+        first and return a view of the block they just built -- taking that would write
+        through into the frame, and copying it costs a second full-size buffer on top of
+        the consolidation. Going column by column costs one buffer on every version, and
+        leaves the frame's own blocks alone.
+        """
         destination, passthrough = self._output_positions(X, name, selected)
-        out = np.empty(
-            X.shape,
-            dtype=self._assembled_dtype(X, codes, passthrough),
-            order=self._assembled_order(X, codes, passthrough),
-        )
+        dtype = self._assembled_dtype(X, codes, passthrough)
+        order = self._assembled_order(X, codes, passthrough)
+
+        if codes is None and _converts_in_one_call(X):
+            # Nothing was transformed, so the output is the whole input converted, in
+            # input order -- which both layouts agree on when the selection is empty.
+            # One call for all of it where that is the cheaper way to reach the same
+            # single allocation: measured at 50,000 x 2,000, going column by column
+            # instead costs 46% more wall time.
+            values = (
+                X.to_numpy(dtype=dtype, copy=False)
+                if isinstance(X, pd.DataFrame)
+                else X
+            )
+            return np.array(values, dtype=dtype, order=order, copy=True)
+
+        out = np.empty(X.shape, dtype=dtype, order=order)
         if codes is not None:
             out[:, destination] = codes
         # Per column, so the passthrough half never needs a full-width temporary of its

--- a/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
+++ b/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
@@ -426,8 +426,8 @@ class EfficientColumnTransformer(ColumnTransformer):
         # where it would also leave the layout alone, since it hands back a
         # Fortran-contiguous array whatever it was given and `_assembled_order` says
         # what reads that. A frame has no such layout to keep.
-        if all(index == position for position, index in enumerate(indices)) and (
-            not isinstance(X, np.ndarray) or X.flags.f_contiguous
+        if (not isinstance(X, np.ndarray) or X.flags.f_contiguous) and all(
+            index == position for position, index in enumerate(indices)
         ):
             return X
         # restore the column order from before the transformer has been applied

--- a/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
+++ b/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
@@ -292,10 +292,8 @@ class EfficientColumnTransformer(ColumnTransformer):
         if codes is None and (not isinstance(X, pd.DataFrame) or to_numpy_may_alias(X)):
             # Nothing was transformed, so the output is the whole input converted, in
             # input order -- which both layouts agree on when the selection is empty.
-            # One call for all of it saves the per-column overhead of the loop below,
-            # which grows with the column count: nothing at 300 columns, 12% of the wall
-            # time at 2,000 and 26% at 5,000. Copied because `to_numpy` can hand back a
-            # view of a block the frame itself still holds.
+            # Copied because `to_numpy` can hand back a view of a block the frame
+            # itself still holds.
             values = (
                 X.to_numpy(dtype=dtype, copy=False)
                 if isinstance(X, pd.DataFrame)

--- a/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
+++ b/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Sequence
 from typing import TYPE_CHECKING, Any, ClassVar
 from typing_extensions import Self, override
 
@@ -13,7 +12,6 @@ import pandas as pd
 from scipy import sparse
 from sklearn import get_config
 from sklearn.base import (
-    BaseEstimator,
     OneToOneFeatureMixin,
     check_is_fitted,
 )
@@ -499,31 +497,14 @@ class EfficientColumnTransformer(ColumnTransformer):
 
 
 class OrderPreservingColumnTransformer(EfficientColumnTransformer):
-    """An EfficientColumnTransformer that preserves the column order after transform."""
+    """An EfficientColumnTransformer that preserves the column order after transform.
+
+    Its parameters are `ColumnTransformer`'s, narrowed to what restoring that order
+    needs: at most one transformer, one-to-one, over a list of column keys or a callable
+    returning one.
+    """
 
     preserves_column_order: ClassVar[bool] = True
-
-    def __init__(
-        self,
-        transformers: Sequence[
-            tuple[
-                str,
-                BaseEstimator,
-                Iterable[str | int] | Callable[[Any], Iterable[str | int]],
-            ]
-        ],
-        **kwargs: Any,
-    ):
-        """Implementation base on https://scikit-learn.org/stable/modules/generated/sklearn.compose.ColumnTransformer.html.
-
-        Parameters
-        ----------
-        transformers : sequence of (name, transformer, columns) tuples
-            List of (name, transformer, columns) tuples specifying the transformers.
-        **kwargs : additional keyword arguments
-            Passed to sklearn.compose.ColumnTransformer.
-        """
-        super().__init__(transformers=transformers, **kwargs)
 
     @override
     def _validate_transformers(self) -> None:

--- a/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
+++ b/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
@@ -489,7 +489,7 @@ class EfficientColumnTransformer(ColumnTransformer):
                     indices.append(index)
                 if all(index == position for position, index in enumerate(indices)):
                     continue
-                # restore the column order from before the transfomer has been applied
+                # restore the column order from before the transformer has been applied
                 X = X.iloc[:, indices] if isinstance(X, pd.DataFrame) else X[:, indices]
         return X
 

--- a/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
+++ b/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
@@ -252,11 +252,11 @@ class EfficientColumnTransformer(ColumnTransformer):
     def _fit_column_bookkeeping(self, X: XType) -> XType:
         """Fit everything but the values, and return the one-row result that took.
 
-        `ColumnTransformer.fit` is implemented as `fit_transform`, so fitting on
-        the whole input would run the very transform this class replaces. Called on the
-        parent because `self.fit` would land back here.
+        `ColumnTransformer.fit` is implemented as `fit_transform`, so fitting on the
+        whole input would run the very transform this class replaces. Taken up the chain
+        rather than through `self.fit`, which would land back in the override above.
         """
-        return ColumnTransformer.fit_transform(self, _head(X, 1), None)
+        return super().fit_transform(_head(X, 1), None)
 
     def _named_selection(self) -> tuple[str | None, list[Any] | None]:
         """The named transformer's name and the columns it holds, in its own order.

--- a/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
+++ b/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
@@ -21,6 +21,7 @@ from sklearn.compose import ColumnTransformer, make_column_selector
 from sklearn.preprocessing import FunctionTransformer, OrdinalEncoder
 
 from tabpfn.constants import DEFAULT_NUMPY_PREPROCESSING_DTYPE
+from tabpfn.preprocessing.steps.utils import is_identity_transformer
 
 if TYPE_CHECKING:
     from typing import Literal
@@ -82,30 +83,6 @@ def _converts_in_one_call(X: XType) -> bool:
     full-size buffer on top.
     """
     return not isinstance(X, pd.DataFrame) or to_numpy_may_alias(X)
-
-
-def _hands_columns_through(remainder: Any) -> bool:
-    """Whether `remainder` returns the columns it is handed, untouched.
-
-    `"passthrough"` says so outright. A `FunctionTransformer` does when it has no `func`
-    *and* does not validate -- which is how `get_ordinal_encoder` configures it.
-    `validate=True` is not nothing: it sends the columns through `check_array`, which
-    coerces the dtype and refuses a NaN that the assembly would carry through, so a
-    remainder asking for it is one whose work cannot be skipped.
-
-    The type is compared exactly rather than with `isinstance` because of what this
-    decides -- that a transform need not run at all. A subclass may override `transform`
-    and do something else entirely with `func` still unset, which no inspection here
-    would catch. Refusing a harmless subclass costs a fallback; accepting an unfaithful
-    one costs the result.
-    """
-    if isinstance(remainder, str):
-        return remainder == "passthrough"
-    return (
-        type(remainder) is FunctionTransformer
-        and remainder.func is None
-        and not remainder.validate
-    )
 
 
 class EfficientColumnTransformer(ColumnTransformer):
@@ -223,7 +200,7 @@ class EfficientColumnTransformer(ColumnTransformer):
         output_config = getattr(self, "_sklearn_output_config", {}).get(
             "transform", get_config()["transform_output"]
         )
-        return _hands_columns_through(self.remainder) and output_config == "default"
+        return is_identity_transformer(self.remainder) and output_config == "default"
 
     @property
     def _is_one_to_one(self) -> bool:

--- a/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
+++ b/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
@@ -68,14 +68,6 @@ def to_numpy_may_alias(X: pd.DataFrame) -> bool:
     return blocks is None or len(blocks) <= 1
 
 
-def _converts_in_one_call(X: XType) -> bool:
-    """Whether `X` can hand out every column at once for a single allocation."""
-    # a frame only when `to_numpy` hands back a block it already holds: otherwise it
-    # builds one, and before pandas 3 rearranges the frame in place to do so, which
-    # costs a second full-size buffer on top
-    return not isinstance(X, pd.DataFrame) or to_numpy_may_alias(X)
-
-
 class EfficientColumnTransformer(ColumnTransformer):
     """A `ColumnTransformer` that assembles its output into one preallocated array.
 
@@ -297,7 +289,7 @@ class EfficientColumnTransformer(ColumnTransformer):
         dtype = self._assembled_dtype(X, codes, passthrough)
         order = self._assembled_order(X, codes, passthrough)
 
-        if codes is None and _converts_in_one_call(X):
+        if codes is None and (not isinstance(X, pd.DataFrame) or to_numpy_may_alias(X)):
             # Nothing was transformed, so the output is the whole input converted, in
             # input order -- which both layouts agree on when the selection is empty.
             # One call for all of it saves the per-column overhead of the loop below,

--- a/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
+++ b/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
@@ -382,7 +382,8 @@ class EfficientColumnTransformer(ColumnTransformer):
             # the single column where the two layouts coincide
             return "F"
         blocks = [] if transformed is None else [transformed]
-        if passthrough:
+        # A frame's passthrough block is column-major
+        if passthrough and not isinstance(X, pd.DataFrame):
             sources = [source for _, source in passthrough]
             # read off two rows rather than the full-size block this exists not to
             # build; selecting columns gives the same layout at either height

--- a/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
+++ b/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
@@ -475,24 +475,18 @@ class EfficientColumnTransformer(ColumnTransformer):
                 and len(col_subset) < X.shape[-1]
                 and name != "remainder"
             ):
-                # Where each input column landed: the transformer's block first, in the
-                # order it selected, then the columns it left, in input order. So one
-                # lookup over the selection answers it -- what the selection does not
-                # hold follows in the order it is read here, which is the order those
-                # columns were handed through in.
+                # where each processed  column landed in X
                 rank = {column: index for index, column in enumerate(col_subset)}
+                # next free index to use for untransformed columns
                 next_index = len(col_subset)
+                # indices[i] is the column index in X corresponding to input column i
                 indices = []
                 for column in original_columns:
                     index = rank.get(column)
                     if index is None:
+                        # column wasn't input to the transformer
                         index, next_index = next_index, next_index + 1
                     indices.append(index)
-                # The gather below is a full-size copy, and the one order it need not
-                # restore is the one already there: a stack whose transformed block
-                # holds the columns it came from is handed back as `ColumnTransformer`
-                # built it. Still an array of this call's own -- `_hstack` concatenates
-                # the blocks it stacks -- so a caller may write into it either way.
                 if all(index == position for position, index in enumerate(indices)):
                     continue
                 # restore the column order from before the transfomer has been applied

--- a/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
+++ b/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
@@ -5,11 +5,13 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Sequence
-from typing import TYPE_CHECKING, Any
-from typing_extensions import override
+from typing import TYPE_CHECKING, Any, ClassVar
+from typing_extensions import Self, override
 
 import numpy as np
 import pandas as pd
+from scipy import sparse
+from sklearn import get_config
 from sklearn.base import (
     BaseEstimator,
     OneToOneFeatureMixin,
@@ -21,11 +23,360 @@ from sklearn.preprocessing import FunctionTransformer, OrdinalEncoder
 from tabpfn.constants import DEFAULT_NUMPY_PREPROCESSING_DTYPE
 
 if TYPE_CHECKING:
+    from typing import Literal
+
     from tabpfn.classifier import XType, YType
 
+_FLOAT64 = np.dtype(np.float64)
 
-class OrderPreservingColumnTransformer(ColumnTransformer):
-    """An ColumnTransformer that preserves the column order after transformation."""
+
+def _input_columns(X: XType) -> pd.Index | range:
+    """The input's column keys, in input order."""
+    return X.columns if isinstance(X, pd.DataFrame) else range(X.shape[-1])
+
+
+def _head(X: XType, rows: int) -> XType:
+    """The input's leading rows, as the same kind of container."""
+    return X.iloc[:rows] if isinstance(X, pd.DataFrame) else X[:rows]
+
+
+def _column_subset(X: XType, columns: list[Any]) -> XType:
+    """The given columns, as the same kind of container."""
+    return X[columns] if isinstance(X, pd.DataFrame) else X[:, columns]
+
+
+def _columns_at(X: XType, positions: list[int]) -> XType:
+    """The columns at the given positions, as the same kind of container."""
+    return X.iloc[:, positions] if isinstance(X, pd.DataFrame) else X[:, positions]
+
+
+def _column_values(X: XType, position: int) -> np.ndarray:
+    """One column, by position, as an array -- a view wherever that is possible."""
+    if isinstance(X, pd.DataFrame):
+        return X.iloc[:, position].to_numpy(copy=False)
+    return X[:, position]
+
+
+def _hands_columns_through(remainder: Any) -> bool:
+    """Whether `remainder` returns the columns it is handed, untouched.
+
+    `"passthrough"` says so outright. A `FunctionTransformer` with no `func` is
+    the identity too, and is what `get_ordinal_encoder` configures.
+    """
+    if isinstance(remainder, str):
+        return remainder == "passthrough"
+    return type(remainder) is FunctionTransformer and remainder.func is None
+
+
+class EfficientColumnTransformer(ColumnTransformer):
+    """A `ColumnTransformer` that assembles its output into one preallocated array.
+
+    `ColumnTransformer` reaches its result through three full-size arrays: one per
+    transformer, a second from stacking them, and (when preserving column order)
+    a third from the gather that reorders. A wide input reaches its RAM peak twice
+    inside that, once in the stack and once in the gather, which is why removing either
+    one alone changes nothing. This class writes every column straight to its final
+    place instead, so only the output and the named transformer's own block are ever
+    held at once.
+
+    That is only possible for the narrow shape this codebase needs: at most one named
+    transformer, one-to-one, over a subset of the columns, plus a remainder that hands
+    the rest through untouched. Anything else -- a transformer that expands its columns
+    or is fed a `y`, a sparse result, a `set_output` asking for a frame, a frame whose
+    passthrough columns are not already float64 -- falls back to `ColumnTransformer`,
+    so this stays a drop-in replacement for it.
+
+    `fit` goes one further and builds no output at all, where `ColumnTransformer.fit`
+    -- implemented as `fit_transform` -- pays for a full-size result and discards it.
+
+    `transform` is deliberately left on sklearn. It validates the input against the
+    one seen at fit -- column count, names, order -- which the assembly does not, so
+    replacing it would trade a real check for memory the fit path has already saved.
+    """
+
+    # Whether the output keeps the input's column order rather than
+    # `ColumnTransformer`'s `[transformed, remainder]` one. A class attribute
+    # rather than a constructor parameter, so sklearn's parameter introspection --
+    # and with it `clone` and `get_params` -- stays exactly its parent's.
+    preserves_column_order: ClassVar[bool] = False
+
+    @override
+    def fit(self, X: XType, y: YType = None, **params: Any) -> Self:
+        """Fit without building the transformed array `ColumnTransformer.fit` builds.
+
+        All the fitted state consists of is the column bookkeeping and the named
+        transformer. The bookkeeping comes from one row -- widths and output positions
+        do not depend on the row count for a one-to-one transformer -- and the
+        transformer then learns from every row, in one pass, with no full-size result
+        stacked or discarded on the way.
+
+        Decided on the same conditions as the assembly, so that the state left here is
+        either sklearn's own or one those conditions vouch for.
+        """
+        if not self._may_assemble(X, y, params):
+            return super().fit(X, y, **params)
+        probe = self._fit_column_bookkeeping(X)
+        name, selected = self._named_selection()
+        if not self._can_assemble(X, probe, selected):
+            return super().fit(X, y, **params)
+        if selected:
+            self.named_transformers_[name].fit(_column_subset(X, selected))
+        return self
+
+    @override
+    def fit_transform(self, X: XType, y: YType = None, **params: Any) -> XType:
+        """Fit and transform, writing each column straight to its final place."""
+        original_columns = _input_columns(X)
+        if not self._may_assemble(X, y, params):
+            return self._in_input_order(
+                super().fit_transform(X, y, **params), original_columns
+            )
+
+        probe = self._fit_column_bookkeeping(X)
+        name, selected = self._named_selection()
+        if not self._can_assemble(X, probe, selected):
+            # Bail before the named transformer has learned anything from the values:
+            # the fallback learns them again from scratch, so doing it first would be a
+            # wasted pass over the data. Only the one-row fit is lost, which costs no
+            # pass at all.
+            return self._in_input_order(
+                super().fit_transform(X, y, **params), original_columns
+            )
+
+        codes = None
+        if selected:
+            # `fit_transform` rather than a fit and then a transform: it is one pass
+            # over one slice of the selected columns, where the second pass would have
+            # to hold that slice for the whole of it.
+            codes = self.named_transformers_[name].fit_transform(
+                _column_subset(X, selected)
+            )
+            # What `_hstack` does with a sparse block whose density beat
+            # `sparse_threshold`, and what a `set_output` on the transformer itself
+            # would otherwise leave here.
+            codes = np.asarray(codes.toarray() if sparse.issparse(codes) else codes)
+        return self._assemble(X, name, codes, selected)
+
+    @override
+    def transform(self, X: XType, **params: Any) -> XType:
+        """Left to `ColumnTransformer`; only the column order is restored after it."""
+        original_columns = _input_columns(X)
+        return self._in_input_order(super().transform(X, **params), original_columns)
+
+    def selected_columns(self) -> list[Any]:
+        """The columns the named transformer holds, in the order it holds them.
+
+        Empty when it selected nothing, when only a remainder is configured, or when
+        the selection is not a list of column keys at all.
+        """
+        _, selected = self._named_selection()
+        return selected or []
+
+    def _may_assemble(self, X: XType, y: YType, params: dict[str, Any]) -> bool:
+        """Whether the transformers as configured could be written into one array.
+
+        Read off the specification rather than a fitted state, so that a transformer
+        this rejects never sees the one-row fit below -- which for one that cannot be
+        fitted on a single row, a quantile transform say, is the difference between a
+        fallback and a crash.
+
+        A `y` or routed metadata is declined outright: the one-row fit would have to
+        be given something to match it, and no transformer with the shape assembled here
+        has any use for either. So is an input that is neither an array nor a frame:
+        a sparse one would be densified by the array written into here, which is not
+        what `ColumnTransformer` hands back.
+        """
+        if y is not None or params or not isinstance(X, (np.ndarray, pd.DataFrame)):
+            return False
+        named = [
+            (name, transformer)
+            for name, transformer, _ in self.transformers
+            if name != "remainder"
+        ]
+        output_config = getattr(self, "_sklearn_output_config", {}).get(
+            "transform", get_config()["transform_output"]
+        )
+        return (
+            len(named) <= 1
+            and all(isinstance(t, OneToOneFeatureMixin) for _, t in named)
+            and _hands_columns_through(self.remainder)
+            and output_config == "default"
+        )
+
+    def _fit_column_bookkeeping(self, X: XType) -> XType:
+        """Fit everything but the values, and return the one-row result that took.
+
+        `ColumnTransformer.fit` is implemented as `fit_transform`, so fitting on
+        the whole input would run the very transform this class replaces. Called on the
+        parent because `self.fit` would land back here.
+        """
+        return ColumnTransformer.fit_transform(self, _head(X, 1), None)
+
+    def _named_selection(self) -> tuple[str | None, list[Any] | None]:
+        """The named transformer's name and the columns it holds, in its own order.
+
+        `None` for the columns when the selection is not a list of keys -- a `slice`
+        or a bare label -- which cannot be placed one column at a time. Both entries are
+        empty when only a remainder is configured.
+        """
+        for name, _, columns in self.transformers_:
+            if name == "remainder":
+                continue
+            if isinstance(columns, (list, np.ndarray, pd.Index)):
+                return name, list(columns)
+            return name, None
+        return None, []
+
+    def _can_assemble(self, X: XType, probe: XType, selected: list[Any] | None) -> bool:
+        """Whether the layout just fitted is one that can be written column by column.
+
+        The one-row `probe` is the fit's own answer on the output's width, so
+        one-to-oneness is checked rather than taken on the mixin's word: every input
+        column has to reach exactly one output column, or the array the assembly
+        allocates is the wrong shape and the bookkeeping around it is wrong too.
+
+        A frame carries one more condition. Every column the transformer does *not*
+        take has to be plain float64 already, so writing it into the float64 output is a
+        copy and not a conversion that could differ from the one `ColumnTransformer`
+        would have done -- notably an `object` column, which a dtype selector skips
+        and the stacking path carries through as objects until the caller's closing
+        cast. And the column keys have to be unique, since each column is placed by key.
+        """
+        if selected is None or self.sparse_output_ or probe.shape[1] != X.shape[1]:
+            return False
+        if not isinstance(X, pd.DataFrame):
+            return True
+        if X.columns.has_duplicates:
+            return False
+        taken = set(selected)
+        return all(
+            dtype == _FLOAT64
+            for column, dtype in zip(X.columns, X.dtypes, strict=True)
+            if column not in taken
+        )
+
+    def _assemble(
+        self,
+        X: XType,
+        name: str | None,
+        codes: np.ndarray | None,
+        selected: list[Any],
+    ) -> np.ndarray:
+        """Write the transformer's block and every other column to its final place."""
+        destination, passthrough = self._output_positions(X, name, selected)
+        out = np.empty(
+            X.shape,
+            dtype=self._assembled_dtype(X, codes, passthrough),
+            order=self._assembled_order(X, codes, passthrough),
+        )
+        if codes is not None:
+            out[:, destination] = codes
+        # Per column, so the passthrough half never needs a full-width temporary of its
+        # own; each write is a copy out of the container's own buffer.
+        for position, source in passthrough:
+            out[:, position] = _column_values(X, source)
+        return out
+
+    def _output_positions(
+        self, X: XType, name: str | None, selected: list[Any]
+    ) -> tuple[Any, list[tuple[int, int]]]:
+        """Where the transformer's block, and each column it left, land in the output.
+
+        Two layouts. Preserving the input order, every column stays where it came from,
+        so the block is scattered back over the positions it was taken from. Otherwise
+        it is `ColumnTransformer`'s, read off the fit's own `output_indices_`: the
+        block takes its slice, and the columns the transformer did not take follow in
+        input order.
+        """
+        positions = {column: index for index, column in enumerate(_input_columns(X))}
+        taken = set(selected)
+        remainder = [
+            index for column, index in positions.items() if column not in taken
+        ]
+        if self.preserves_column_order:
+            return (
+                [positions[column] for column in selected],
+                [(index, index) for index in remainder],
+            )
+        destination = slice(0, 0) if name is None else self.output_indices_[name]
+        start = self.output_indices_["remainder"].start
+        return destination, list(enumerate(remainder, start=start))
+
+    def _assembled_dtype(
+        self, X: XType, codes: np.ndarray | None, passthrough: list[tuple[int, int]]
+    ) -> np.dtype:
+        """The dtype `ColumnTransformer` would have stacked its way to.
+
+        `np.concatenate` promotes across the blocks it stacks, so the columns handed
+        through only weigh in when there are any: an input whose every column is
+        transformed comes out as the transformer's own dtype. A frame weighs in as
+        float64, which `_can_assemble` has established every one of its passthrough
+        columns already is.
+        """
+        input_dtype = _FLOAT64 if isinstance(X, pd.DataFrame) else X.dtype
+        if codes is None:
+            return input_dtype
+        if not passthrough:
+            return codes.dtype
+        return np.result_type(codes.dtype, input_dtype)
+
+    def _assembled_order(
+        self, X: XType, codes: np.ndarray | None, passthrough: list[tuple[int, int]]
+    ) -> Literal["C", "F"]:
+        """The memory layout `ColumnTransformer` would have arrived at.
+
+        Not cosmetic: the sklearn SVD that can run downstream of these steps converges
+        to a different basis on a C- than on a Fortran-contiguous input, so a drift here
+        would quietly rotate those features.
+
+        Preserving the input order, the layout is the one the gather in
+        `_preserve_order` produced, which numpy makes column-major for any output
+        wider than the single column where the two orders coincide. Otherwise it is
+        `np.concatenate`'s: Fortran only when every block it stacks already is, and
+        row-major otherwise -- so the blocks decide. The passthrough block's layout is
+        read off a two-row slice rather than the full-size block this exists not to
+        build; column selection gives the same answer at either height.
+        """
+        if self.preserves_column_order:
+            return "F"
+        blocks = [] if codes is None else [codes]
+        if passthrough:
+            sources = [source for _, source in passthrough]
+            blocks.append(np.asarray(_columns_at(_head(X, 2), sources)))
+        return "F" if all(block.flags.f_contiguous for block in blocks) else "C"
+
+    def _in_input_order(self, Xt: XType, original_columns: pd.Index | range) -> XType:
+        """`Xt` with the input's column order restored, if this class preserves it."""
+        if not self.preserves_column_order:
+            return Xt
+        return self._preserve_order(X=Xt, original_columns=original_columns)
+
+    def _preserve_order(
+        self, X: XType, original_columns: list | range | pd.Index
+    ) -> XType:
+        check_is_fitted(self)
+        assert X.ndim == 2, f"Expected 2D input, got {X.ndim}D (shape={X.shape})"
+        for name, _, col_subset in reversed(self.transformers_):
+            if (
+                len(col_subset) > 0
+                and len(col_subset) < X.shape[-1]
+                and name != "remainder"
+            ):
+                col_subset_list = list(col_subset)
+                # Map original columns to indices in the transformed array
+                transformed_columns = col_subset_list + [
+                    c for c in original_columns if c not in col_subset_list
+                ]
+                indices = [transformed_columns.index(c) for c in original_columns]
+                # restore the column order from before the transfomer has been applied
+                X = X.iloc[:, indices] if isinstance(X, pd.DataFrame) else X[:, indices]
+        return X
+
+
+class OrderPreservingColumnTransformer(EfficientColumnTransformer):
+    """An EfficientColumnTransformer that preserves the column order after transform."""
+
+    preserves_column_order: ClassVar[bool] = True
 
     def __init__(
         self,
@@ -66,45 +417,6 @@ class OrderPreservingColumnTransformer(ColumnTransformer):
         assert len([t for name, _, t in transformers if name != "remainder"]) <= 1, (
             "OrderPreservingColumnTransformer only supports up to one transformer."
         )
-
-    @override
-    def transform(self, X: XType, **kwargs: dict[str, Any]) -> XType:
-        original_columns = (
-            X.columns if isinstance(X, pd.DataFrame) else range(X.shape[-1])
-        )
-        X_t = super().transform(X, **kwargs)
-        return self._preserve_order(X=X_t, original_columns=original_columns)
-
-    @override
-    def fit_transform(
-        self, X: XType, y: YType = None, **kwargs: dict[str, Any]
-    ) -> XType:
-        original_columns = (
-            X.columns if isinstance(X, pd.DataFrame) else range(X.shape[-1])
-        )
-        X_t = super().fit_transform(X, y, **kwargs)
-        return self._preserve_order(X=X_t, original_columns=original_columns)
-
-    def _preserve_order(
-        self, X: XType, original_columns: list | range | pd.Index
-    ) -> XType:
-        check_is_fitted(self)
-        assert X.ndim == 2, f"Expected 2D input, got {X.ndim}D (shape={X.shape})"
-        for name, _, col_subset in reversed(self.transformers_):
-            if (
-                len(col_subset) > 0
-                and len(col_subset) < X.shape[-1]
-                and name != "remainder"
-            ):
-                col_subset_list = list(col_subset)
-                # Map original columns to indices in the transformed array
-                transformed_columns = col_subset_list + [
-                    c for c in original_columns if c not in col_subset_list
-                ]
-                indices = [transformed_columns.index(c) for c in original_columns]
-                # restore the column order from before the transfomer has been applied
-                X = X.iloc[:, indices] if isinstance(X, pd.DataFrame) else X[:, indices]
-        return X
 
 
 def get_ordinal_encoder(

--- a/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
+++ b/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
@@ -87,12 +87,25 @@ def _converts_in_one_call(X: XType) -> bool:
 def _hands_columns_through(remainder: Any) -> bool:
     """Whether `remainder` returns the columns it is handed, untouched.
 
-    `"passthrough"` says so outright. A `FunctionTransformer` with no `func` is
-    the identity too, and is what `get_ordinal_encoder` configures.
+    `"passthrough"` says so outright. A `FunctionTransformer` does when it has no `func`
+    *and* does not validate -- which is how `get_ordinal_encoder` configures it.
+    `validate=True` is not nothing: it sends the columns through `check_array`, which
+    coerces the dtype and refuses a NaN that the assembly would carry through, so a
+    remainder asking for it is one whose work cannot be skipped.
+
+    The type is compared exactly rather than with `isinstance` because of what this
+    decides -- that a transform need not run at all. A subclass may override `transform`
+    and do something else entirely with `func` still unset, which no inspection here
+    would catch. Refusing a harmless subclass costs a fallback; accepting an unfaithful
+    one costs the result.
     """
     if isinstance(remainder, str):
         return remainder == "passthrough"
-    return type(remainder) is FunctionTransformer and remainder.func is None
+    return (
+        type(remainder) is FunctionTransformer
+        and remainder.func is None
+        and not remainder.validate
+    )
 
 
 class EfficientColumnTransformer(ColumnTransformer):

--- a/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
+++ b/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
@@ -488,6 +488,13 @@ class EfficientColumnTransformer(ColumnTransformer):
                     if index is None:
                         index, next_index = next_index, next_index + 1
                     indices.append(index)
+                # The gather below is a full-size copy, and the one order it need not
+                # restore is the one already there: a stack whose transformed block
+                # holds the columns it came from is handed back as `ColumnTransformer`
+                # built it. Still an array of this call's own -- `_hstack` concatenates
+                # the blocks it stacks -- so a caller may write into it either way.
+                if all(index == position for position, index in enumerate(indices)):
+                    continue
                 # restore the column order from before the transfomer has been applied
                 X = X.iloc[:, indices] if isinstance(X, pd.DataFrame) else X[:, indices]
         return X

--- a/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
+++ b/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
@@ -174,10 +174,14 @@ class EfficientColumnTransformer(ColumnTransformer):
 
     def _may_assemble(self, X: XType, params: dict[str, Any]) -> bool:
         """Whether an output of this shape could be written into one array at all."""
-        # Routed metadata is declined outright: nothing assembled here has any use for
-        # it. So is an input that is neither an array nor a frame -- a sparse one would
-        # come back dense, which is not what `ColumnTransformer` hands back.
-        if params or not isinstance(X, (np.ndarray, pd.DataFrame)):
+        if (
+            # extra fit/predict params would be ignored:
+            params
+            # no transformer weight support:
+            or self.transformer_weights
+            # input can't be metadata:
+            or not isinstance(X, (np.ndarray, pd.DataFrame))
+        ):
             return False
         output_config = getattr(self, "_sklearn_output_config", {}).get(
             "transform", get_config()["transform_output"]

--- a/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
+++ b/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
@@ -412,8 +412,13 @@ class EfficientColumnTransformer(ColumnTransformer):
                 # column wasn't input to the transformer
                 index, next_index = next_index, next_index + 1
             indices.append(index)
-        # nothing moved, and the gather below is a full-size copy
-        if all(index == position for position, index in enumerate(indices)):
+        # Nothing moved, and the gather below is a full-size copy -- but only skipped
+        # where it would also leave the layout alone, since it hands back a
+        # Fortran-contiguous array whatever it was given and `_assembled_order` says
+        # what reads that. A frame has no such layout to keep.
+        if all(index == position for position, index in enumerate(indices)) and (
+            not isinstance(X, np.ndarray) or X.flags.f_contiguous
+        ):
             return X
         # restore the column order from before the transformer has been applied
         return X.iloc[:, indices] if isinstance(X, pd.DataFrame) else X[:, indices]

--- a/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
+++ b/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
@@ -97,7 +97,7 @@ class EfficientColumnTransformer(ColumnTransformer):
         Decided on the same conditions as the assembly, so the state left here is either
         sklearn's own or one those conditions vouch for.
         """
-        if not (y is None and self._is_one_to_one and self._may_assemble(X, params)):
+        if not self._may_assemble_a_fit(X, y, params):
             return super().fit(X, y, **params)
         # widths and output positions do not depend on the row count here, so one row
         # settles all of the bookkeeping
@@ -114,7 +114,7 @@ class EfficientColumnTransformer(ColumnTransformer):
     def fit_transform(self, X: XType, y: YType = None, **params: Any) -> XType:
         """Fit and transform, writing each column straight to its final place."""
         original_columns = _input_columns(X)
-        if not (y is None and self._is_one_to_one and self._may_assemble(X, params)):
+        if not self._may_assemble_a_fit(X, y, params):
             return self._maybe_in_input_order(
                 super().fit_transform(X, y, **params), original_columns
             )
@@ -153,6 +153,24 @@ class EfficientColumnTransformer(ColumnTransformer):
         """
         _, selected = self._named_selection()
         return selected or []
+
+    def _may_assemble_a_fit(self, X: XType, y: YType, params: dict[str, Any]) -> bool:
+        """Whether a fit over this input can be assembled instead of stacked."""
+        return (
+            y is None
+            and self._is_one_to_one
+            and self._selects_the_same_from_one_row
+            and self._may_assemble(X, params)
+        )
+
+    @property
+    def _selects_the_same_from_one_row(self) -> bool:
+        """Whether every column selection can be made based on a single row."""
+        return all(
+            not callable(columns) or isinstance(columns, make_column_selector)
+            for name, _, columns in self.transformers
+            if name != "remainder"
+        )
 
     def _may_assemble(self, X: XType, params: dict[str, Any]) -> bool:
         """Whether an output of this shape could be written into one array at all."""

--- a/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
+++ b/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
@@ -467,31 +467,36 @@ class EfficientColumnTransformer(ColumnTransformer):
     def _in_input_order(
         self, X: XType, original_columns: list | range | pd.Index
     ) -> XType:
+        """`X` with the columns back where the input had them.
+
+        Every column is somewhere in `ColumnTransformer`'s two blocks: at its rank in
+        the selection, or, unselected, at the next place after that block.
+        """
         check_is_fitted(self)
         assert X.ndim == 2, f"Expected 2D input, got {X.ndim}D (shape={X.shape})"
-        for name, _, col_subset in reversed(self.transformers_):
-            if (
-                len(col_subset) > 0
-                and len(col_subset) < X.shape[-1]
-                and name != "remainder"
-            ):
-                # where each processed  column landed in X
-                rank = {column: index for index, column in enumerate(col_subset)}
-                # next free index to use for untransformed columns
-                next_index = len(col_subset)
-                # indices[i] is the column index in X corresponding to input column i
-                indices = []
-                for column in original_columns:
-                    index = rank.get(column)
-                    if index is None:
-                        # column wasn't input to the transformer
-                        index, next_index = next_index, next_index + 1
-                    indices.append(index)
-                if all(index == position for position, index in enumerate(indices)):
-                    continue
-                # restore the column order from before the transformer has been applied
-                X = X.iloc[:, indices] if isinstance(X, pd.DataFrame) else X[:, indices]
-        return X
+        name, selected = self._named_selection()
+        if selected is None:
+            raise TypeError(
+                f"The {name!r} transformer selects its columns by something other than "
+                "a list of keys, which cannot be placed back in the input's order."
+            )
+        # where each processed column landed in X
+        rank = {column: index for index, column in enumerate(selected)}
+        # next free index to use for untransformed columns
+        next_index = len(selected)
+        # indices[i] is the column index in X corresponding to input column i
+        indices = []
+        for column in original_columns:
+            index = rank.get(column)
+            if index is None:
+                # column wasn't input to the transformer
+                index, next_index = next_index, next_index + 1
+            indices.append(index)
+        # nothing moved, and the gather below is a full-size copy
+        if all(index == position for position, index in enumerate(indices)):
+            return X
+        # restore the column order from before the transformer has been applied
+        return X.iloc[:, indices] if isinstance(X, pd.DataFrame) else X[:, indices]
 
 
 class OrderPreservingColumnTransformer(EfficientColumnTransformer):
@@ -505,11 +510,7 @@ class OrderPreservingColumnTransformer(EfficientColumnTransformer):
             tuple[
                 str,
                 BaseEstimator,
-                str
-                | int
-                | slice
-                | Iterable[str | int]
-                | Callable[[Any], Iterable[str | int]],
+                Iterable[str | int] | Callable[[Any], Iterable[str | int]],
             ]
         ],
         **kwargs: Any,
@@ -537,6 +538,17 @@ class OrderPreservingColumnTransformer(EfficientColumnTransformer):
 
         assert len([t for name, _, t in transformers if name != "remainder"]) <= 1, (
             "OrderPreservingColumnTransformer only supports up to one transformer."
+        )
+
+        # Restoring the input order places one column at a time, by key
+        assert all(
+            callable(columns) or isinstance(columns, (list, np.ndarray, pd.Index))
+            for name, _, columns in transformers
+            if name != "remainder"
+        ), (
+            "OrderPreservingColumnTransformer only supports selecting columns by a "
+            "list of keys, or a callable returning one -- not by a slice or a single "
+            "label."
         )
 
 

--- a/src/tabpfn/preprocessing/steps/reshape_feature_distribution_step.py
+++ b/src/tabpfn/preprocessing/steps/reshape_feature_distribution_step.py
@@ -265,6 +265,8 @@ class ReshapeFeatureDistributionsStep(PreprocessingStep):
         """Whether this step's transformer would hand the data back untouched, in which
         case it is not built and the data pass is skipped. ``None`` until fitted, so
         "not fitted yet" stays distinguishable from "fitted to a no-op"."""
+        self.column_order_: list[int] | None = None
+        """Input columns in output order, when this step only reorders them."""
 
     def _create_transformers_and_new_schema(
         self,
@@ -371,16 +373,33 @@ class ReshapeFeatureDistributionsStep(PreprocessingStep):
         self._set_ancestors(new_schema, feature_schema, layout)
 
         # A transform scheduled onto the GPU leaves "none" behind on this side, which
-        # the registry maps to the identity `FunctionTransformer`.
-        self.data_is_unchanged_ = (
+        # the registry maps to the identity `FunctionTransformer`. Then the only thing
+        # the ColumnTransformer still does to the data is move columns, and it pays two
+        # full-size arrays to do it: one for the blocks, one for the hstack.
+        passes_values_through = (
             # FunctionTransformer(func=None, validate=False) is the identity function
             isinstance(_transformer, FunctionTransformer)
             and _transformer.func is None
             and not _transformer.validate
-            # also check if the column order should change
-            and [column.source_ix for column in layout] == all_feats_ix
         )
-        self.transformer_ = None if self.data_is_unchanged_ else transformer
+        source_order = [column.source_ix for column in layout]
+        self.data_is_unchanged_ = passes_values_through and source_order == all_feats_ix
+        # Every input column used exactly once, only in a different place: one gather
+        # gets there in a single array. Anything else -- a column dropped, duplicated
+        # by append_to_original, or a multi-output transform -- fails the sort and
+        # keeps the ColumnTransformer.
+        self.column_order_ = (
+            source_order
+            if passes_values_through
+            and not self.data_is_unchanged_
+            and sorted(source_order) == all_feats_ix
+            else None
+        )
+        self.transformer_ = (
+            None
+            if self.data_is_unchanged_ or self.column_order_ is not None
+            else transformer
+        )
 
         if self.schedule_gpu_transform is not None:
             if self.append_to_original_decision_:
@@ -458,6 +477,8 @@ class ReshapeFeatureDistributionsStep(PreprocessingStep):
         # so the skip is off for it and the assert below is what reports "not fitted".
         if getattr(self, "data_is_unchanged_", False):
             return X, None, None
+        if self.column_order_ is not None:
+            return X[:, self.column_order_], None, None
         assert self.transformer_ is not None, "You must call fit first"
         return self.transformer_.transform(X), None, None
 
@@ -484,7 +505,12 @@ class ReshapeFeatureDistributionsStep(PreprocessingStep):
             n_features,
             feature_schema,
         )
-        x_transformed = X if transformer is None else transformer.fit_transform(X)
+        if transformer is not None:
+            x_transformed = transformer.fit_transform(X)
+        elif self.column_order_ is not None:
+            x_transformed = X[:, self.column_order_]
+        else:
+            x_transformed = X
         self.transformer_ = transformer
         self.feature_schema_updated_ = output_schema
 

--- a/src/tabpfn/preprocessing/steps/reshape_feature_distribution_step.py
+++ b/src/tabpfn/preprocessing/steps/reshape_feature_distribution_step.py
@@ -477,8 +477,9 @@ class ReshapeFeatureDistributionsStep(PreprocessingStep):
         # so the skip is off for it and the assert below is what reports "not fitted".
         if getattr(self, "data_is_unchanged_", False):
             return X, None, None
-        if self.column_order_ is not None:
-            return X[:, self.column_order_], None, None
+        column_order = getattr(self, "column_order_", None)
+        if column_order is not None:
+            return X[:, column_order], None, None
         assert self.transformer_ is not None, "You must call fit first"
         return self.transformer_.transform(X), None, None
 

--- a/src/tabpfn/preprocessing/steps/reshape_feature_distribution_step.py
+++ b/src/tabpfn/preprocessing/steps/reshape_feature_distribution_step.py
@@ -41,7 +41,10 @@ from tabpfn.preprocessing.steps.kdi_transformer import (
 )
 from tabpfn.preprocessing.steps.safe_power_transformer import SafePowerTransformer
 from tabpfn.preprocessing.steps.squashing_scaler_transformer import SquashingScaler
-from tabpfn.preprocessing.steps.utils import wrap_with_safe_standard_scaler
+from tabpfn.preprocessing.steps.utils import (
+    is_identity_transformer,
+    wrap_with_safe_standard_scaler,
+)
 from tabpfn.utils import infer_random_state
 
 if TYPE_CHECKING:
@@ -376,12 +379,7 @@ class ReshapeFeatureDistributionsStep(PreprocessingStep):
         # the registry maps to the identity `FunctionTransformer`. Then the only thing
         # the ColumnTransformer still does to the data is move columns, and it pays two
         # full-size arrays to do it: one for the blocks, one for the hstack.
-        passes_values_through = (
-            # FunctionTransformer(func=None, validate=False) is the identity function
-            isinstance(_transformer, FunctionTransformer)
-            and _transformer.func is None
-            and not _transformer.validate
-        )
+        passes_values_through = is_identity_transformer(_transformer)
         source_order = [column.source_ix for column in layout]
         self.data_is_unchanged_ = passes_values_through and source_order == all_feats_ix
         # Every input column used exactly once, only in a different place: one gather

--- a/src/tabpfn/preprocessing/steps/utils.py
+++ b/src/tabpfn/preprocessing/steps/utils.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from typing_extensions import override
 
 import numpy as np
@@ -14,6 +14,35 @@ from sklearn.preprocessing import FunctionTransformer, StandardScaler
 
 if TYPE_CHECKING:
     from sklearn.base import TransformerMixin
+
+
+def is_identity_transformer(transformer: Any) -> bool:
+    """Whether `transformer` hands back what it is given, untouched.
+
+    Used to decide that a transform need not be run at all -- so it answers only for the
+    cases where that is provable, and declines everything else.
+
+    `"passthrough"` says so outright. A `FunctionTransformer` qualifies when it has no
+    `func` *and* does not validate: `validate=True` is not nothing, it sends the input
+    through `check_array`, which coerces the dtype and refuses a NaN that would
+    otherwise pass. Its remaining arguments cannot reach the values -- `kw_args` only
+    applies to a `func`, `check_inverse` is skipped without one, `accept_sparse` only
+    matters under `validate`, and `inverse_func` and `feature_names_out` are not on the
+    forward path.
+
+    The type is compared exactly rather than with `isinstance` because of what this
+    decides. A subclass may override `transform` and do something else entirely with
+    `func` still unset, and no inspection here would catch it. Refusing a harmless
+    subclass costs whichever fallback the caller keeps for the general case; accepting
+    an unfaithful one costs the result.
+    """
+    if isinstance(transformer, str):
+        return transformer == "passthrough"
+    return (
+        type(transformer) is FunctionTransformer
+        and transformer.func is None
+        and not transformer.validate
+    )
 
 
 def make_scaler_safe(name: str, scaler: TransformerMixin) -> Pipeline:

--- a/src/tabpfn/preprocessing/steps/utils.py
+++ b/src/tabpfn/preprocessing/steps/utils.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 from typing_extensions import override
 
 import numpy as np
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from sklearn.base import TransformerMixin
 
 
-def is_identity_transformer(transformer: Any) -> bool:
+def is_identity_transformer(transformer: str | TransformerMixin) -> bool:
     """Whether `transformer` hands back what it is given, untouched.
 
     Used to decide that a transform need not be run at all -- so it answers only for the

--- a/tests/test_preprocessing/test_data_cleaning.py
+++ b/tests/test_preprocessing/test_data_cleaning.py
@@ -20,7 +20,6 @@ from tabpfn.preprocessing import (
 )
 from tabpfn.preprocessing.clean import (
     _is_single_float_block,
-    _owned_float64_values,
     fix_dtypes,
     process_text_na_dataframe,
 )
@@ -853,89 +852,16 @@ def test__fix_dtypes__mixed_numeric_dtypes_are_still_cast() -> None:
     assert np.isnan(frame["a"].to_numpy()[2])
 
 
-# --- ownership of the identity path's output -------------------------------------
+# --- the frozen shortcut, end to end --------------------------------------------
 #
-# The identity path hands its array straight to the caller, who writes into it, so it
-# has to own it. How many copies that takes depends on the frame's block layout,
-# which is what these two pin.
-
-
-def _fragmented_float_frame(values: np.ndarray) -> pd.DataFrame:
-    """A float frame held as one block per column, as a recast frame is left."""
-    frame = pd.DataFrame(values)
-    frame[frame.columns] = frame[frame.columns].astype(values.dtype)
-    return frame
-
-
-def test__owned_float64_values__assembles_a_multi_block_frame_in_one_buffer() -> None:
-    """A frame of many blocks is assembled directly, never routed through `to_numpy`.
-
-    Asserted through the frame rather than the result, because what the result looks
-    like depends on the pandas: `to_numpy` consolidates the frame in place before
-    pandas 3, so a run that went through it would cost a second full-size buffer and
-    leave the frame holding one block instead of many.
-    """
-    values = np.random.default_rng(0).standard_normal((8, 5))
-    frame = _fragmented_float_frame(values)
-    assert not _is_single_float_block(frame)
-
-    out = _owned_float64_values(frame)
-
-    np.testing.assert_array_equal(out, values)
-    assert out.flags.writeable
-    assert out.flags.f_contiguous
-    assert not np.shares_memory(out, values)
-    # Still one block per column: nothing consolidated it on the way.
-    assert not _is_single_float_block(frame)
-    # And the buffer is the caller's alone -- writing into it cannot reach the frame.
-    assert not any(
-        np.shares_memory(out, frame.iloc[:, position].to_numpy(copy=False))
-        for position in range(frame.shape[1])
-    )
-
-
-def test__owned_float64_values__copies_a_single_block_frame() -> None:
-    """A single-block frame is handed out as a view of the array it was built from."""
-    values = np.random.default_rng(0).standard_normal((8, 5))
-    frame = pd.DataFrame(values, copy=False)
-    assert _is_single_float_block(frame)
-    assert np.shares_memory(frame.to_numpy(dtype=np.float64, copy=False), values)
-
-    out = _owned_float64_values(frame)
-
-    np.testing.assert_array_equal(out, values)
-    assert out.flags.writeable
-    assert out.flags.f_contiguous
-    # Writing into the result must not reach the caller's array. Under copy-on-write
-    # the view is read-only, but on pandas 2 it is writeable and aliases `values`.
-    assert not np.shares_memory(out, values)
-    out[0, 0] = 12345.0
-    assert values[0, 0] != 12345.0
-
-
-# --- the frozen shortcut's preconditions -----------------------------------------
-#
-# At predict time the encoding step is skipped when a fitted encoder selected no
-# columns. Skipping `transform` skips its checks too, so the shortcut is only taken
-# for a frame `transform` would have handled the same way.
+# At predict time the encoding step is a cast whenever the fitted encoder selected no
+# columns. Skipping `transform` skips its checks too, so the shortcut is only taken for
+# a frame `transform` would have handled the same way -- see
+# `EfficientColumnTransformer._changes_no_value`, which decides it.
 
 
 def _float_frame(**columns: list[float]) -> pd.DataFrame:
     return pd.DataFrame({name: np.array(values) for name, values in columns.items()})
-
-
-def test__encoding_is_identity__an_unfitted_encoder_is_not_an_empty_selection() -> None:
-    """An encoder that never selected anything because it was never fitted.
-
-    It has no selection to read, which must not be mistaken for having selected no
-    columns -- that would hand the frame back unencoded instead of failing.
-    """
-    with pytest.raises(AttributeError):
-        clean_module._encoding_is_identity(
-            _float_frame(a=[1.0, 2.0], b=[3.0, 4.0]),
-            get_ordinal_encoder(),
-            fit_encoder=False,
-        )
 
 
 def test__process_text_na_dataframe__frozen_shortcut_rejects_a_narrower_frame() -> None:
@@ -972,11 +898,14 @@ def test__process_text_na_dataframe__frozen_shortcut_taken_when_lined_up() -> No
     encoder.fit(frame)
 
     with mock.patch.object(
-        clean_module, "_owned_float64_values", wraps=clean_module._owned_float64_values
+        EfficientColumnTransformer,
+        "_assemble",
+        autospec=True,
+        side_effect=EfficientColumnTransformer._assemble,
     ) as shortcut:
         out = process_text_na_dataframe(frame, ord_encoder=encoder)
 
-    assert shortcut.call_count == 1
+    assert shortcut.call_count == 1, "went through ColumnTransformer.transform"
     np.testing.assert_array_equal(out, frame.to_numpy())
 
 
@@ -1126,6 +1055,13 @@ def test__cast_columns__a_shared_block_is_never_assigned_into() -> None:
 
     assert list(out.dtypes[1::2].map(str)) == ["category"] * 3
     assert list(out.dtypes[0::2].map(str)) == ["object"] * 3
+
+
+def _fragmented_float_frame(values: np.ndarray) -> pd.DataFrame:
+    """A float frame held as one block per column, as a recast frame is left."""
+    frame = pd.DataFrame(values)
+    frame[frame.columns] = frame[frame.columns].astype(values.dtype)
+    return frame
 
 
 def test__cast_columns__a_block_per_column_frame_keeps_its_own_columns() -> None:

--- a/tests/test_preprocessing/test_data_cleaning.py
+++ b/tests/test_preprocessing/test_data_cleaning.py
@@ -25,7 +25,10 @@ from tabpfn.preprocessing.clean import (
     process_text_na_dataframe,
 )
 from tabpfn.preprocessing.datamodel import Feature, FeatureModality, FeatureSchema
-from tabpfn.preprocessing.steps.preprocessing_helpers import get_ordinal_encoder
+from tabpfn.preprocessing.steps.preprocessing_helpers import (
+    EfficientColumnTransformer,
+    get_ordinal_encoder,
+)
 from tabpfn.validation import ensure_compatible_fit_inputs
 
 
@@ -1003,9 +1006,11 @@ def test__clean_data__mixed_columns_take_the_assembly_path() -> None:
     """The assembly is used, and its result is placed by column, not by transformer."""
     X, schema = _mixed_frame_inputs()
 
-    with mock.patch(
-        "tabpfn.preprocessing.clean._encode_into_preallocated",
-        wraps=clean_module._encode_into_preallocated,
+    with mock.patch.object(
+        EfficientColumnTransformer,
+        "_assemble",
+        autospec=True,
+        side_effect=EfficientColumnTransformer._assemble,
     ) as assembled:
         out, _encoder, _ = clean_data(X=X, feature_schema=schema)
 
@@ -1079,9 +1084,8 @@ def test__clean_data__object_passthrough_falls_back_to_the_encoder() -> None:
     )
     encoder = get_ordinal_encoder()
 
-    assert not clean_module._can_write_encoded_columns(
-        frame, clean_module._encoder_selection(encoder.fit(frame.iloc[:1]))
-    )
+    encoder.fit(frame.iloc[:1])
+    assert not encoder._can_assemble(frame, frame.iloc[:1], encoder.selected_columns())
     # The real call still works, through sklearn, and learns the categories exactly
     # once. Declining the assembly *after* fitting them would pay for a second pass
     # over the data and then discard it, since `fit_transform` fits again itself.

--- a/tests/test_preprocessing/test_encode_categorical_features_step.py
+++ b/tests/test_preprocessing/test_encode_categorical_features_step.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import numpy as np
 import pytest
+from sklearn.compose import ColumnTransformer
 
 from tabpfn.preprocessing.datamodel import (
     Feature,
@@ -17,9 +18,7 @@ from tabpfn.preprocessing.datamodel import (
 )
 from tabpfn.preprocessing.pipeline_interface import PreprocessingPipeline
 from tabpfn.preprocessing.steps import EncodeCategoricalFeaturesStep
-from tabpfn.preprocessing.steps.encode_categorical_features_step import (
-    _encode_into_preallocated,
-)
+from tabpfn.preprocessing.steps.preprocessing_helpers import EfficientColumnTransformer
 
 
 def _make_feature_schema(n_features: int, cat_indices: list[int]) -> FeatureSchema:
@@ -558,9 +557,9 @@ class TestCarryOverGpuTransformMarks:
 # The preallocated assembly against the ColumnTransformer it replaces
 # ---------------------------------------------------------------------------
 #
-# `_encode_into_preallocated` exists only to reach `ColumnTransformer`'s result with
-# fewer full-size arrays, so sklearn is the oracle: these compare against a
-# ColumnTransformer fitted the ordinary way and fail on any drift from it.
+# The step's `EfficientColumnTransformer` exists only to reach `ColumnTransformer`'s
+# result with fewer full-size arrays, so sklearn is the oracle: these compare against a
+# plain ColumnTransformer over the same transformers and fail on any drift from it.
 
 
 def _ordinal_case(
@@ -582,6 +581,14 @@ def _ordinal_case(
     return X.astype(dtype)
 
 
+def _plain_column_transformer(
+    X: np.ndarray, cat_indices: list[int]
+) -> ColumnTransformer:
+    """The step's ordinal transformer as a stock `ColumnTransformer`: the oracle."""
+    ct, _ = EncodeCategoricalFeaturesStep("ordinal")._get_transformer(X, cat_indices)
+    return ColumnTransformer(list(ct.transformers), remainder=ct.remainder)
+
+
 @pytest.mark.parametrize(
     ("dtype", "cat_indices", "with_nan"),
     [
@@ -599,7 +606,7 @@ def _ordinal_case(
         pytest.param(np.float64, [0, 1, 2, 3], False, id="one-passthrough"),
     ],
 )
-def test__encode_into_preallocated__matches_column_transformer(
+def test__efficient_column_transformer__matches_column_transformer(
     dtype: Any,
     cat_indices: list[int],
     with_nan: bool,
@@ -613,17 +620,13 @@ def test__encode_into_preallocated__matches_column_transformer(
     """
     X = _ordinal_case(dtype, cat_indices, with_nan=with_nan)
 
-    step = EncodeCategoricalFeaturesStep("ordinal", random_state=0)
-    reference_ct, _ = step._get_transformer(X, cat_indices)
-    reference = reference_ct.fit_transform(X)
+    ct, _ = EncodeCategoricalFeaturesStep("ordinal")._get_transformer(X, cat_indices)
+    assert isinstance(ct, EfficientColumnTransformer)
+    reference = ColumnTransformer(
+        list(ct.transformers), remainder=ct.remainder
+    ).fit_transform(X)
 
-    ct, ct_cat_features = step._get_transformer(X, cat_indices)
-    # What the step does: the column bookkeeping from one row, the codes from all.
-    ct.fit(X[:1])
-    codes = ct.named_transformers_["ordinal_encoder"].fit_transform(
-        X[:, ct_cat_features]
-    )
-    assembled = _encode_into_preallocated(X, codes, ct_cat_features)
+    assembled = ct.fit_transform(X)
 
     assert assembled.shape == reference.shape
     assert assembled.dtype == reference.dtype
@@ -647,10 +650,7 @@ def test__encode_categorical__ordinal__step_output_matches_column_transformer() 
     step = EncodeCategoricalFeaturesStep("ordinal", random_state=0)
     result = step.fit_transform(X.copy(), schema)
 
-    reference_ct, _ = EncodeCategoricalFeaturesStep(
-        "ordinal", random_state=0
-    )._get_transformer(X, cat_indices)
-    reference = reference_ct.fit_transform(X)
+    reference = _plain_column_transformer(X, cat_indices).fit_transform(X)
 
     np.testing.assert_array_equal(result.X, reference)
     assert np.isfortran(result.X) == np.isfortran(reference)
@@ -671,9 +671,7 @@ def test__encode_categorical__ordinal__one_row_fit_learns_every_category() -> No
     step = EncodeCategoricalFeaturesStep("ordinal", random_state=0)
     step.fit_transform(X.copy(), schema)
 
-    reference_ct, _ = EncodeCategoricalFeaturesStep(
-        "ordinal", random_state=0
-    )._get_transformer(X, cat_indices)
+    reference_ct = _plain_column_transformer(X, cat_indices)
     reference_ct.fit(X)
 
     fitted = step.categorical_transformer_.named_transformers_["ordinal_encoder"]

--- a/tests/test_preprocessing/test_encode_categorical_features_step.py
+++ b/tests/test_preprocessing/test_encode_categorical_features_step.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import numpy as np
 import pytest
 
@@ -15,6 +17,9 @@ from tabpfn.preprocessing.datamodel import (
 )
 from tabpfn.preprocessing.pipeline_interface import PreprocessingPipeline
 from tabpfn.preprocessing.steps import EncodeCategoricalFeaturesStep
+from tabpfn.preprocessing.steps.encode_categorical_features_step import (
+    _encode_into_preallocated,
+)
 
 
 def _make_feature_schema(n_features: int, cat_indices: list[int]) -> FeatureSchema:
@@ -547,3 +552,132 @@ class TestCarryOverGpuTransformMarks:
 
         marked = result.feature_schema.get_indices_marked_for_gpu_quantile_transform()
         assert marked == []
+
+
+# ---------------------------------------------------------------------------
+# The preallocated assembly against the ColumnTransformer it replaces
+# ---------------------------------------------------------------------------
+#
+# `_encode_into_preallocated` exists only to reach `ColumnTransformer`'s result with
+# fewer full-size arrays, so sklearn is the oracle: these compare against a
+# ColumnTransformer fitted the ordinary way and fail on any drift from it.
+
+
+def _ordinal_case(
+    dtype: Any,
+    cat_indices: list[int],
+    *,
+    with_nan: bool,
+    n_samples: int = 60,
+    n_features: int = 5,
+) -> np.ndarray:
+    """A table whose `cat_indices` columns are low-cardinality."""
+    rng = np.random.default_rng(0)
+    X = rng.random((n_samples, n_features))
+    for index in cat_indices:
+        X[:, index] = rng.integers(0, 4, size=n_samples).astype(float)
+    if with_nan:
+        X[0, cat_indices[0]] = np.nan
+        X[5, (cat_indices[0] + 1) % n_features] = np.nan
+    return X.astype(dtype)
+
+
+@pytest.mark.parametrize(
+    ("dtype", "cat_indices", "with_nan"),
+    [
+        pytest.param(np.float64, [0, 1], False, id="leading-categoricals"),
+        pytest.param(np.float64, [1, 3], False, id="scattered-categoricals"),
+        pytest.param(np.float64, [0, 1, 2, 3, 4], False, id="every-column-categorical"),
+        pytest.param(np.float64, [2], False, id="one-categorical"),
+        pytest.param(np.float32, [1, 3], False, id="float32-promoted-by-hstack"),
+        pytest.param(object, [1, 3], False, id="object-dtype"),
+        pytest.param(np.float64, [1, 3], True, id="missing-values"),
+        # Corner cases for the output layout: a single encoded column, and a single
+        # passthrough column, each make their block Fortran-compatible and so flip the
+        # order `hstack` picks.
+        pytest.param(np.float64, [0], False, id="one-categorical-leading"),
+        pytest.param(np.float64, [0, 1, 2, 3], False, id="one-passthrough"),
+    ],
+)
+def test__encode_into_preallocated__matches_column_transformer(
+    dtype: Any,
+    cat_indices: list[int],
+    with_nan: bool,
+) -> None:
+    """The assembly must not drift from the ColumnTransformer it stands in for.
+
+    Values, dtype and memory layout are all checked. The layout is not cosmetic: the
+    sklearn SVD that can run downstream of this step converges to a different basis on
+    a C- than on a Fortran-contiguous input, so a layout drift would quietly rotate
+    those features.
+    """
+    X = _ordinal_case(dtype, cat_indices, with_nan=with_nan)
+
+    step = EncodeCategoricalFeaturesStep("ordinal", random_state=0)
+    reference_ct, _ = step._get_transformer(X, cat_indices)
+    reference = reference_ct.fit_transform(X)
+
+    ct, ct_cat_features = step._get_transformer(X, cat_indices)
+    # What the step does: the column bookkeeping from one row, the codes from all.
+    ct.fit(X[:1])
+    codes = ct.named_transformers_["ordinal_encoder"].fit_transform(
+        X[:, ct_cat_features]
+    )
+    assembled = _encode_into_preallocated(X, codes, ct_cat_features)
+
+    assert assembled.shape == reference.shape
+    assert assembled.dtype == reference.dtype
+    assert np.isfortran(assembled) == np.isfortran(reference)
+    np.testing.assert_array_equal(
+        np.asarray(assembled, dtype=np.float64),
+        np.asarray(reference, dtype=np.float64),
+    )
+
+
+def test__encode_categorical__ordinal__step_output_matches_column_transformer() -> None:
+    """End to end: the step's array is the one a plain ColumnTransformer would build.
+
+    Covers the fit path as a whole, including the one-row fit the assembly relies on,
+    which the helper-level test above takes as given.
+    """
+    cat_indices = [1, 3]
+    X = _ordinal_case(np.float64, cat_indices, with_nan=True)
+    schema = _make_feature_schema(X.shape[1], cat_indices)
+
+    step = EncodeCategoricalFeaturesStep("ordinal", random_state=0)
+    result = step.fit_transform(X.copy(), schema)
+
+    reference_ct, _ = EncodeCategoricalFeaturesStep(
+        "ordinal", random_state=0
+    )._get_transformer(X, cat_indices)
+    reference = reference_ct.fit_transform(X)
+
+    np.testing.assert_array_equal(result.X, reference)
+    assert np.isfortran(result.X) == np.isfortran(reference)
+
+
+def test__encode_categorical__ordinal__one_row_fit_learns_every_category() -> None:
+    """Fitting the transformer on one row must not cost the encoder its categories.
+
+    The assembly fits the ColumnTransformer on a single row -- `fit` is implemented as
+    `fit_transform`, so fitting on everything would run the pass being replaced -- and
+    then fits the inner encoder on all rows. If that second fit were dropped, unseen
+    values would silently encode as NaN.
+    """
+    cat_indices = [1, 3]
+    X = _ordinal_case(np.float64, cat_indices, with_nan=False)
+    schema = _make_feature_schema(X.shape[1], cat_indices)
+
+    step = EncodeCategoricalFeaturesStep("ordinal", random_state=0)
+    step.fit_transform(X.copy(), schema)
+
+    reference_ct, _ = EncodeCategoricalFeaturesStep(
+        "ordinal", random_state=0
+    )._get_transformer(X, cat_indices)
+    reference_ct.fit(X)
+
+    fitted = step.categorical_transformer_.named_transformers_["ordinal_encoder"]
+    expected = reference_ct.named_transformers_["ordinal_encoder"]
+    assert len(fitted.categories_) == len(expected.categories_)
+    for learned, wanted in zip(fitted.categories_, expected.categories_, strict=True):
+        np.testing.assert_array_equal(learned, wanted)

--- a/tests/test_preprocessing/test_preprocessing_steps.py
+++ b/tests/test_preprocessing/test_preprocessing_steps.py
@@ -41,6 +41,7 @@ from tabpfn.preprocessing.steps.preprocessing_helpers import (
 from tabpfn.preprocessing.steps.remove_constant_features_step import (
     RemoveConstantFeaturesStep,
 )
+from tabpfn.preprocessing.steps.utils import is_identity_transformer
 
 if TYPE_CHECKING:
     from tabpfn.classifier import XType, YType
@@ -772,3 +773,68 @@ def test__efficient_column_transformer__a_validating_remainder_is_not_a_passthro
     with pytest.raises(ValueError, match="NaN"):
         transformer.fit_transform(X)
     assert assemblies == []
+
+
+# --- the shared identity predicate ------------------------------------------------
+#
+# Two steps decide from it that a transform need not run: the assembly skips a
+# remainder it vouches for, and the reshape step drops its ColumnTransformer for a
+# gather. So it has to answer for the cases where that is provable and decline the rest.
+
+
+class _SneakyFunctionTransformer(FunctionTransformer):
+    """A subclass that transforms without a `func`, which no attribute would reveal."""
+
+    @override
+    def transform(self, X: np.ndarray) -> np.ndarray:
+        return X * 2
+
+
+@pytest.mark.parametrize(
+    ("transformer", "identity", "why"),
+    [
+        pytest.param("passthrough", True, "says so outright", id="passthrough"),
+        pytest.param("drop", False, "drops its columns", id="drop"),
+        pytest.param(FunctionTransformer(), True, "no func, no validation", id="bare"),
+        pytest.param(
+            FunctionTransformer(validate=True),
+            False,
+            "check_array coerces the dtype and refuses a NaN",
+            id="validating",
+        ),
+        pytest.param(
+            FunctionTransformer(func=np.sqrt), False, "has a func", id="with-func"
+        ),
+        pytest.param(
+            FunctionTransformer(func=None, inverse_func=np.sqrt),
+            True,
+            "an inverse is not on the forward path",
+            id="with-inverse-only",
+        ),
+        pytest.param(
+            _SneakyFunctionTransformer(),
+            False,
+            "a subclass may override transform with func still unset",
+            id="subclass",
+        ),
+        pytest.param(OrdinalEncoder(), False, "encodes its columns", id="encoder"),
+    ],
+)
+def test__is_identity_transformer(
+    transformer: object, identity: bool, why: str
+) -> None:
+    """Only what provably hands its input back counts as the identity."""
+    assert is_identity_transformer(transformer) is identity, why
+
+
+def test__is_identity_transformer__is_what_both_callers_use() -> None:
+    """The two steps that skip work on it must not drift back to their own copies."""
+    encoder = get_ordinal_encoder()
+    assert is_identity_transformer(encoder.remainder)
+
+    with mock.patch(
+        "tabpfn.preprocessing.steps.preprocessing_helpers.is_identity_transformer",
+        return_value=False,
+    ):
+        # Declining the remainder has to cost the assembly, not go unnoticed.
+        assert not encoder._may_assemble(_mixed_frame(), {})

--- a/tests/test_preprocessing/test_preprocessing_steps.py
+++ b/tests/test_preprocessing/test_preprocessing_steps.py
@@ -599,6 +599,7 @@ def _reference(
         list(transformer.transformers),
         remainder=transformer.remainder,
         sparse_threshold=transformer.sparse_threshold,
+        transformer_weights=transformer.transformer_weights,
     )
     return plain.fit_transform(X, y)
 
@@ -1039,6 +1040,38 @@ def test__order_preserving_column_transformer__names_the_order_it_returns() -> N
         "n0",
         "n1",
     ]
+
+
+@pytest.mark.parametrize(
+    "cls",
+    [EfficientColumnTransformer, OrderPreservingColumnTransformer],
+    ids=lambda cls: cls.__name__,
+)
+def test__efficient_column_transformer__declines_a_transformer_weight(
+    cls: type[EfficientColumnTransformer], assemblies: list[tuple[int, ...]]
+) -> None:
+    """A weight is `ColumnTransformer`'s to apply, and the assembly goes around it.
+
+    It calls the transformer itself and writes what comes back, so a weight would be
+    dropped on the floor -- and it is a parameter `get_params` exposes, which any
+    sklearn `clone` or `set_params` caller can set.
+    """
+    X = pd.DataFrame(
+        {"a": pd.Series(list("xyz"), dtype="string"), "b": [1.0, 2.0, 3.0]}
+    )
+    transformer = cls(
+        [("encoder", OrdinalEncoder(), ["a"])],
+        remainder=FunctionTransformer(),
+        transformer_weights={"encoder": 10.0},
+        sparse_threshold=0.0,
+    )
+
+    out = transformer.fit_transform(X)
+
+    assert assemblies == []
+    # The selection is 'a' alone, so sklearn's order is the input's here too.
+    np.testing.assert_array_equal(out, _reference(transformer, X))
+    np.testing.assert_array_equal(out[:, 0], [0.0, 10.0, 20.0])
 
 
 @pytest.mark.parametrize(

--- a/tests/test_preprocessing/test_preprocessing_steps.py
+++ b/tests/test_preprocessing/test_preprocessing_steps.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 import inspect
 from collections.abc import Callable
 from functools import partial
+from typing import TYPE_CHECKING
 from typing_extensions import override
+from unittest import mock
 
 import numpy as np
 import pandas as pd
 import pytest
+import sklearn.base
 from sklearn.compose import ColumnTransformer
 from sklearn.preprocessing import (
     FunctionTransformer,
@@ -30,11 +33,16 @@ from tabpfn.preprocessing.steps import (
     ReshapeFeatureDistributionsStep,
 )
 from tabpfn.preprocessing.steps.preprocessing_helpers import (
+    EfficientColumnTransformer,
     OrderPreservingColumnTransformer,
+    get_ordinal_encoder,
 )
 from tabpfn.preprocessing.steps.remove_constant_features_step import (
     RemoveConstantFeaturesStep,
 )
+
+if TYPE_CHECKING:
+    from tabpfn.classifier import XType, YType
 
 
 def _get_schema(num_columns: int) -> FeatureSchema:
@@ -395,3 +403,260 @@ def test__pipeline__num_added_features():
     # This is a minor effect that we ignore for now. In the future,
     # we will make sure that the pipeline never actually sees constant features.
     assert pipeline.num_added_features(100, _get_schema(num_columns=10)) == 1
+
+
+# ---------------------------------------------------------------------------
+# EfficientColumnTransformer against the ColumnTransformer it stands in for
+# ---------------------------------------------------------------------------
+#
+# The class exists only to reach `ColumnTransformer`'s result with fewer full-size
+# arrays, so sklearn is the oracle throughout: every case below compares against a
+# plain `ColumnTransformer` over the same transformers, and says whether the assembly
+# was taken or fallen back from -- a fallback that stops being a fallback is a silent
+# behaviour change, and an assembly that quietly stops being one is a silent
+# regression.
+
+
+def _reference(
+    transformer: EfficientColumnTransformer, X: XType, y: YType = None
+) -> np.ndarray:
+    """What a stock `ColumnTransformer` over the same transformers produces."""
+    plain = ColumnTransformer(
+        list(transformer.transformers),
+        remainder=transformer.remainder,
+        sparse_threshold=transformer.sparse_threshold,
+    )
+    return plain.fit_transform(X, y)
+
+
+@pytest.fixture
+def assemblies(monkeypatch: pytest.MonkeyPatch) -> list[tuple[int, ...]]:
+    """Records the shape of every array the assembly writes into."""
+    written: list[tuple[int, ...]] = []
+    assemble = EfficientColumnTransformer._assemble
+
+    def recording(self: EfficientColumnTransformer, *args: object) -> np.ndarray:
+        out = assemble(self, *args)
+        written.append(out.shape)
+        return out
+
+    monkeypatch.setattr(EfficientColumnTransformer, "_assemble", recording)
+    return written
+
+
+def _mixed_frame() -> pd.DataFrame:
+    """Numeric and string columns, alternating, all passthrough columns float64."""
+    return pd.DataFrame(
+        {
+            "n0": np.arange(6, dtype="float64"),
+            "s0": pd.Series(list("abcabc"), dtype="string"),
+            "n1": np.arange(6, dtype="float64") * 2,
+            "s1": pd.Series(list("xyzxyz"), dtype="string"),
+        }
+    )
+
+
+def test__efficient_column_transformer__assembles_the_column_transformer_layout(
+    assemblies: list[tuple[int, ...]],
+) -> None:
+    """Codes first, then the columns the encoder left, in input order."""
+    X = np.column_stack([np.arange(6.0), np.tile([1.0, 2.0], 3), np.arange(6.0) * 3])
+    transformer = EfficientColumnTransformer(
+        [("encoder", OrdinalEncoder(), [1])], remainder="passthrough"
+    )
+
+    out = transformer.fit_transform(X)
+
+    assert assemblies == [(6, 3)]
+    np.testing.assert_array_equal(out, _reference(transformer, X))
+
+
+def test__efficient_column_transformer__assembles_the_preserved_layout(
+    assemblies: list[tuple[int, ...]],
+) -> None:
+    """Every column at its own position, which is what the reference has to be gathered
+    back into.
+    """
+    X = _mixed_frame()
+    transformer = get_ordinal_encoder()
+
+    out = transformer.fit_transform(X)
+
+    assert assemblies == [(6, 4)]
+    # The reference is the stacked layout: encoded columns first, then the rest.
+    reference = _reference(transformer, X)
+    np.testing.assert_array_equal(out[:, [1, 3]], reference[:, [0, 1]])
+    np.testing.assert_array_equal(out[:, [0, 2]], reference[:, [2, 3]])
+
+
+@pytest.mark.parametrize(
+    ("transformers", "kwargs", "why"),
+    [
+        pytest.param(
+            [("onehot", OneHotEncoder(sparse_output=False), [1])],
+            {},
+            "an expanding transformer has no column to write each output into",
+            id="expanding-transformer",
+        ),
+        pytest.param(
+            [("a", OrdinalEncoder(), [0]), ("b", OrdinalEncoder(), [1])],
+            {},
+            "two transformers can each claim a column",
+            id="two-transformers",
+        ),
+        pytest.param(
+            [("encoder", OrdinalEncoder(), [1])],
+            {"remainder": "drop"},
+            "a dropped remainder does not cover the output",
+            id="dropping-remainder",
+        ),
+        pytest.param(
+            [("encoder", OrdinalEncoder(), slice(1, 2))],
+            {"remainder": "passthrough"},
+            "a slice selection is not a list of column keys",
+            id="slice-selection",
+        ),
+    ],
+)
+def test__efficient_column_transformer__falls_back_and_still_matches_sklearn(
+    transformers: list[tuple],
+    kwargs: dict,
+    why: str,
+    assemblies: list[tuple[int, ...]],
+) -> None:
+    """A shape the assembly cannot place has to come out of sklearn unchanged."""
+    X = np.column_stack([np.arange(6.0), np.tile([1.0, 2.0], 3), np.arange(6.0) * 3])
+    transformer = EfficientColumnTransformer(transformers, **kwargs)
+
+    out = transformer.fit_transform(X)
+
+    assert assemblies == [], why
+    np.testing.assert_array_equal(out, _reference(transformer, X))
+
+
+def test__efficient_column_transformer__a_y_falls_back(
+    assemblies: list[tuple[int, ...]],
+) -> None:
+    """The one-row fit has nothing to line a full-length `y` up with, so decline it."""
+    X = np.column_stack([np.arange(6.0), np.tile([1.0, 2.0], 3)])
+    y = np.arange(6.0)
+    transformer = EfficientColumnTransformer(
+        [("encoder", OrdinalEncoder(), [1])], remainder="passthrough"
+    )
+
+    out = transformer.fit_transform(X, y)
+
+    assert assemblies == []
+    np.testing.assert_array_equal(out, _reference(transformer, X, y))
+
+
+def test__order_preserving_column_transformer__declines_an_object_passthrough(
+    assemblies: list[tuple[int, ...]],
+) -> None:
+    """A frame the assembly cannot write column by column still goes through sklearn.
+
+    `object` is not in the encoder's dtype selection, so it reaches the output through
+    the passthrough; writing it into a float64 array is not the conversion sklearn's own
+    path would have done.
+    """
+    frame = _mixed_frame().assign(o=np.arange(6).astype(object))
+    transformer = get_ordinal_encoder()
+
+    out = transformer.fit_transform(frame)
+
+    assert assemblies == []
+    assert out.shape == frame.shape
+
+
+def test__efficient_column_transformer__declines_duplicate_column_labels() -> None:
+    """Each column is placed by key, so a duplicated one makes its place ambiguous.
+
+    Asserted on the check rather than end to end: sklearn's own column selector refuses
+    such a frame first, and this is what keeps the assembly from being the thing that
+    has to.
+    """
+    frame = _mixed_frame()
+    transformer = get_ordinal_encoder()
+    transformer.fit(frame)
+
+    doubled = frame.iloc[:, [0, 1, 2, 3, 0]]
+    assert not transformer._can_assemble(
+        doubled, doubled.iloc[:1], transformer.selected_columns()
+    )
+
+
+def test__efficient_column_transformer__fit_builds_no_full_size_output() -> None:
+    """`fit` learns everything `ColumnTransformer.fit` does without transforming.
+
+    `ColumnTransformer.fit` is implemented as `fit_transform`, so it pays for a
+    full-size result and throws it away. This asserts the state is identical anyway --
+    it is kept on the estimator and drives `transform` -- and that nothing wider than
+    the one bookkeeping row was ever stacked.
+    """
+    X = np.column_stack([np.arange(6.0), np.tile([1.0, 2.0], 3), np.arange(6.0) * 3])
+    transformer = EfficientColumnTransformer(
+        [("encoder", OrdinalEncoder(), [1])], remainder="passthrough"
+    )
+    stacked: list[int] = []
+    hstack = ColumnTransformer._hstack
+
+    def recording(self: ColumnTransformer, Xs: list, **kwargs: object) -> np.ndarray:
+        stacked.append(max(len(x) for x in Xs))
+        return hstack(self, Xs, **kwargs)
+
+    with mock.patch.object(ColumnTransformer, "_hstack", recording):
+        transformer.fit(X)
+
+    assert stacked == [1], "a full-size result was stacked and discarded"
+
+    reference = ColumnTransformer(
+        list(transformer.transformers), remainder=transformer.remainder
+    ).fit(X)
+    assert transformer.n_features_in_ == reference.n_features_in_
+    assert transformer.output_indices_ == reference.output_indices_
+    for learned, wanted in zip(
+        transformer.named_transformers_["encoder"].categories_,
+        reference.named_transformers_["encoder"].categories_,
+        strict=True,
+    ):
+        np.testing.assert_array_equal(learned, wanted)
+
+
+def test__efficient_column_transformer__transform_keeps_sklearns_validation() -> None:
+    """`transform` is sklearn's, so what it refuses at predict time stays refused."""
+    X = np.column_stack([np.arange(6.0), np.tile([1.0, 2.0], 3), np.arange(6.0) * 3])
+    transformer = EfficientColumnTransformer(
+        [("encoder", OrdinalEncoder(), [1])], remainder="passthrough"
+    )
+    transformer.fit_transform(X)
+
+    np.testing.assert_array_equal(transformer.transform(X), _reference(transformer, X))
+    with pytest.raises(ValueError, match="features"):
+        transformer.transform(X[:, :2])
+
+
+def test__efficient_column_transformer__clones_like_a_column_transformer() -> None:
+    """No parameter may be hidden from `get_params`, or sklearn's `clone` drops it.
+
+    Which is the reason the class declares no `__init__` of its own: sklearn reads the
+    parameter names off that signature, and one taking `**kwargs` reports only what it
+    names -- everything else is silently lost on a clone.
+    """
+    transformers = [("encoder", OrdinalEncoder(), [1])]
+    transformer = EfficientColumnTransformer(
+        transformers,
+        remainder="passthrough",
+        sparse_threshold=0.0,
+        verbose_feature_names_out=False,
+    )
+
+    clone = sklearn.base.clone(transformer)
+
+    assert (
+        transformer.get_params(deep=False).keys()
+        == ColumnTransformer(transformers).get_params(deep=False).keys()
+    )
+    assert clone.remainder == "passthrough"
+    assert clone.sparse_threshold == 0.0
+    assert clone.verbose_feature_names_out is False
+    assert clone.preserves_column_order is transformer.preserves_column_order

--- a/tests/test_preprocessing/test_preprocessing_steps.py
+++ b/tests/test_preprocessing/test_preprocessing_steps.py
@@ -1047,9 +1047,11 @@ def test__efficient_column_transformer__declines_routed_metadata(
     X = _mixed_frame()
     transformer = get_ordinal_encoder()
 
-    # Left to sklearn to accept or refuse -- which without metadata routing enabled
-    # is to refuse. What must not happen is an assembly that ignores it.
-    with pytest.raises(ValueError, match="enable_metadata_routing"):
+    # Left to sklearn to accept or refuse -- which without metadata routing enabled is
+    # to refuse: a `ValueError` saying so, or, on the sklearn 1.2 floor whose
+    # `fit_transform` takes no such parameter at all, a `TypeError` from the call.
+    # What must not happen is an assembly that ignores it.
+    with pytest.raises((TypeError, ValueError), match="sample_weight"):
         transformer.fit_transform(X, None, encoder__sample_weight=np.ones(6))
 
     assert assemblies == []

--- a/tests/test_preprocessing/test_preprocessing_steps.py
+++ b/tests/test_preprocessing/test_preprocessing_steps.py
@@ -504,6 +504,34 @@ def test__order_preserving_column_transformer__already_in_input_order(
     assert out is stacked[-1]
 
 
+def test__order_preserving_column_transformer__skipped_gather_keeps_layout() -> None:
+    """Skipping a gather that changes no position must not change the layout either.
+
+    `_assembled_order` treats the contiguity of what leaves here as load-bearing -- the
+    SVD downstream settles on a different basis per layout -- and the gather leaves a
+    Fortran-contiguous array whatever it was handed. So must skipping it.
+    """
+    rows = 64
+    # The encoded columns lead, so `ColumnTransformer`'s own order is already the
+    # input's and there is nothing for the gather to move. The object column is what
+    # keeps this off the assembly path *and* what makes the stack row-major, so the two
+    # layouts differ here where they would otherwise coincide.
+    X = pd.DataFrame(
+        {
+            "a": pd.Series(["x", "y"] * (rows // 2), dtype="string"),
+            "b": pd.Series(["p", "q"] * (rows // 2), dtype="string"),
+            "c": np.arange(rows, dtype=object),
+            "d": np.arange(rows, dtype=float),
+        }
+    )
+    transformer = get_ordinal_encoder()
+
+    out = transformer.fit_transform(X)
+
+    assert out.flags.f_contiguous
+    np.testing.assert_array_equal(out, transformer.transform(X))
+
+
 def test__pipeline__num_added_features():
     """Test that the pipeline returns the correct number of added features."""
     pipeline = PreprocessingPipeline(

--- a/tests/test_preprocessing/test_preprocessing_steps.py
+++ b/tests/test_preprocessing/test_preprocessing_steps.py
@@ -12,11 +12,14 @@ from unittest import mock
 import numpy as np
 import pandas as pd
 import pytest
+import sklearn
 import sklearn.base
+from scipy import sparse
 from sklearn.compose import ColumnTransformer
 from sklearn.exceptions import NotFittedError
 from sklearn.preprocessing import (
     FunctionTransformer,
+    MaxAbsScaler,
     OneHotEncoder,
     OrdinalEncoder,
 )
@@ -941,6 +944,218 @@ def test__efficient_column_transformer__a_validating_remainder_is_not_a_passthro
     with pytest.raises(ValueError, match="NaN"):
         transformer.fit_transform(X)
     assert assemblies == []
+
+
+# --- what the assembly declines -------------------------------------------------
+#
+# Three shapes reach the same result through sklearn only. What each has in common is
+# that the assembly would not be wrong so much as silently different -- a dense array
+# where a sparse one was asked for, a name where a value was, a routed parameter
+# nobody looked at.
+
+
+@pytest.mark.parametrize("globally", [False, True], ids=["set_output", "config"])
+def test__efficient_column_transformer__declines_a_frame_output(
+    assemblies: list[tuple[int, ...]], *, globally: bool
+) -> None:
+    """A caller asking for a frame gets one, from sklearn, not an array from here.
+
+    Either route to it: the estimator's own `set_output`, or sklearn's global config,
+    which a surrounding `config_context` turns on without touching this estimator at
+    all.
+    """
+    X = _mixed_frame()
+    transformer = get_ordinal_encoder()
+    if not globally:
+        transformer.set_output(transform="pandas")
+
+    with sklearn.config_context(transform_output="pandas" if globally else "default"):
+        out = transformer.fit_transform(X)
+
+    assert assemblies == []
+    assert isinstance(out, pd.DataFrame)
+    # in the input's order, values and names alike
+    assert list(out.columns) == list(X.columns)
+    np.testing.assert_array_equal(out["n0"], X["n0"])
+    np.testing.assert_array_equal(out["n1"], X["n1"])
+
+
+def test__order_preserving_column_transformer__names_the_order_it_returns() -> None:
+    """The names have to be reordered with the columns, not left in sklearn's order.
+
+    Nothing here reads them, but sklearn's `set_output` wrapper does: it labels a
+    frame output with exactly these, over data this class has already reordered. Left
+    alone, every column would be named after whatever used to sit at its position.
+    """
+    X = _mixed_frame()
+    # A named remainder, since `FunctionTransformer` cannot name its own columns and
+    # sklearn refuses to name the output at all through one.
+    transformer = OrderPreservingColumnTransformer(
+        [("encoder", OrdinalEncoder(), ["s0", "s1"])],
+        remainder="passthrough",
+        sparse_threshold=0.0,
+        verbose_feature_names_out=False,
+    ).fit(X)
+
+    assert list(transformer.get_feature_names_out()) == list(X.columns)
+    # The stacked order is still what the parent reports, and what has to be undone.
+    assert list(ColumnTransformer.get_feature_names_out(transformer)) == [
+        "s0",
+        "s1",
+        "n0",
+        "n1",
+    ]
+
+
+def test__efficient_column_transformer__declines_routed_metadata(
+    assemblies: list[tuple[int, ...]],
+) -> None:
+    """A parameter meant for the inner transformer must not be quietly dropped."""
+    X = _mixed_frame()
+    transformer = get_ordinal_encoder()
+
+    # Left to sklearn to accept or refuse -- which without metadata routing enabled
+    # is to refuse. What must not happen is an assembly that ignores it.
+    with pytest.raises(ValueError, match="enable_metadata_routing"):
+        transformer.fit_transform(X, None, encoder__sample_weight=np.ones(6))
+
+    assert assemblies == []
+
+
+def test__efficient_column_transformer__declines_a_sparse_input(
+    assemblies: list[tuple[int, ...]],
+) -> None:
+    """A sparse input keeps sklearn's sparse output, which the assembly cannot write.
+
+    The same transformer over the same values densely *is* assembled, so sparseness is
+    the only reason for the fallback here.
+    """
+    values = np.zeros((10, 4))
+    values[0, 0], values[3, 1], values[5, 2] = 1.0, 2.0, 3.0
+    transformers = [("scaler", MaxAbsScaler(), [1])]
+
+    dense = EfficientColumnTransformer(transformers, remainder="passthrough")
+    dense.fit_transform(values)
+    assert assemblies == [(10, 4)], "the dense input is one the assembly takes"
+
+    transformer = EfficientColumnTransformer(transformers, remainder="passthrough")
+    out = transformer.fit_transform(sparse.csr_matrix(values))
+
+    assert assemblies == [(10, 4)], "a sparse input was assembled"
+    assert transformer.sparse_output_
+    assert sparse.issparse(out)
+    np.testing.assert_array_equal(
+        out.toarray(), _reference(transformer, sparse.csr_matrix(values)).toarray()
+    )
+
+
+def test__efficient_column_transformer__fit_falls_back_to_sklearns_state(
+    assemblies: list[tuple[int, ...]],
+) -> None:
+    """A `fit` the assembly declines has to leave exactly the state sklearn leaves.
+
+    The one-row probe fit runs first and is then thrown away, so what the estimator
+    carries into `transform` is the full fit's -- categories learned from every row
+    included.
+    """
+    frame = _mixed_frame().assign(o=np.arange(6).astype(object))
+    transformer = get_ordinal_encoder().fit(frame)
+    reference = ColumnTransformer(
+        list(transformer.transformers),
+        remainder=transformer.remainder,
+        sparse_threshold=transformer.sparse_threshold,
+    ).fit(frame)
+
+    assert assemblies == [], "an object passthrough column was assembled"
+    assert transformer.n_features_in_ == reference.n_features_in_
+    assert transformer.output_indices_ == reference.output_indices_
+    for learned, wanted in zip(
+        transformer.named_transformers_["encoder"].categories_,
+        reference.named_transformers_["encoder"].categories_,
+        strict=True,
+    ):
+        np.testing.assert_array_equal(learned, wanted)
+
+
+# --- the assembly and the fallback are the same output ----------------------------
+#
+# `fit_transform` assembles where `transform` goes through sklearn, so the two routes
+# have to arrive at the same array -- values, dtype and memory layout. Fit and predict
+# run one each, and a layout that differs between them rotates the SVD's basis
+# downstream on exactly one of the two.
+
+
+@pytest.mark.parametrize("selected", [[1], [0], [0, 2], [1, 2], [0, 1, 2]], ids=str)
+def test__efficient_column_transformer__transform_repeats_the_assembly(
+    selected: list[int], assemblies: list[tuple[int, ...]]
+) -> None:
+    """Every selection over an array, assembled at fit and stacked at transform."""
+    X = np.column_stack([np.arange(6.0), np.tile([1.0, 2.0], 3), np.arange(6.0) * 3])
+    transformer = EfficientColumnTransformer(
+        [("encoder", OrdinalEncoder(), selected)], remainder="passthrough"
+    )
+
+    assembled = transformer.fit_transform(X)
+    stacked = transformer.transform(X)
+
+    assert assemblies == [(6, 3)], "the fit was not assembled"
+    np.testing.assert_array_equal(assembled, stacked)
+    assert assembled.dtype == stacked.dtype
+    assert np.isfortran(assembled) == np.isfortran(stacked)
+
+
+def test__order_preserving_column_transformer__transform_repeats_the_assembly(
+    assemblies: list[tuple[int, ...]],
+) -> None:
+    """The same, where the fallback reaches the input's order through a gather."""
+    X = _mixed_frame()
+    transformer = get_ordinal_encoder()
+
+    assembled = transformer.fit_transform(X)
+    gathered = transformer.transform(X)
+
+    assert assemblies == [(6, 4)], "the fit was not assembled"
+    np.testing.assert_array_equal(assembled, gathered)
+    assert assembled.dtype == gathered.dtype
+    assert np.isfortran(assembled) == np.isfortran(gathered)
+
+
+def test__efficient_column_transformer__assembles_a_frame_in_the_stacked_layout(
+    assemblies: list[tuple[int, ...]],
+) -> None:
+    """A frame through the plain class, whose output order is sklearn's own.
+
+    Every other frame case here goes through the order-preserving subclass, so this is
+    what pins the other half of `_output_positions` -- the transformed columns in their
+    own slice -- for an input whose columns are keyed by name.
+    """
+    X = _mixed_frame()
+    transformer = EfficientColumnTransformer(
+        [("encoder", OrdinalEncoder(), ["s0", "s1"])],
+        remainder=FunctionTransformer(),
+        sparse_threshold=0.0,
+    )
+
+    out = transformer.fit_transform(X)
+    reference = _reference(transformer, X)
+
+    assert assemblies == [(6, 4)]
+    np.testing.assert_array_equal(out, reference)
+    assert out.dtype == reference.dtype
+    assert np.isfortran(out) == np.isfortran(reference)
+
+
+def test__order_preserving_column_transformer__promotes_a_narrower_encoder(
+    assemblies: list[tuple[int, ...]],
+) -> None:
+    """A float32 encoder against float64 passthrough columns: sklearn promotes."""
+    X = _mixed_frame()
+    transformer = get_ordinal_encoder(numpy_dtype=np.float32)  # type: ignore[arg-type]
+
+    out = transformer.fit_transform(X)
+
+    assert assemblies == [(6, 4)]
+    assert out.dtype == _reference(transformer, X).dtype == np.float64
 
 
 # --- the shared identity predicate ------------------------------------------------

--- a/tests/test_preprocessing/test_preprocessing_steps.py
+++ b/tests/test_preprocessing/test_preprocessing_steps.py
@@ -398,6 +398,26 @@ def test__order_preserving_column_transformer__selection_not_a_list_of_keys(
         transformer.fit(X)
 
 
+@pytest.mark.parametrize("remainder", ["drop", OneHotEncoder()])
+def test__order_preserving_column_transformer__remainder_that_drops_columns(
+    remainder: object,
+) -> None:
+    """A column the remainder never hands back has nowhere to go in the input's order.
+
+    'drop' is `ColumnTransformer`'s default, so this is the shape reached by leaving
+    the parameter off entirely.
+    """
+    X = pd.DataFrame({"a": [1.0, 2.0], "b": ["p", "q"]})
+    transformer = OrderPreservingColumnTransformer(
+        transformers=[("encoder", OrdinalEncoder(), ["b"])],
+        remainder=remainder,
+        sparse_threshold=0.0,
+    )
+
+    with pytest.raises(ValueError, match="a remainder that hands every column"):
+        transformer.fit_transform(X)
+
+
 @pytest.mark.parametrize(
     "transformers",
     [

--- a/tests/test_preprocessing/test_preprocessing_steps.py
+++ b/tests/test_preprocessing/test_preprocessing_steps.py
@@ -1155,18 +1155,25 @@ def test__order_preserving_column_transformer__transform_repeats_the_assembly(
     assert np.isfortran(assembled) == np.isfortran(gathered)
 
 
+@pytest.mark.parametrize("selected", [["s0"], ["s0", "s1"]], ids=str)
 def test__efficient_column_transformer__assembles_a_frame_in_the_stacked_layout(
-    assemblies: list[tuple[int, ...]],
+    selected: list[str], assemblies: list[tuple[int, ...]]
 ) -> None:
     """A frame through the plain class, whose output order is sklearn's own.
 
     Every other frame case here goes through the order-preserving subclass, so this is
     what pins the other half of `_output_positions` -- the transformed columns in their
     own slice -- for an input whose columns are keyed by name.
+
+    Both widths of selection, because they land on different layouts: sklearn stacks a
+    column-major output only when the encoder's own block is column-major too, which
+    one column is and two are not.
     """
-    X = _mixed_frame()
+    # Only the selected string columns: an unselected one is not float64, which the
+    # assembly declines outright.
+    X = _mixed_frame().drop(columns=[s for s in ("s0", "s1") if s not in selected])
     transformer = EfficientColumnTransformer(
-        [("encoder", OrdinalEncoder(), ["s0", "s1"])],
+        [("encoder", OrdinalEncoder(), selected)],
         remainder=FunctionTransformer(),
         sparse_threshold=0.0,
     )
@@ -1174,7 +1181,7 @@ def test__efficient_column_transformer__assembles_a_frame_in_the_stacked_layout(
     out = transformer.fit_transform(X)
     reference = _reference(transformer, X)
 
-    assert assemblies == [(6, 4)]
+    assert assemblies == [(6, X.shape[1])]
     np.testing.assert_array_equal(out, reference)
     assert out.dtype == reference.dtype
     assert np.isfortran(out) == np.isfortran(reference)

--- a/tests/test_preprocessing/test_preprocessing_steps.py
+++ b/tests/test_preprocessing/test_preprocessing_steps.py
@@ -364,6 +364,48 @@ def test__order_preserving_column_transformer():
     np.testing.assert_equal(mock_data_df.iloc[:, 0].values, preserved_output[:, 0])
 
 
+@pytest.mark.parametrize("columns", [slice(0, 2), "b", 1, ("a", "b")])
+def test__order_preserving_column_transformer__selection_not_a_list_of_keys(
+    columns: object,
+) -> None:
+    """A selection that cannot be placed one column at a time is refused up front."""
+    with pytest.raises(AssertionError, match="only supports selecting columns by a"):
+        OrderPreservingColumnTransformer(
+            transformers=[("encoder", OrdinalEncoder(), columns)]
+        )
+
+
+def test__order_preserving_column_transformer__callable_selects_a_slice() -> None:
+    """What the constructor cannot see, the reorder says outright rather than crash."""
+    X = pd.DataFrame({"a": ["x", "y"], "b": [1, 2]})
+    transformer = OrderPreservingColumnTransformer(
+        transformers=[("encoder", OrdinalEncoder(), lambda _: slice(0, 1))],
+        remainder=FunctionTransformer(),
+        sparse_threshold=0.0,
+    )
+
+    with pytest.raises(TypeError, match="other than a list of keys"):
+        transformer.fit_transform(X)
+
+
+def test__order_preserving_column_transformer__permuted_full_selection() -> None:
+    """Every column selected, in another order, is still restored to the input's."""
+    X = pd.DataFrame({"a": ["x", "y", "z"], "b": ["q", "p", "r"], "c": ["v", "v", "u"]})
+    transformer = OrderPreservingColumnTransformer(
+        # The whole input, in an order of its own: `ColumnTransformer` returns one block
+        # holding every column, so the gather that undoes it covers all of them.
+        transformers=[("encoder", OrdinalEncoder(), ["c", "a", "b"])],
+        remainder=FunctionTransformer(),
+        sparse_threshold=0.0,
+    )
+    encoded = [[0.0, 1.0, 1.0], [1.0, 0.0, 1.0], [2.0, 2.0, 0.0]]
+
+    np.testing.assert_array_equal(transformer.fit_transform(X), encoded)
+    # `transform` leaves the values to sklearn, so it reaches the reorder by its own
+    # route -- the assembly above never builds the shuffled order to begin with.
+    np.testing.assert_array_equal(transformer.transform(X), encoded)
+
+
 def test__order_preserving_column_transformer__already_in_input_order(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_preprocessing/test_preprocessing_steps.py
+++ b/tests/test_preprocessing/test_preprocessing_steps.py
@@ -311,36 +311,40 @@ def test__pipeline__raises_error_when_modality_step_changes_column_count():
 
 
 def test__order_preserving_column_transformer():
-    """Should raise AssertionError if column sets overlap."""
+    """Should raise ValueError if column sets overlap."""
     ordinal_enc1 = OrdinalEncoder()
     ordinal_enc2 = OrdinalEncoder()
     onehotencoder1 = OneHotEncoder()
 
-    # Test assertion raised due to too many transformers
-    multiple_transformers = [
-        ("ordinal_enc1", ordinal_enc1, ["a", "b"]),
-        ("ordinal_enc2", ordinal_enc2, ["c", "d"]),
-    ]
-
-    with pytest.raises(
-        AssertionError,
-        match="OrderPreservingColumnTransformer only supports up to one transformer",
-    ):
-        OrderPreservingColumnTransformer(transformers=multiple_transformers)
-
-    # Test assertion, due to unsupported encoder type (OneHotEncoder)
-    incompatible_transformer = [("onehot", onehotencoder1, ["a", "b"])]
-
-    with pytest.raises(AssertionError, match="are instances of OneToOneFeatureMixin"):
-        OrderPreservingColumnTransformer(transformers=incompatible_transformer)
-
-        # --- Mock dataset ---
+    # --- Mock dataset ---
     mock_data_df = pd.DataFrame(
         {
             "a": [10, 20, 30, 40],
             "b": ["x", "y", "x", "z"],
         }
     )
+
+    # Test error raised due to too many transformers
+    multiple_transformers = [
+        ("ordinal_enc1", ordinal_enc1, ["a"]),
+        ("ordinal_enc2", ordinal_enc2, ["b"]),
+    ]
+
+    with pytest.raises(
+        ValueError,
+        match="OrderPreservingColumnTransformer only supports up to one transformer",
+    ):
+        OrderPreservingColumnTransformer(transformers=multiple_transformers).fit(
+            mock_data_df
+        )
+
+    # Test error, due to unsupported encoder type (OneHotEncoder)
+    incompatible_transformer = [("onehot", onehotencoder1, ["b"])]
+
+    with pytest.raises(ValueError, match="are instances of OneToOneFeatureMixin"):
+        OrderPreservingColumnTransformer(transformers=incompatible_transformer).fit(
+            mock_data_df
+        )
 
     # Test if normal column transformer shuffles column order,
     # while the OrderPreserving restores the original order
@@ -368,11 +372,40 @@ def test__order_preserving_column_transformer():
 def test__order_preserving_column_transformer__selection_not_a_list_of_keys(
     columns: object,
 ) -> None:
-    """A selection that cannot be placed one column at a time is refused up front."""
-    with pytest.raises(AssertionError, match="only supports selecting columns by a"):
-        OrderPreservingColumnTransformer(
-            transformers=[("encoder", OrdinalEncoder(), columns)]
-        )
+    """A selection that cannot be placed one column at a time is refused."""
+    X = pd.DataFrame({"a": ["x", "y"], "b": ["p", "q"]})
+    transformer = OrderPreservingColumnTransformer(
+        transformers=[("encoder", OrdinalEncoder(), columns)]
+    )
+
+    with pytest.raises(ValueError, match="only supports selecting columns by a"):
+        transformer.fit(X)
+
+
+@pytest.mark.parametrize(
+    "transformers",
+    [
+        [("encoder", OrdinalEncoder(), ["a"]), ("second", OrdinalEncoder(), ["b"])],
+        [("encoder", OneHotEncoder(), ["a"])],
+        [("encoder", OrdinalEncoder(), slice(0, 1))],
+    ],
+    ids=["two_transformers", "not_one_to_one", "selection_not_keys"],
+)
+def test__order_preserving_column_transformer__contract_survives_set_params(
+    transformers: list,
+) -> None:
+    """`set_params` writes past the constructor, so fit is what has to hold the line."""
+    X = pd.DataFrame({"a": ["x", "y"], "b": ["p", "q"]})
+    transformer = OrderPreservingColumnTransformer(
+        transformers=[("encoder", OrdinalEncoder(), ["a"])],
+        remainder=FunctionTransformer(),
+        sparse_threshold=0.0,
+    )
+
+    transformer.set_params(transformers=transformers)
+
+    with pytest.raises(ValueError, match="OrderPreservingColumnTransformer only"):
+        transformer.fit_transform(X)
 
 
 def test__order_preserving_column_transformer__callable_selects_a_slice() -> None:

--- a/tests/test_preprocessing/test_preprocessing_steps.py
+++ b/tests/test_preprocessing/test_preprocessing_steps.py
@@ -751,3 +751,24 @@ def test__efficient_column_transformer__an_unfitted_transform_is_not_an_identity
     """
     with pytest.raises(NotFittedError):
         get_ordinal_encoder().transform(_mixed_frame())
+
+
+def test__efficient_column_transformer__a_validating_remainder_is_not_a_passthrough(
+    assemblies: list[tuple[int, ...]],
+) -> None:
+    """`validate=True` gives the remainder real work, so it cannot be assembled around.
+
+    It sends the columns it is handed through `check_array`, which coerces their dtype
+    and refuses a NaN. A table sklearn would reject therefore has to keep being
+    rejected, rather than quietly assembled past the check.
+    """
+    X = np.column_stack([np.arange(6.0), np.tile([1.0, 2.0], 3), np.arange(6.0) * 3])
+    X[0, 2] = np.nan
+    transformer = EfficientColumnTransformer(
+        [("encoder", OrdinalEncoder(), [1])],
+        remainder=FunctionTransformer(validate=True),
+    )
+
+    with pytest.raises(ValueError, match="NaN"):
+        transformer.fit_transform(X)
+    assert assemblies == []

--- a/tests/test_preprocessing/test_preprocessing_steps.py
+++ b/tests/test_preprocessing/test_preprocessing_steps.py
@@ -368,6 +368,22 @@ def test__order_preserving_column_transformer():
     np.testing.assert_equal(mock_data_df.iloc[:, 0].values, preserved_output[:, 0])
 
 
+def test__order_preserving_column_transformer__clone_keeps_its_parameters() -> None:
+    """Every parameter it was configured with has to survive sklearn's `clone`."""
+    encoder = get_ordinal_encoder()
+
+    assert set(encoder.get_params(deep=False)) == set(
+        ColumnTransformer(transformers=[]).get_params(deep=False)
+    )
+
+    copy = sklearn.base.clone(encoder)
+
+    # A `remainder` lost to its 'drop' default silently drops every numeric column
+    assert isinstance(copy.remainder, FunctionTransformer)
+    assert copy.sparse_threshold == encoder.sparse_threshold
+    assert copy.verbose_feature_names_out == encoder.verbose_feature_names_out
+
+
 @pytest.mark.parametrize("columns", [slice(0, 2), "b", 1, ("a", "b")])
 def test__order_preserving_column_transformer__selection_not_a_list_of_keys(
     columns: object,

--- a/tests/test_preprocessing/test_preprocessing_steps.py
+++ b/tests/test_preprocessing/test_preprocessing_steps.py
@@ -14,6 +14,7 @@ import pandas as pd
 import pytest
 import sklearn.base
 from sklearn.compose import ColumnTransformer
+from sklearn.exceptions import NotFittedError
 from sklearn.preprocessing import (
     FunctionTransformer,
     OneHotEncoder,
@@ -660,3 +661,93 @@ def test__efficient_column_transformer__clones_like_a_column_transformer() -> No
     assert clone.sparse_threshold == 0.0
     assert clone.verbose_feature_names_out is False
     assert clone.preserves_column_order is transformer.preserves_column_order
+
+
+# --- ownership of the assembled output --------------------------------------------
+#
+# The assembly hands its array straight to the caller, who writes into it, so it has to
+# own it. How many copies that takes depends on the frame's block layout, which is what
+# these pin. The frames here are all float64, so the encoder selects nothing and the
+# whole step is the cast -- the case where taking `to_numpy`'s result would have been
+# tempting.
+
+
+def _fragmented_float_frame(values: np.ndarray) -> pd.DataFrame:
+    """A float frame held as one block per column, as a recast frame is left."""
+    frame = pd.DataFrame(values)
+    frame[frame.columns] = frame[frame.columns].astype(values.dtype)
+    return frame
+
+
+@pytest.mark.parametrize("fit", [True, False], ids=["fit_transform", "transform"])
+def test__order_preserving_column_transformer__owns_a_multi_block_frames_output(
+    *, fit: bool
+) -> None:
+    """A frame of many blocks is assembled directly, never routed through `to_numpy`.
+
+    Asserted through the frame rather than the result, because what the result looks
+    like depends on the pandas: `to_numpy` consolidates the frame in place before
+    pandas 3, so a run that went through it would cost a second full-size buffer and
+    leave the frame holding one block instead of many.
+    """
+    values = np.random.default_rng(0).standard_normal((8, 5))
+    frame = _fragmented_float_frame(values)
+    transformer = get_ordinal_encoder()
+
+    out = (
+        transformer.fit_transform(frame)
+        if fit
+        else transformer.fit(frame).transform(frame)
+    )
+
+    np.testing.assert_array_equal(out, values)
+    assert out.flags.writeable
+    assert out.flags.f_contiguous
+    assert not np.shares_memory(out, values)
+    # Still one block per column: nothing consolidated it on the way.
+    assert len(frame._mgr.blocks) == frame.shape[1]
+    # And the buffer is the caller's alone -- writing into it cannot reach the frame.
+    assert not any(
+        np.shares_memory(out, frame.iloc[:, position].to_numpy(copy=False))
+        for position in range(frame.shape[1])
+    )
+
+
+@pytest.mark.parametrize("fit", [True, False], ids=["fit_transform", "transform"])
+def test__order_preserving_column_transformer__owns_a_single_block_frames_output(
+    *, fit: bool
+) -> None:
+    """A single-block frame is handed out by pandas as a view of its own buffer."""
+    values = np.random.default_rng(0).standard_normal((8, 5))
+    frame = pd.DataFrame(values, copy=False)
+    assert len(frame._mgr.blocks) == 1
+    assert np.shares_memory(frame.to_numpy(dtype=np.float64, copy=False), values)
+    transformer = get_ordinal_encoder()
+
+    out = (
+        transformer.fit_transform(frame)
+        if fit
+        else transformer.fit(frame).transform(frame)
+    )
+
+    np.testing.assert_array_equal(out, values)
+    assert out.flags.writeable
+    assert out.flags.f_contiguous
+    # Writing into the result must not reach the caller's array. Under copy-on-write
+    # the view pandas hands out is read-only, but on pandas 2 it is writeable and
+    # aliases `values`.
+    assert not np.shares_memory(out, values)
+    out[0, 0] = 12345.0
+    assert values[0, 0] != 12345.0
+
+
+def test__efficient_column_transformer__an_unfitted_transform_is_not_an_identity() -> (
+    None
+):
+    """A transformer that never selected anything because it was never fitted.
+
+    It has no selection to read, which must not be mistaken for having selected no
+    columns -- that would hand the input back untransformed instead of failing.
+    """
+    with pytest.raises(NotFittedError):
+        get_ordinal_encoder().transform(_mixed_frame())

--- a/tests/test_preprocessing/test_preprocessing_steps.py
+++ b/tests/test_preprocessing/test_preprocessing_steps.py
@@ -980,6 +980,39 @@ def test__efficient_column_transformer__declines_a_frame_output(
     np.testing.assert_array_equal(out["n1"], X["n1"])
 
 
+def test__efficient_column_transformer__names_the_stacked_order_it_returns(
+    assemblies: list[tuple[int, ...]],
+) -> None:
+    """The plain class returns sklearn's own order, so it keeps sklearn's own names.
+
+    Nothing is overridden here, and nothing may be: the reorder in the subclass is
+    what makes the parent's names wrong, and an override hoisted up to this class
+    would name every column after whatever that reorder would have moved there. What
+    keeps the two in step is that the assembly places the transformed columns by
+    `output_indices_`, which is the same state the names are read off.
+    """
+    X = _mixed_frame()
+    transformers = [("encoder", OrdinalEncoder(), ["s0", "s1"])]
+    kwargs = {
+        "remainder": "passthrough",
+        "sparse_threshold": 0.0,
+        "verbose_feature_names_out": False,
+    }
+    transformer = EfficientColumnTransformer(transformers, **kwargs)
+
+    out = transformer.fit_transform(X)
+    names = list(transformer.get_feature_names_out())
+
+    assert assemblies == [(6, 4)]
+    assert names == list(
+        ColumnTransformer(transformers, **kwargs).fit(X).get_feature_names_out()
+    )
+    # And they describe the columns they are on, which is the whole point of them.
+    named = pd.DataFrame(out, columns=names)
+    for column in ["n0", "n1"]:
+        np.testing.assert_array_equal(named[column], X[column])
+
+
 def test__order_preserving_column_transformer__names_the_order_it_returns() -> None:
     """The names have to be reordered with the columns, not left in sklearn's order.
 

--- a/tests/test_preprocessing/test_preprocessing_steps.py
+++ b/tests/test_preprocessing/test_preprocessing_steps.py
@@ -22,6 +22,7 @@ from sklearn.preprocessing import (
     MaxAbsScaler,
     OneHotEncoder,
     OrdinalEncoder,
+    StandardScaler,
 )
 
 from tabpfn.preprocessing import steps
@@ -1038,6 +1039,43 @@ def test__order_preserving_column_transformer__names_the_order_it_returns() -> N
         "n0",
         "n1",
     ]
+
+
+@pytest.mark.parametrize(
+    "cls",
+    [EfficientColumnTransformer, OrderPreservingColumnTransformer],
+    ids=lambda cls: cls.__name__,
+)
+def test__efficient_column_transformer__declines_a_data_dependent_selector(
+    cls: type[EfficientColumnTransformer], assemblies: list[tuple[int, ...]]
+) -> None:
+    """A selector that reads the values resolves differently against the one probe row.
+
+    And it fails silently where the others fail loudly: the columns the probe left out
+    come back untransformed, in the right places, at the right dtype. Only a
+    `make_column_selector`, which reads dtypes, survives one row -- as every other
+    frame case here relies on.
+    """
+
+    def more_than_one_value(frame: pd.DataFrame) -> list[str]:
+        return [name for name in frame.columns if frame[name].std() > 0]
+
+    # One row has no spread in any column, so the selector picks nothing where the
+    # bookkeeping fit asks it and 'a' where `ColumnTransformer` asks it.
+    X = pd.DataFrame({"a": [1.0, 1.0, 2.0], "b": [1.0, 1.0, 1.0]})
+    transformer = cls(
+        [("scaler", StandardScaler(), more_than_one_value)],
+        remainder=FunctionTransformer(),
+        sparse_threshold=0.0,
+    )
+
+    out = transformer.fit_transform(X)
+
+    assert assemblies == []
+    # The selection is 'a' alone, so sklearn's order is the input's and the two
+    # classes have the same answer to compare against.
+    np.testing.assert_allclose(out, _reference(transformer, X))
+    assert out[0, 0] != X["a"][0], "the selected column came back unscaled"
 
 
 def test__efficient_column_transformer__declines_routed_metadata(

--- a/tests/test_preprocessing/test_preprocessing_steps.py
+++ b/tests/test_preprocessing/test_preprocessing_steps.py
@@ -364,6 +364,35 @@ def test__order_preserving_column_transformer():
     np.testing.assert_equal(mock_data_df.iloc[:, 0].values, preserved_output[:, 0])
 
 
+def test__order_preserving_column_transformer__already_in_input_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stack that is already in input order is handed back without a gather."""
+    stacked = []
+    hstack = ColumnTransformer._hstack
+
+    def recording(self: ColumnTransformer, Xs: list, **kwargs: object) -> np.ndarray:
+        stacked.append(hstack(self, Xs, **kwargs))
+        return stacked[-1]
+
+    monkeypatch.setattr(ColumnTransformer, "_hstack", recording)
+
+    # The encoded column leads, so `ColumnTransformer`'s own order is the input's. The
+    # int64 column is what keeps this off the assembly path, which reaches its result
+    # without a stack to gather over at all.
+    X = pd.DataFrame({"a": ["x", "y"], "b": [1, 2], "c": [3.0, 4.0]})
+    transformer = OrderPreservingColumnTransformer(
+        transformers=[("encoder", OrdinalEncoder(), ["a"])],
+        remainder=FunctionTransformer(),
+        sparse_threshold=0.0,
+    )
+
+    out = transformer.fit_transform(X)
+
+    np.testing.assert_array_equal(out, [[0.0, 1.0, 3.0], [1.0, 2.0, 4.0]])
+    assert out is stacked[-1]
+
+
 def test__pipeline__num_added_features():
     """Test that the pipeline returns the correct number of added features."""
     pipeline = PreprocessingPipeline(

--- a/tests/test_preprocessing/test_reshape_feature_distribution_step.py
+++ b/tests/test_preprocessing/test_reshape_feature_distribution_step.py
@@ -644,3 +644,26 @@ def test__reshape__transform__estimator_without_data_is_unchanged_attribute():
 
     del step.data_is_unchanged_
     np.testing.assert_array_equal(step.transform(X).X, expected)
+
+
+def test__reshape__transform__estimator_without_column_order_attribute():
+    """The same, for a step unpickled without ``column_order_``.
+
+    Both attributes were added after the class shipped, so both lookups on the way to
+    ``transformer_`` have to tolerate their absence -- and this one sits between the
+    other's guard and that fallthrough.
+    """
+    rng = np.random.default_rng(0)
+    X = rng.random((50, 4))
+    schema = _get_schema(num_columns=4)
+
+    step = ReshapeFeatureDistributionsStep(
+        transform_name="safepower",
+        apply_to_categorical=False,
+        append_to_original=False,
+        random_state=0,
+    )
+    expected = step.fit_transform(X, schema).X
+
+    del step.data_is_unchanged_, step.column_order_
+    np.testing.assert_array_equal(step.transform(X).X, expected)


### PR DESCRIPTION
## Issue

[RES-2592: optimize `TabPFNEnsemblePreprocessor.fit_transform_ensemble_members_iterator` RAM usage](https://linear.app/priorlabs/issue/RES-2592/optimize-tabpfnensemblepreprocessorfit-transform-ensemble-members) — stacked on #1186, which left the half-categorical case as the one mix it could not help.

## Motivation and Context

**What**

-   Two more rebuilds of the feature matrix removed, both on the path a table with categorical columns takes.
-   Takes the half-string mix from **3.33 GB to 2.80 GB** of transient RSS, and 4.40 GB -> 2.80 GB cumulatively against `main`.

**Why**

-   #1186 skips the reshape rebuild only when the column order is untouched, and the encoder rebuild only when nothing is categorical. A half-categorical table meets neither condition, so it kept paying three full-size arrays where the numeric mixes now pay one.
-   That mix is not a corner case: it is what any table with a categorical column looks like to this step.

**How**

-   Reshape: when the transform is the identity and every input column is used exactly once, take the permutation in one gather instead of a ColumnTransformer's block-plus-hstack.
-   Encode: `EfficientColumnTransformer`, a `ColumnTransformer` subclass that writes the codes and the passthrough columns straight into one preallocated output rather than stacking its transformers' results, and whose `fit` builds no output at all.

Both stages had to go: they were tied at the peak, so removing either alone moved nothing. Measured at 66,667 x 400 with the profiler, this step's transient goes 0.422 GB -> 0.213 GB for the reshape and 0.427 GB -> 0.318 GB for the encoder.

|                              | numeric                        | half-string                   | numeric-object              |
| :--------------------------- | :----------------------------- | :---------------------------- | :-------------------------- |
| input              | 10.67 GB (666,667 x 2,000)     | 1.07 GB (333,333 x 400)       | 1.07 GB (333,333 x 400)     |
| categoricals   | 0 of 2,000                     | 200 of 400                    | 0 of 400                    |
| transient RSS, highest       | 12.00 -> 12.00 GB (+0.0%)      | 3.33 -> 2.80 GB (**-16.0%**)  | 1.07 -> 1.07 GB (+0.0%)     |
| transient RSS, lowest-direct | 12.00 -> 12.00 GB (+0.0%)      | 2.67 -> 2.67 GB (+0.0%)       | 1.07 -> 1.07 GB (+0.0%)     |
| median wall, highest         | 11.015 -> 10.980 s (-0.3%)     | 6.698 -> 6.741 s (+0.6%)      | 0.695 -> 0.683 s (-1.7%)    |
| median wall, lowest-direct   | 10.976 -> 10.859 s (-1.1%)     | 13.684 -> 13.975 s (+2.1%)    | 0.696 -> 0.686 s (-1.5%)    |

Six complete A/B comparisons against this PR's base, run by `scripts/bench_matrix.py` on dedicated `cpuhighmem16spot` nodes, with the ensemble members compared cell by cell: **bit-identical in all six**. Only the half-string RSS cell is outside the ±3% this benchmark carries; every other number here says "unchanged", including all six wall times.

<details><summary>Two results worth reading before the diff</summary>

**Nothing is won on the dependency floor.** On python 3.10 / numpy 1.22 / sklearn 1.2 the base already peaks at 2.67 GB where current libraries peak at 3.33 GB, and this change leaves the floor exactly where it was. Profiling both environments at a shape small enough to profile (66,667 x 400) shows identical stage ladders, so the floor's cheaper baseline only appears at the full shape and I did not chase the cause further. What the table does establish is that the floor is not made worse.

**Wall time is a wash, and the gate is stricter than the measurement.** The two half-string cells read +0.6% and +2.1%; a nine-repeat run of the same comparison put the medians 2.3% apart while the fastest repeats were 0.3% apart, with the spread inside one run reaching 8.9%. The assembly is doing slightly more work than sklearn's two block copies, but I could not measure it above the noise. The benchmark's zero-tolerance default therefore rejects these cells; `--tolerance 0.03` passes them.

What remains on this mix is one gather output, one assembled output and the block of codes, so ~2.5x the table it returns. Going below that means letting the encoder write into its input in place — safe inside the pipeline, which copies once up front precisely so steps have a private array, but a change to the mutation contract of a step that can also be called directly. Deliberately left out of this PR.

</details>

---

## Public API Changes

-   [x] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?

| suite                                                                                  | result                                             |
| :------------------------------------------------------------------------------------- | :------------------------------------------------- |
| `tests/test_preprocessing`, `tests/test_torch_preprocessing`                            | 825 passed, 45 skipped                             |
| A/B vs this PR's base: 3 mixes x 2 dependency sets, plus `--no-gpu-preprocessing`        | members bit-identical, no RSS regression           |

-   New: both transformers are pinned against a plain `ColumnTransformer` as the oracle — values, dtype **and** memory layout — over the shapes they assemble, the shapes they decline to sklearn (frame output, routed metadata, sparse input, an object passthrough, a `y`), and `fit_transform` against `transform` on the same estimator, which take the two routes and must not disagree.
-   That layout assertion earned its place immediately: the first draft of this branch pinned the output to Fortran order, and the test caught that `hstack` returns row-major for two real blocks and Fortran order only when every block it stacks already is. A layout drift here is not cosmetic — the sklearn SVD downstream converges to a different basis on a C- than on a Fortran-contiguous input, which is exactly what #1186's `_pin_layout` exists to stop.

---

## Checklist

-   [x] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [x] A changelog entry has been added (see `changelog/README.md`), or "no changelog needed" label requested.
-   [x] The code follows the project's style guidelines.
-   [x] I have considered the impact of these changes on the public API.

---

