### PR TITLE
cache decoder keys instead of the embeddings [RES-2474]

### DIFF
--- a/changelog/1189.breaking.md
+++ b/changelog/1189.breaking.md
@@ -1,0 +1,1 @@
+Cache the decoder keys instead of the train embeddings. ` get_embeddings(model, X_test, data_source="train")` is not supported with cached infernce anymore.

--- a/src/tabpfn/architectures/interface.py
+++ b/src/tabpfn/architectures/interface.py
@@ -242,6 +242,8 @@ class Architecture(nn.Module, ABC):
             standard decoder.
             Otherwise, a dictionary containing the output of each decoder, and also:
                 - "train_embeddings": The output of the encoder on the training data.
+                  Only present when the forward pass actually ran the training
+                  rows; a pass served from a `kv_cache` may omit it.
                 - "test_embeddings": The output of the encoder on the test data.
             Particular models may also return additional information.
         """

--- a/src/tabpfn/architectures/tabpfn_v3.py
+++ b/src/tabpfn/architectures/tabpfn_v3.py
@@ -517,15 +517,7 @@ class ManyClassDecoder(nn.Module):
         self.softmax_scaling_layer = softmax_scaling_layer
 
     def project_keys(self, train_embeddings: torch.Tensor) -> torch.Tensor:
-        """Project train embeddings to per-head keys: (B, N, E) -> (B, N, H, D).
-
-        Split out of the forward pass so cached inference can run it once when
-        the cache is built and store the result (see
-        :attr:`TabPFNV3Cache.decoder_keys`), instead of re-projecting every
-        train row on every predict. The projection is a plain linear map with
-        no dependence on the test rows or on ``N``, so the cached keys are
-        exactly what the forward pass would have recomputed.
-        """
+        """Project train embeddings to per-head keys: (B,N,E)->(B,N,H,D)."""
         k_BNE = self.k_projection(train_embeddings)
         h, d = self.num_heads, self.head_dim
         return k_BNE.view(*k_BNE.shape[:2], h, d).contiguous()

--- a/src/tabpfn/architectures/tabpfn_v3.py
+++ b/src/tabpfn/architectures/tabpfn_v3.py
@@ -203,8 +203,12 @@ class TabPFNV3Cache(KVCache):
 
     Attributes:
         kv: Per-layer KV cache for the ICL transformer blocks.
-        train_embeddings: Post-ICL, post-norm train embeddings of shape
-            ``(B, N_train, D)``. Needed by the multiclass decoder.
+        decoder_keys: Projected many-class decoder keys of shape
+            ``(B, N_train, H_dec, D_dec)``, i.e. ``k_projection`` already
+            applied to the post-ICL, post-norm train embeddings. ``None`` for
+            regression, which has no many-class decoder. Caching the keys
+            rather than the embeddings they come from is smaller (``H*D <
+            emsize``) and keeps the projection off the predict path.
         train_shape: ``(batch_size, num_train)`` for validation.
         scaler_cache: Fitted standard-scaler statistics (``mean``, ``std``).
             Allows standardising test-only data without train rows present.
@@ -214,7 +218,7 @@ class TabPFNV3Cache(KVCache):
             recomputing ``cross_attn_block1`` from train rows.
     """
 
-    train_embeddings: torch.Tensor | None = None
+    decoder_keys: torch.Tensor | None = None
     train_shape: tuple[int, int] = (0, 0)
     scaler_cache: dict[str, torch.Tensor] | None = None
     inducing_hidden: list[torch.Tensor] | None = None
@@ -224,10 +228,8 @@ class TabPFNV3Cache(KVCache):
         """Move all cached tensors to the given device."""
         return TabPFNV3Cache(
             kv=self._kv_to(device),
-            train_embeddings=(
-                self.train_embeddings.to(device)
-                if self.train_embeddings is not None
-                else None
+            decoder_keys=(
+                self.decoder_keys.to(device) if self.decoder_keys is not None else None
             ),
             train_shape=self.train_shape,
             scaler_cache=self._dict_of_tensors_to(self.scaler_cache, device),
@@ -237,7 +239,7 @@ class TabPFNV3Cache(KVCache):
     def quantize(self, dtype: torch.dtype = QUANTIZED_KV_DTYPE) -> TabPFNV3Cache:
         """Return a new cache with quantized ICL KV entries.
 
-        Only the ICL KV cache is quantized; ``train_embeddings``,
+        Only the ICL KV cache is quantized; ``decoder_keys``,
         ``scaler_cache``, and ``inducing_hidden`` stay in full precision.
 
         Args:
@@ -249,7 +251,7 @@ class TabPFNV3Cache(KVCache):
         }
         return TabPFNV3Cache(
             kv=quantized_kv,
-            train_embeddings=self.train_embeddings,
+            decoder_keys=self.decoder_keys,
             train_shape=self.train_shape,
             scaler_cache=self.scaler_cache,
             inducing_hidden=self.inducing_hidden,
@@ -271,8 +273,8 @@ def get_cache_size(
     one estimator, summing every tensor a built cache holds:
 
     1. The ICL transformer KV cache (int8 + per-tensor scales when quantized).
-    2. The last-layer train activations (cached for both tasks; regression
-       stores but ignores them).
+    2. The many-class decoder keys, ``(N_train, H_dec * D_dec)``. Classification
+       only -- regression has no many-class decoder and caches nothing here.
     3. The distribution-embedder ``inducing_hidden`` states.
     4. The fitted scaler stats ``scaler_cache`` (``mean`` + ``std``).
 
@@ -284,7 +286,7 @@ def get_cache_size(
       ``dtype``, so every non-KV term lands at ``dtype``.
     * **Autocast** (``dtype="autocast"``, the GPU default for
       ``inference_precision='auto'``): weights stay fp32 and ops are cast at
-      runtime to fp16. The matmul-lineage tensors (KV, and ``train_embeddings``
+      runtime to fp16. The matmul-lineage tensors (KV, and ``decoder_keys``
       via its explicit cast to the KV dtype) take fp16, while the
       reduction/norm-lineage tensors (``inducing_hidden``, ``scaler_cache``)
       stay fp32.
@@ -303,7 +305,7 @@ def get_cache_size(
         model_config: The v3 architecture config.
         base_dtype: Either a ``torch.dtype`` (forced-precision path -- every term is
             sized at this dtype; on CPU this is usually Float32) or the string
-            ``"autocast"`` (GPU autocast path -- KV and ``train_embeddings`` are
+            ``"autocast"`` (GPU autocast path -- KV and ``decoder_keys`` are
             sized at fp16 while ``inducing_hidden`` and ``scaler_cache`` stay
             fp32, since autocast keeps those ops in fp32).
         kv_cache_precision: If ``"int8"`` (default) or ``"fp8"``, the KV cache
@@ -326,18 +328,18 @@ def get_cache_size(
     # component is ``dtype``. Under autocast the cache is mixed precision.
     if base_dtype == "autocast":
         # Autocast keeps fp32 weights and casts ops to fp16 at runtime, so KV and
-        # train_embeddings (matmul outputs) are fp16, while inducing_hidden and
+        # decoder_keys (matmul outputs) are fp16, while inducing_hidden and
         # the scaler (fp32 reduction/norm ops, scaler fit on the fp32 input) stay
         # fp32.
         kv_dtype = QUANTIZED_KV_DTYPE if quantize_kv_cache else torch.float16
         kv_scale_dtype = torch.float16  # per-tensor scales, at the KV fp16 dtype
-        train_emb_dtype = torch.float16
+        decoder_key_dtype = torch.float16
         inducing_dtype = torch.float32
         scaler_dtype = torch.float32
     else:
         kv_dtype = QUANTIZED_KV_DTYPE if quantize_kv_cache else base_dtype
         kv_scale_dtype = base_dtype
-        train_emb_dtype = base_dtype
+        decoder_key_dtype = base_dtype
         inducing_dtype = base_dtype
         scaler_dtype = base_dtype
 
@@ -357,8 +359,14 @@ def get_cache_size(
         # One scalar scale per key and per value tensor.
         total_bytes += model_config.nlayers * 2 * kv_scale_dtype.itemsize
 
-    # 2. Train activations, (N_train, icl_emsize). Cached for both tasks.
-    total_bytes += n_train * icl_emsize * train_emb_dtype.itemsize
+    # 2. Many-class decoder keys, (N_train, H_dec * D_dec). Classification only:
+    # regression has no many-class decoder, so its cache omits this term. This
+    # mirrors how the architecture picks its task type from the config.
+    if model_config.max_num_classes >= 2:
+        decoder_key_width = (
+            model_config.decoder_num_heads * model_config.decoder_head_dim
+        )
+        total_bytes += n_train * decoder_key_width * decoder_key_dtype.itemsize
 
     # 3. Distribution-embedder inducing states: one
     # (n_features, dist_embed_num_inducing_points, embed_dim) tensor per block.
@@ -508,33 +516,46 @@ class ManyClassDecoder(nn.Module):
         self.k_projection = nn.Linear(self.input_size, self.attention_size)
         self.softmax_scaling_layer = softmax_scaling_layer
 
-    def _project_qk(
-        self,
-        train_embeddings: torch.Tensor,  # (B, N, E)
-        test_embeddings: torch.Tensor,  # (B, M, E)
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Project inputs to per-head queries/keys: (B, M, H, D), (B, N, H, D)."""
-        q_BME = self.q_projection(test_embeddings)
-        # Mirrors the dtype guard in ICLAttention's cached path.
-        if train_embeddings.dtype != q_BME.dtype:
-            train_embeddings = train_embeddings.to(q_BME.dtype)
+    def project_keys(self, train_embeddings: torch.Tensor) -> torch.Tensor:
+        """Project train embeddings to per-head keys: (B, N, E) -> (B, N, H, D).
+
+        Split out of the forward pass so cached inference can run it once when
+        the cache is built and store the result (see
+        :attr:`TabPFNV3Cache.decoder_keys`), instead of re-projecting every
+        train row on every predict. The projection is a plain linear map with
+        no dependence on the test rows or on ``N``, so the cached keys are
+        exactly what the forward pass would have recomputed.
+        """
         k_BNE = self.k_projection(train_embeddings)
         h, d = self.num_heads, self.head_dim
+        return k_BNE.view(*k_BNE.shape[:2], h, d).contiguous()
+
+    def _project_q(
+        self,
+        train_keys_BNHD: torch.Tensor,  # (B, N, H, D)
+        test_embeddings: torch.Tensor,  # (B, M, E)
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Project test rows to queries and match the keys' dtype to them."""
+        q_BME = self.q_projection(test_embeddings)
+        h, d = self.num_heads, self.head_dim
         q_BMHD = q_BME.view(*q_BME.shape[:2], h, d).contiguous()
-        k_BNHD = k_BNE.view(*k_BNE.shape[:2], h, d).contiguous()
-        return q_BMHD, k_BNHD
+        # Mirrors the dtype guard in ICLAttention's cached path: keys built
+        # under autocast are fp16/bf16 and must match q for the attention call.
+        if train_keys_BNHD.dtype != q_BMHD.dtype:
+            train_keys_BNHD = train_keys_BNHD.to(q_BMHD.dtype)
+        return q_BMHD, train_keys_BNHD
 
     @override
     def forward(
         self,
-        train_embeddings: torch.Tensor,  # (B, N, E)
+        train_keys_BNHD: torch.Tensor,  # (B, N, H, D), from project_keys
         test_embeddings: torch.Tensor,  # (B, M, E)
         targets: torch.Tensor,  # (B, N) - class indices
         highest_target: int | None = None,  # max(targets), if already on the host
     ) -> torch.Tensor:
         """Perform a forward pass."""
         B, M, _ = test_embeddings.shape
-        q_BMHD, k_BNHD = self._project_qk(train_embeddings, test_embeddings)
+        q_BMHD, k_BNHD = self._project_q(train_keys_BNHD, test_embeddings)
 
         if M == 0:
             # OOM checks at training start run with no test rows. Flash attention
@@ -572,7 +593,7 @@ class ManyClassDecoder(nn.Module):
 
     def attention_weights(
         self,
-        train_embeddings: torch.Tensor,  # (B, N, E)
+        train_keys_BNHD: torch.Tensor,  # (B, N, H, D), from project_keys
         test_embeddings: torch.Tensor,  # (B, M, E)
     ) -> torch.Tensor:
         """Per-train-row attention weights, averaged over heads: `(B, M, N)`.
@@ -585,7 +606,7 @@ class ManyClassDecoder(nn.Module):
         `forward` fuses this into a single attention kernel to avoid
         materializing an O(N*M) tensor.
         """
-        q_BMHD, k_BNHD = self._project_qk(train_embeddings, test_embeddings)
+        q_BMHD, k_BNHD = self._project_q(train_keys_BNHD, test_embeddings)
         if self.softmax_scaling_layer is not None:
             q_BMHD = self.softmax_scaling_layer(q_BMHD, k_BNHD.shape[1])
         scores_BHMN = torch.einsum("bmhd,bnhd->bhmn", q_BMHD, k_BNHD).float()
@@ -1938,17 +1959,33 @@ class TabPFNV3(Architecture):
         x_BRiD = self.output_norm(x_BRiD)
 
         # ---- Split embeddings --------------------------------------------------
-        if kv_cache is not None and not kv_cache.is_empty():
+        running_from_cache = kv_cache is not None and not kv_cache.is_empty()
+        if running_from_cache:
             test_emb = x_BRiD
-            train_emb = kv_cache.train_embeddings
+            # Train embeddings are not cached, only the decoder keys projected
+            # from them, so they are unavailable on this path.
+            train_emb = None
         else:
             test_emb = x_BRiD[:, num_train:]
             train_emb = x_BRiD[:, :num_train]
 
+        # ---- Many-class decoder keys -------------------------------------------
+        train_keys: torch.Tensor | None = None
+        if self.task_type == "multiclass":
+            if running_from_cache:
+                assert kv_cache is not None
+                assert kv_cache.decoder_keys is not None, (
+                    "A multiclass KV cache must carry the decoder keys."
+                )
+                train_keys = kv_cache.decoder_keys
+            else:
+                assert train_emb is not None
+                train_keys = self.many_class_decoder.project_keys(train_emb)
+
         # ---- Build KV cache output ---------------------------------------------
         built_cache: TabPFNV3Cache | None = None
         if return_kv_cache:
-            if kv_cache is not None and not kv_cache.is_empty():
+            if running_from_cache:
                 built_cache = kv_cache  # pass through unchanged
             else:
                 # Reuse the statistics fitted during preprocessing (on the
@@ -1956,12 +1993,16 @@ class TabPFNV3(Architecture):
                 # raw input, whose passed-through +/-inf would poison the mean/std
                 # and turn every standardised test cell into NaN at predict time.
                 assert kv_out
-                # Store train_embeddings at the unquantized ICL compute dtype. The
+                # Store the decoder keys at the unquantized ICL compute dtype. The
                 # KV entries may already have been quantized layer by layer above.
                 assert kv_compute_dtype is not None
                 built_cache = TabPFNV3Cache(
                     kv=kv_out,
-                    train_embeddings=train_emb.detach().to(kv_compute_dtype),
+                    decoder_keys=(
+                        train_keys.detach().to(kv_compute_dtype)
+                        if train_keys is not None
+                        else None
+                    ),
                     train_shape=(B, num_train),
                     scaler_cache={k: v.detach() for k, v in scaler_stats.items()},
                     inducing_hidden=(
@@ -1974,8 +2015,9 @@ class TabPFNV3(Architecture):
         # ---- Decoder -----------------------------------------------------------
         if self.task_type == "multiclass":
             y_BN = y.transpose(0, 1) if y.dim() == 2 else y.unsqueeze(0)
+            assert train_keys is not None
             test_out: torch.Tensor = self.many_class_decoder(
-                train_emb,
+                train_keys,
                 test_emb,
                 y_BN[:, :num_train],
                 highest_target=highest_target,
@@ -1991,9 +2033,10 @@ class TabPFNV3(Architecture):
         else:
             output = {
                 "standard": test_out,
-                "train_embeddings": train_emb.transpose(0, 1),
                 "test_embeddings": test_emb.transpose(0, 1),
             }
+            if train_emb is not None:
+                output["train_embeddings"] = train_emb.transpose(0, 1)
         if return_kv_cache:
             return output, built_cache
         return output

--- a/src/tabpfn/architectures/tabpfn_v3.py
+++ b/src/tabpfn/architectures/tabpfn_v3.py
@@ -188,6 +188,11 @@ class TabPFNV3Config(ArchitectureConfig):
                     f"<= the number of train KV heads ({effective_kv})"
                 )
 
+    @property
+    def is_classification(self) -> bool:
+        """Whether this config describes a classifier."""
+        return self.max_num_classes >= 2
+
 
 # ---------------------------------------------------------------------------
 # TabPFN v3 KV cache
@@ -360,9 +365,8 @@ def get_cache_size(
         total_bytes += model_config.nlayers * 2 * kv_scale_dtype.itemsize
 
     # 2. Many-class decoder keys, (N_train, H_dec * D_dec). Classification only:
-    # regression has no many-class decoder, so its cache omits this term. This
-    # mirrors how the architecture picks its task type from the config.
-    if model_config.max_num_classes >= 2:
+    # regression has no many-class decoder, so its cache omits this term.
+    if model_config.is_classification:
         decoder_key_width = (
             model_config.decoder_num_heads * model_config.decoder_head_dim
         )
@@ -2482,7 +2486,7 @@ def get_architecture(
     # cache_trainset_representation is accepted for interface compatibility but
     # is a no-op: v3 uses explicit KV cache passing via forward() parameters
     # (kv_cache / return_kv_cache) instead of model-internal caching.
-    task_type = "multiclass" if config.max_num_classes >= 2 else "regression"
+    task_type = "multiclass" if config.is_classification else "regression"
     n_out = config.max_num_classes if task_type == "multiclass" else config.num_buckets
     return TabPFNV3(
         config=config,

--- a/src/tabpfn/base.py
+++ b/src/tabpfn/base.py
@@ -458,6 +458,13 @@ def get_embeddings(
         data_source : {"train", "test"}, default="test"
             Select the transformer output to return. Use ``"train"`` to obtain
             embeddings from the training tokens and ``"test"`` for the test tokens.
+            ``"train"`` requires a fit mode that keeps the training rows around;
+            it is not available with ``fit_mode="fit_with_cache"``, whose predict
+            pass never runs the training rows through the transformer.
+
+    Raises:
+        TabPFNValidationError: If ``data_source="train"`` and the model was
+            fitted with ``fit_mode="fit_with_cache"``.
 
     Returns:
         np.ndarray
@@ -471,6 +478,19 @@ def get_embeddings(
                 emb_concat = emb.reshape(emb.shape[1], -1)
     """
     check_is_fitted(model)
+
+    if data_source == "train" and isinstance(
+        model.executor_, InferenceEngineExplicitKVCache
+    ):
+        # The cached predict pass only ever sees the test rows: the cache holds
+        # the ICL key/value pairs and the projected decoder keys, not the train
+        # embeddings themselves, so there is nothing to return here.
+        raise TabPFNValidationError(
+            'get_embeddings(..., data_source="train") is not supported with '
+            'fit_mode="fit_with_cache", because the cached predict pass does not '
+            "run the training rows through the transformer. Refit the model with "
+            'fit_mode="fit_preprocessors" to obtain training embeddings.'
+        )
 
     data_map = {"train": "train_embeddings", "test": "test_embeddings"}
 

--- a/src/tabpfn/classifier.py
+++ b/src/tabpfn/classifier.py
@@ -1829,7 +1829,9 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
                 Select the transformer output to return. Use ``"train"`` to obtain
                 embeddings from the training tokens and ``"test"`` for the test
                 tokens. When ``n_estimators > 1`` the returned array has shape
-                ``(n_estimators, n_samples, embedding_dim)``.
+                ``(n_estimators, n_samples, embedding_dim)``. ``"train"`` is not
+                available with ``fit_mode="fit_with_cache"``; see
+                :func:`tabpfn.base.get_embeddings`.
 
         Returns:
             np.ndarray

--- a/src/tabpfn/inference.py
+++ b/src/tabpfn/inference.py
@@ -1248,7 +1248,8 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
             return torch.cat(outputs)
 
         concat_keys = {"standard", "test_embeddings"}
-        shared_keys = {"train_embeddings"}  # replicated across chunk
+        # Not emitted by the v3 cached path, but v2 still replicates it per chunk.
+        shared_keys = {"train_embeddings"}
         unexpected = outputs[0].keys() - concat_keys - shared_keys
         if unexpected:
             raise RuntimeError(

--- a/src/tabpfn/regressor.py
+++ b/src/tabpfn/regressor.py
@@ -2088,7 +2088,9 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
                 Select the transformer output to return. Use ``"train"`` to obtain
                 embeddings from the training tokens and ``"test"`` for the test
                 tokens. When ``n_estimators > 1`` the returned array has shape
-                ``(n_estimators, n_samples, embedding_dim)``.
+                ``(n_estimators, n_samples, embedding_dim)``. ``"train"`` is not
+                available with ``fit_mode="fit_with_cache"``; see
+                :func:`tabpfn.base.get_embeddings`.
 
         Returns:
             np.ndarray

--- a/tests/test_architectures/test_tabpfn_v3.py
+++ b/tests/test_architectures/test_tabpfn_v3.py
@@ -142,7 +142,8 @@ def test__many_class_decoder_attention_weights_matches_forward(
     test_emb = torch.randn(B, M, E)
     targets = torch.randint(0, max_num_classes, (B, N))
 
-    weights = decoder.attention_weights(train_emb, test_emb)
+    train_keys = decoder.project_keys(train_emb)
+    weights = decoder.attention_weights(train_keys, test_emb)
     assert weights.shape == (B, M, N)
     assert torch.all(weights >= 0)
     torch.testing.assert_close(weights.sum(-1), torch.ones(B, M))
@@ -151,7 +152,7 @@ def test__many_class_decoder_attention_weights_matches_forward(
     class_avg = torch.einsum("bmn,bnt->bmt", weights, one_hot)
     logits = torch.log(torch.clamp(class_avg, min=1e-5) + 3e-5).transpose(0, 1)
 
-    expected = decoder(train_emb, test_emb, targets)
+    expected = decoder(train_keys, test_emb, targets)
     torch.testing.assert_close(logits, expected, atol=1e-4, rtol=1e-4)
 
 
@@ -288,7 +289,8 @@ def test__kv_cache__matches_standard_forward(use_chunkwise: bool) -> None:
 
     assert isinstance(cache, TabPFNV3Cache)
     assert not cache.is_empty()
-    assert cache.train_embeddings is not None
+    # Regression has no many-class decoder, so nothing is cached for it.
+    assert cache.decoder_keys is None
     assert len(cache.kv) == 2  # nlayers=2
 
     # Store-mode output matches standard
@@ -489,7 +491,7 @@ def test__kv_cache__layerwise_quantization_matches_post_forward(
     assert layerwise is not None
     post_forward = full_precision.quantize(cache_dtype)
 
-    assert layerwise.train_embeddings.dtype == full_precision.train_embeddings.dtype
+    assert layerwise.decoder_keys.dtype == full_precision.decoder_keys.dtype
     for layer_idx in post_forward.kv:
         expected = post_forward.kv[layer_idx]
         actual = layerwise.kv[layer_idx]
@@ -576,8 +578,8 @@ def test__quantized_kv_cache__close_to_standard_forward(use_chunkwise: bool) -> 
     for entry in q_cache.kv.values():
         assert isinstance(entry, QuantizedKVCacheEntry)
         assert entry.key.dtype == torch.int8
-    # Train embeddings stay in native dtype
-    assert q_cache.train_embeddings.dtype == torch.float32
+    # Regression caches no decoder keys.
+    assert q_cache.decoder_keys is None
 
     out_quantized = arch(x, y, performance_options=perf, kv_cache=q_cache)
 
@@ -611,9 +613,10 @@ def test__quantized_kv_cache__multiclass__close_to_standard_forward() -> None:
     for entry in q_cache.kv.values():
         assert isinstance(entry, QuantizedKVCacheEntry)
         assert entry.key.dtype == torch.int8
-    # Train embeddings stay in full precision
-    assert q_cache.train_embeddings is not None
-    assert q_cache.train_embeddings.dtype == torch.float32
+    # quantize() touches only the KV entries: the decoder keys keep the dtype they
+    # were computed at, which is fp32 here (fp32 model, no autocast context).
+    assert q_cache.decoder_keys is not None
+    assert q_cache.decoder_keys.dtype == torch.float32
 
     out_quantized = arch(x, y, kv_cache=q_cache)
 
@@ -718,7 +721,7 @@ def test__calculate_cache_size__matches_whole_classifier_cache_autocast(
     GPU).
 
     Unlike the forced-precision path, autocast keeps fp32 model weights and casts
-    ops at runtime -- matmul-lineage tensors (KV, and ``train_embeddings`` via its
+    ops at runtime -- matmul-lineage tensors (KV, and ``decoder_keys`` via its
     explicit cast to the KV dtype) become the 2-byte compute dtype, while
     reduction/norm-lineage tensors (``inducing_hidden``, ``scaler_cache``) stay
     fp32. ``get_cache_size(dtype="autocast")`` must size each term at its real
@@ -745,7 +748,7 @@ def test__calculate_cache_size__matches_whole_classifier_cache_autocast(
         n_train=n_train,
         n_features=n_features,
         model_config=cfg,
-        # "autocast": KV/train_embeddings sized at fp16, inducing/scaler at fp32.
+        # "autocast": KV/decoder_keys sized at fp16, inducing/scaler at fp32.
         base_dtype="autocast",
         kv_cache_precision=kv_cache_precision,
     )
@@ -760,10 +763,8 @@ def test__calculate_cache_size__matches_whole_regression_cache(
     """get_cache_size equals the exact byte size of every tensor in a real
     regression cache, across the engine's forced-precision dtypes.
 
-    Regression currently *stores* train_embeddings even though it never uses
-    them, so counting the full physical cache is correct today. If a future
-    change stops caching those for regression, this exact-equality assert breaks
-    -- signalling that get_cache_size should then drop that term for regression.
+    Regression has no many-class decoder, so its cache carries no ``decoder_keys``
+    term at all -- exact equality here is what pins that down.
     """
     arch = _get_regression_model()
     arch.type(dtype)  # mirror the engine's set_dtype for forced precision.
@@ -831,7 +832,7 @@ def test__calculate_cache_size__tabpfn3_classifier_1000_rows() -> None:
     #   KV int8:            nlayers*2*H_kv*head_dim * N = 24*2*1*64 * 1000 = 3,072,000
     #   + int8 KV scales:   nlayers*2 * 2 bytes         = 24*2*2           =        96
     #   + scaler stats:     2 * n_features(1) * 2 bytes                    =         4
-    #   + fp16 activations: icl_emsize * N * 2 = 512 * 1000 * 2            = 1,024,000
+    #   + fp16 decoder keys: H_dec*D_dec * N * 2 = 6*64 * 1000 * 2        =   768,000
     # The inducing term depends on the shipped dist-embedder config, so derive it
     # from the config instead of hardcoding it.
     n_features = 1
@@ -845,4 +846,4 @@ def test__calculate_cache_size__tabpfn3_classifier_1000_rows() -> None:
     total = get_cache_size(**common)
 
     # Numbers need manual update if we bump the default architecture.
-    assert total == 3_072_000 + 96 + 4 + 1_024_000 + inducing
+    assert total == 3_072_000 + 96 + 4 + 768_000 + inducing

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -22,6 +22,7 @@ from tabpfn.architectures.shared import workaround_mps_linear_bug
 from tabpfn.architectures.shared.workaround_mps_linear_bug import MpsSafeLinear
 from tabpfn.architectures.tabpfn_v3 import TabPFNV3Cache
 from tabpfn.base import create_inference_engine, get_embeddings
+from tabpfn.errors import TabPFNValidationError
 from tabpfn.inference import (
     InferenceEngineCachePreprocessing,
     InferenceEngineExplicitKVCache,
@@ -205,7 +206,7 @@ class _TestModelWithKVCache(Architecture):
             )
             cache = TabPFNV3Cache(
                 kv={0: dummy_kv},
-                train_embeddings=torch.zeros(1, n_train, 1, device=x.device),
+                decoder_keys=torch.zeros(1, n_train, 1, 1, device=x.device),
                 train_shape=(1, n_train),
             )
             return output, cache
@@ -853,15 +854,16 @@ def test__kv_cache_chunking__matches_unchunked(
 
 
 @pytest.mark.parametrize("device", get_pytest_devices())
-def test__kv_cache_chunking__train_embeddings_not_duplicated(
+def test__kv_cache__embeddings_test_only_and_chunk_safe(
     device: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Chunking must not inflate the dict (only_return_standard_out=False) path.
+    """The cached path serves test embeddings only, and chunking must not inflate them.
 
-    Test embeddings are test-indexed and get concatenated across chunks, but
-    train embeddings are read from the KV cache and are identical per chunk, so
-    naively concatenating them would yield n_chunks * n_train rows.
+    The cache holds the ICL KV pairs and the projected decoder keys, not the train
+    embeddings, so ``data_source="train"`` is rejected outright rather than
+    returning something empty or stale. Test embeddings are test-indexed and get
+    concatenated across chunks, so the merge must not multiply their row count.
     """
     if torch.device(device).type == "mps":
         pytest.skip("float64 inference is not supported on MPS")
@@ -881,10 +883,12 @@ def test__kv_cache_chunking__train_embeddings_not_duplicated(
     X_test = X[n_train:]
 
     monkeypatch.setattr(settings.tabpfn, "max_batched_test_rows", chunk)
-    train_emb = get_embeddings(model, X_test, data_source="train")
-    test_emb = get_embeddings(model, X_test, data_source="test")
+    with pytest.raises(
+        TabPFNValidationError, match='not supported with fit_mode="fit_with_cache"'
+    ):
+        get_embeddings(model, X_test, data_source="train")
 
-    assert train_emb.shape[-2] == n_train
+    test_emb = get_embeddings(model, X_test, data_source="test")
     assert test_emb.shape[-2] == n_test
 
 


### PR DESCRIPTION
This PR changes the caching to only cache the training keys used for the many-class decoder instead of the train embeddings as this is 25% smaller than the full embeddings. For regression we completely remove the caching of the embeddings as they are  not used anymore. 
We adjust the kv_cache_size computation accordingly.

**This change breaks one functionality that we had before,** namely reading out the _train_ embeddings when the model was fitted with cache. You can still read out the test embeddings though. We now fail louldy if users try that and tell them to extract train embeddings from a fit without cache.

I checked w/ TabPFN-extensions and it does not seem to be an issue there.


## Issue

## Motivation and Context

---

## Public API Changes

-   [ ] No Public API changes
-   [x] Yes, Public API changes (Details below)

---

## How Has This Been Tested?
I tested also in TabPFN-extensions and found no users of the corner case cache + train embeddings.
---

## Checklist

-   [x] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [ ] A changelog entry has been added (see `changelog/README.md`), or "no changelog needed" label requested.
-   [x] The code follows the project's style guidelines.
-   [x] I have considered the impact of these changes on the public API.

---
