### PR TITLE
Raise an exception if download_all_models() fails.

### DIFF
--- a/changelog/1195.breaking.md
+++ b/changelog/1195.breaking.md
@@ -1,0 +1,1 @@
+`tabpfn.model_loading.download_all_models()` now raises an exception if one or more of the models fails to download. It will still download all possible models before raising the exception.

--- a/src/tabpfn/model_loading.py
+++ b/src/tabpfn/model_loading.py
@@ -375,6 +375,7 @@ def _try_direct_downloads(
 def download_all_models(to: Path) -> None:
     """Download all available classifier and regressor models into a local directory."""
     to.mkdir(parents=True, exist_ok=True)
+    first_download_exception: Exception | None = None
     for model_version, model_source, model_type in [
         (ModelVersion.V2, ModelSource.get_classifier_v2(), "classifier"),
         (ModelVersion.V2, ModelSource.get_regressor_v2(), "regressor"),
@@ -385,7 +386,6 @@ def download_all_models(to: Path) -> None:
         (ModelVersion.V3, ModelSource.get_classifier_v3(), "classifier"),
         (ModelVersion.V3, ModelSource.get_regressor_v3(), "regressor"),
     ]:
-        first_download_exception: Exception | None = None
         for ckpt_name in model_source.filenames:
             path = to / ckpt_name
             if path.exists():
@@ -405,11 +405,11 @@ def download_all_models(to: Path) -> None:
                 if first_download_exception is None:
                     first_download_exception = result[0]
 
-        # We don't immediately raise the exception so we attempt to download every
-        # model, even if some fail.
-        if first_download_exception is not None:
-            msg = "One or more models failed to download"
-            raise RuntimeError(msg) from first_download_exception
+    # We don't immediately raise the exception so we attempt to download every
+    # model, even if some fail.
+    if first_download_exception is not None:
+        msg = "One or more models failed to download"
+        raise RuntimeError(msg) from first_download_exception
 
 
 def _version_has_direct_download_option(version: ModelVersion) -> bool:

--- a/src/tabpfn/model_loading.py
+++ b/src/tabpfn/model_loading.py
@@ -385,6 +385,7 @@ def download_all_models(to: Path) -> None:
         (ModelVersion.V3, ModelSource.get_classifier_v3(), "classifier"),
         (ModelVersion.V3, ModelSource.get_regressor_v3(), "regressor"),
     ]:
+        first_download_exception: Exception | None = None
         for ckpt_name in model_source.filenames:
             path = to / ckpt_name
             if path.exists():
@@ -399,7 +400,16 @@ def download_all_models(to: Path) -> None:
                 model_name=ckpt_name,
             )
             if result != "ok":
-                logger.warning(f"Errors downloading model {model_version}: {result}")
+                for error in result:
+                    logger.error(f"Error downloading model {model_version}: {error}")
+                if first_download_exception is None:
+                    first_download_exception = result[0]
+
+        # We don't immediately raise the exception so we attempt to download every
+        # model, even if some fail.
+        if first_download_exception is not None:
+            msg = "One or more models failed to download"
+            raise RuntimeError(msg) from first_download_exception
 
 
 def _version_has_direct_download_option(version: ModelVersion) -> bool:


### PR DESCRIPTION
At the moment we log but don't raise. This causes the true problem to be hidden in our CI pipelines, as the download stage appears to succeed and then the test fails later.

This is a potentially breaking change for existing users, as the function will now raise if they haven't accepted the license for one of the models, even if they're not using that model. However:
- This function is not used by TabPFNClassifier or TabPFNRegressor. The user has to explicitly discover it from the readme and then call it (e.g. if they want to work offline later).
- The function now only raises at the end, so it will still try to download all models.