### PR TITLE
Forward task_type when building the explicit KV cache

### DIFF
--- a/changelog/1197.fixed.md
+++ b/changelog/1197.fixed.md
@@ -1,0 +1,1 @@
+Fix `fit_mode="fit_with_cache"` raising `TypeError: forward() missing 1 required positional argument: 'task_type'` for architectures whose forward pass takes a `task_type`: the KV cache build now forwards it, like the prediction paths already did.

--- a/src/tabpfn/base.py
+++ b/src/tabpfn/base.py
@@ -288,6 +288,7 @@ def create_inference_engine(  # noqa: PLR0913
     forced_inference_dtype_: torch.dtype | None,
     memory_saving_mode: MemorySavingMode,
     use_autocast_: bool,
+    task_type: str,
     inference_mode: bool = True,
     keep_cache_on_device: bool = True,
     kv_cache_precision: Literal["auto", "int8", "fp8"] | None = None,
@@ -310,6 +311,9 @@ def create_inference_engine(  # noqa: PLR0913
         forced_inference_dtype_: If not None, the forced dtype for inference.
         memory_saving_mode: GPU/CPU memory saving settings.
         use_autocast_: Whether we use torch.autocast for inference.
+        task_type: The task type, e.g. "multiclass" or "regression". Only used
+            for ``fit_mode="fit_with_cache"``, where the cache is built during
+            initialization and is task-specific.
         inference_mode: Whether to use torch.inference_mode (set False if
             backprop is needed)
         keep_cache_on_device: Only relevant for ``fit_mode="fit_with_cache"``.
@@ -358,6 +362,7 @@ def create_inference_engine(  # noqa: PLR0913
             force_inference_dtype=forced_inference_dtype_,
             save_peak_mem=memory_saving_mode,
             autocast=use_autocast_,
+            task_type=task_type,
             keep_cache_on_device=keep_cache_on_device,
             kv_cache_precision=kv_cache_precision,
         )

--- a/src/tabpfn/classifier.py
+++ b/src/tabpfn/classifier.py
@@ -878,6 +878,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
             forced_inference_dtype_=self.forced_inference_dtype_,
             memory_saving_mode=self.memory_saving_mode,
             use_autocast_=self.use_autocast_,
+            task_type="multiclass",
             inference_mode=True,
             keep_cache_on_device=self.keep_cache_on_device,
             kv_cache_precision=self.kv_cache_precision,

--- a/src/tabpfn/inference.py
+++ b/src/tabpfn/inference.py
@@ -893,6 +893,7 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
         force_inference_dtype: torch.dtype | None,
         save_peak_mem: MemorySavingMode,
         autocast: bool,
+        task_type: str,
         keep_cache_on_device: bool = True,
         kv_cache_precision: Literal["auto", "int8", "fp8"] | None = None,
     ) -> None:
@@ -914,6 +915,9 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
             force_inference_dtype: The dtype to force inference to.
             save_peak_mem: Whether to save peak memory usage.
             autocast: Whether to use torch.autocast during cache build.
+            task_type: The task type, e.g. "multiclass" or "regression". Needed
+                at build time because the cached activations are task-specific,
+                so a cache built for the wrong task would be silently wrong.
             keep_cache_on_device: If True (default), keep each per-estimator
                 KV cache on the device where it was built.  Uses more device
                 memory but avoids CPU↔GPU transfers, giving lower latency.
@@ -939,6 +943,7 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
         # against that member's own architecture (see _resolve_kv_cache_precision).
         self.kv_cache_precision = kv_cache_precision
         self.ensemble_preprocessor = ensemble_preprocessor
+        self.task_type = task_type
 
         # Place model copies on all devices before building caches
         self.to(devices, self.force_inference_dtype, self.dtype_byte_size)
@@ -1069,6 +1074,10 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
             ),
         )
 
+        kwargs = {}
+        if _model_expectes_task_type_arg(model):
+            kwargs["task_type"] = self.task_type
+
         with (
             get_autocast_context(device, enabled=autocast),
             torch.inference_mode(),
@@ -1080,6 +1089,7 @@ class InferenceEngineExplicitKVCache(MultiDeviceInferenceEngine):
                 categorical_inds=batched_cat_ix,
                 performance_options=performance_options,
                 return_kv_cache=True,
+                **kwargs,
             )
 
         assert cache is not None

--- a/src/tabpfn/regressor.py
+++ b/src/tabpfn/regressor.py
@@ -778,6 +778,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
             forced_inference_dtype_=self.forced_inference_dtype_,
             memory_saving_mode=self.memory_saving_mode,
             use_autocast_=self.use_autocast_,
+            task_type="regression",
             keep_cache_on_device=self.keep_cache_on_device,
             kv_cache_precision=self.kv_cache_precision,
             inference_mode=inference_mode,

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -162,6 +162,7 @@ class _TestModelWithKVCache(Architecture):
         self.parameter = torch.nn.Parameter(torch.tensor(1.0))
         self.cache_build_count = 0
         self.cache_used_count = 0
+        self.cache_build_task_type: str | None = None
 
     @override
     def forward(
@@ -199,6 +200,7 @@ class _TestModelWithKVCache(Architecture):
 
         if return_kv_cache:
             self.cache_build_count += 1
+            self.cache_build_task_type = task_type
             # Build a dummy cache with a single KVCacheEntry
             dummy_kv = KVCacheEntry(
                 key=torch.zeros(1, n_train, 1, 1, device=x.device),
@@ -227,6 +229,34 @@ class _TestModelWithKVCache(Architecture):
 
     def reset_save_peak_mem_factor(self, factor: int | None = None) -> None:
         pass
+
+
+class _TestModelWithKVCacheLegacy(_TestModelWithKVCache):
+    """Like _TestModelWithKVCache, but without a task_type forward argument."""
+
+    @override
+    def forward(  # type: ignore[override]
+        self,
+        x: Tensor | dict[str, Tensor],
+        y: Tensor | dict[str, Tensor] | None,
+        *,
+        only_return_standard_out: bool = True,
+        categorical_inds: list[list[int]] | None = None,
+        performance_options: PerformanceOptions | None = None,
+        return_kv_cache: bool = False,
+        kv_cache: TabPFNV3Cache | None = None,
+        x_is_test_only: bool = False,
+    ) -> Tensor | tuple[Tensor, TabPFNV3Cache]:
+        return super().forward(
+            x,
+            y,
+            only_return_standard_out=only_return_standard_out,
+            categorical_inds=categorical_inds,
+            performance_options=performance_options,
+            return_kv_cache=return_kv_cache,
+            kv_cache=kv_cache,
+            x_is_test_only=x_is_test_only,
+        )
 
 
 def test__cache_preprocessing__result_equal_in_serial_and_in_parallel() -> None:
@@ -525,6 +555,7 @@ def test__explicit_kv_cache__produces_outputs() -> None:
         force_inference_dtype=None,
         save_peak_mem=True,
         autocast=False,
+        task_type="multiclass",
     )
     # _build_cache runs once per ensemble member during engine construction.
     assert model.cache_build_count == n_configs
@@ -538,6 +569,62 @@ def test__explicit_kv_cache__produces_outputs() -> None:
     # Predict consumed each cache once and did not rebuild any of them.
     assert model.cache_build_count == n_configs
     assert model.cache_used_count == n_configs
+
+
+@pytest.mark.parametrize(
+    ("model_cls", "task_type"),
+    [
+        (_TestModelWithKVCache, "multiclass"),
+        (_TestModelWithKVCache, "regression"),
+        (_TestModelWithKVCacheLegacy, "multiclass"),
+        (_TestModelWithKVCacheLegacy, "regression"),
+    ],
+)
+def test__explicit_kv_cache__task_type_forwarded_to_cache_build(
+    model_cls: type[_TestModelWithKVCache],
+    task_type: str,
+) -> None:
+    """task_type reaches the cache build only when the model expects it."""
+    rng = default_rng(seed=0)
+    n_train = 50
+    n_features = 4
+    n_classes = 3
+    n_configs = 2
+    X_train = rng.standard_normal(size=(n_train, n_features))
+    y_train = rng.integers(low=0, high=n_classes - 1, size=(n_train, 1))
+
+    ensemble_preprocessor = TabPFNEnsemblePreprocessor(
+        configs=_create_test_ensemble_configs(
+            n_configs=n_configs,
+            n_classes=n_classes,
+            num_models=1,
+        ),
+        n_samples=X_train.shape[0],
+        feature_schema=FeatureSchema.from_only_categorical_indices([], n_features),
+        random_state=rng,
+        n_preprocessing_jobs=1,
+    )
+    model = model_cls()
+    engine = InferenceEngineExplicitKVCache(
+        X_train,
+        y_train,
+        ensemble_preprocessor=ensemble_preprocessor,
+        models=[model],
+        devices=[torch.device("cpu")],
+        dtype_byte_size=4,
+        force_inference_dtype=None,
+        save_peak_mem=True,
+        autocast=False,
+        task_type=task_type,
+    )
+
+    assert model.cache_build_count == n_configs
+    assert len(engine.kv_caches) == n_configs
+    if type(model) is _TestModelWithKVCache:
+        assert model.cache_build_task_type == task_type
+    else:
+        # Models without task_type in forward still build their caches.
+        assert model.cache_build_task_type is None
 
 
 @pytest.mark.parametrize("device", get_pytest_devices())
@@ -581,6 +668,7 @@ def test__explicit_kv_cache__keep_on_device_reuses_tensors(device: str) -> None:
         force_inference_dtype=None,
         save_peak_mem="auto",
         autocast=False,
+        task_type="multiclass",
         keep_cache_on_device=True,
     )
     assert model.cache_build_count == n_configs
@@ -710,6 +798,7 @@ def test__init__mps_target_device__applies_mps_linear_bug_workaround(
         forced_inference_dtype_=None,
         memory_saving_mode=True,
         use_autocast_=False,
+        task_type="multiclass",
         inference_mode=True,
     )
 
@@ -765,6 +854,7 @@ def test__to__mps_target_device__applies_mps_linear_bug_workaround(
         forced_inference_dtype_=None,
         memory_saving_mode=True,
         use_autocast_=False,
+        task_type="multiclass",
         inference_mode=True,
     )
 


### PR DESCRIPTION
## Why

`InferenceEngineExplicitKVCache._build_cache` calls `model(...)` with
`only_return_standard_out`, `categorical_inds`, `performance_options` and
`return_kv_cache`, but never `task_type`. Architectures whose `forward`
requires that argument therefore raise during `fit`:

```
TypeError: <Architecture>.forward() missing 1 required positional argument: 'task_type'
```

so `fit_mode="fit_with_cache"` — and with it the KV cache's memory wins —
is unreachable for them. The three `_call_model` methods already do this
correctly: they guard on `_model_expectes_task_type_arg(model)` and add the
kwarg. Only the cache-build path was missing it.

## What

`task_type` is not available where it is needed: the caches are built eagerly
in the engine's `__init__`, and neither that nor `create_inference_engine`
took a `task_type`. It is now threaded from the estimator, which knows its
task — `"multiclass"` from `TabPFNClassifier`, `"regression"` from
`TabPFNRegressor`.

It cannot be defaulted: both y-encoders (column stage and ICL stage) and the
output head are per-task, so a cache built for the wrong task would be
silently wrong rather than failing. The new `create_inference_engine` and
`InferenceEngineExplicitKVCache.__init__` parameters are therefore required
keyword arguments.

Architectures without a `task_type` argument are unaffected — the
`_model_expectes_task_type_arg` guard keeps their call unchanged.

## Tests

`test__explicit_kv_cache__task_type_forwarded_to_cache_build` covers both
task types against a model that accepts `task_type` (asserts the value
reaches the build) and one that does not (asserts the cache still builds),
mirroring the existing `test__iter_outputs__task_type_forwarded`.

`pytest tests/ -k cache` — 157 passed, 9 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)