### PR TITLE
Expand a detected date into calendar features behind USE_DATES

### DIFF
--- a/changelog/1207.added.md
+++ b/changelog/1207.added.md
@@ -1,0 +1,1 @@
+`fit()` can now expand a detected date column into calendar features (year, month, day, weekday, ...) via `skrub.DatetimeEncoder`, behind a new `InferenceConfig.USE_DATES` flag that defaults to `False`. With the flag off, behavior is unchanged: a date is silently read as a plain category or text and `fit()` warns about it by name.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ dependencies = [
   "tqdm>=4.66.0",
   "filelock>=3.11.0",
   "lightgbm>=4.4",
+  # Capped: skrub is pre-1.0 and its minor releases change transformer behavior.
+  "skrub>=0.10,<0.11",
   "mlx>=0.29.3; sys_platform == 'darwin' and platform_machine == 'arm64'",
 ]
 requires-python = ">=3.10"
@@ -339,6 +341,7 @@ module = [
   "torch.*",
   "kditransform.*",
   "lightgbm.*",
+  "skrub.*",
 ]
 ignore_missing_imports = true
 

--- a/src/tabpfn/classifier.py
+++ b/src/tabpfn/classifier.py
@@ -79,6 +79,7 @@ from tabpfn.preprocessing import (
 )
 from tabpfn.preprocessing.clean import fix_dtypes, process_text_na_dataframe
 from tabpfn.preprocessing.datamodel import Feature, FeatureModality, FeatureSchema
+from tabpfn.preprocessing.date_encoding import FittedDateEncoders, expand_date_features
 from tabpfn.preprocessing.ensemble import (
     TabPFNEnsemblePreprocessor,
     scale_n_estimators_for_feature_coverage,
@@ -190,6 +191,11 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
 
     ordinal_encoder_: OrderPreservingColumnTransformer
     """The column transformer used to preprocess categorical data to be numeric."""
+
+    date_encoders_: FittedDateEncoders
+    """Fitted `DatetimeEncoder` per expanded `DATE` column (empty unless
+    `USE_DATES` is on and a date-like column was found), keyed by its original
+    column index."""
 
     tuned_classification_thresholds_: npt.NDArray[Any] | None
     """The tuned classification thresholds for each class or None if no tuning is
@@ -736,14 +742,16 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
             max_unique_for_category=self.inference_config_.MAX_UNIQUE_FOR_CATEGORICAL_FEATURES,
             min_unique_for_numerical=self.inference_config_.MIN_UNIQUE_FOR_NUMERICAL_FEATURES,
             min_cardinality_for_text=self.inference_config_.MIN_CARDINALITY_FOR_TEXT,
+            use_dates=self.inference_config_.USE_DATES,
         )
-        X, ordinal_encoder, feature_schema = clean_data(
+        X, ordinal_encoder, feature_schema, date_encoders = clean_data(
             X=X,
             feature_schema=feature_schema,
             passthrough_inf=self.get_inference_config().PASSTHROUGH_INF,
         )
         self.inferred_feature_schema_ = feature_schema
         self.ordinal_encoder_ = ordinal_encoder
+        self.date_encoders_ = date_encoders
         self.feature_names_in_ = feature_names
         self.n_features_in_ = n_features
         self.n_train_samples_ = len(X)
@@ -1096,6 +1104,9 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
             # (_raw_predict) before the per-member preprocessors run, so non-numeric
             # inputs (DataFrames, categoricals, NaNs) are handled identically.
             X_test = ensure_compatible_predict_input_sklearn(X_test, worker)  # noqa: PLW2901
+            X_test, _, _ = expand_date_features(  # noqa: PLW2901
+                X_test, feature_schema=None, fitted=worker.date_encoders_
+            )
             X_test = fix_dtypes(  # noqa: PLW2901
                 X_test,
                 cat_indices=worker.inferred_feature_schema_.indices_for(
@@ -1385,6 +1396,9 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
 
         if not self.differentiable_input:
             X = ensure_compatible_predict_input_sklearn(X, self)
+            X, _, _ = expand_date_features(
+                X, feature_schema=None, fitted=self.date_encoders_
+            )
             X = fix_dtypes(
                 X,
                 cat_indices=self.inferred_feature_schema_.indices_for(

--- a/src/tabpfn/inference_config.py
+++ b/src/tabpfn/inference_config.py
@@ -81,6 +81,14 @@ class InferenceConfig:
     follow-up that adds an actual text-encoding capability is expected to raise
     this default independently."""
 
+    USE_DATES: bool = False
+    """Whether a detected date column is expanded into calendar features.
+
+    Off by default: a detected date is read as a plain category or text, exactly
+    as if it had never been recognized as a date. When on, it is instead expanded
+    via `skrub.DatetimeEncoder` into numeric calendar features (year, month, day,
+    weekday, ...), and the raw column is dropped."""
+
     OUTLIER_REMOVAL_STD: float | None | Literal["auto"] = "auto"
     """The number of standard deviations from the mean to consider a sample an outlier.
         - If None, no outliers are removed.

--- a/src/tabpfn/preprocessing/clean.py
+++ b/src/tabpfn/preprocessing/clean.py
@@ -18,6 +18,7 @@ from packaging.version import Version
 
 from tabpfn.constants import NA_PLACEHOLDER
 from tabpfn.preprocessing.datamodel import FeatureModality
+from tabpfn.preprocessing.date_encoding import FittedDateEncoders, expand_date_features
 from tabpfn.preprocessing.steps.preprocessing_helpers import get_ordinal_encoder
 
 if TYPE_CHECKING:
@@ -102,7 +103,9 @@ def clean_data(
     feature_schema: FeatureSchema,
     *,
     passthrough_inf: bool = False,
-) -> tuple[np.ndarray, OrderPreservingColumnTransformer, FeatureSchema]:
+) -> tuple[
+    np.ndarray, OrderPreservingColumnTransformer, FeatureSchema, FittedDateEncoders
+]:
     """Clean the data by converting dtypes and ordinally encoding categorical columns.
 
     Args:
@@ -113,9 +116,13 @@ def clean_data(
             `process_text_na_dataframe`).
 
     Returns:
-        A tuple containing the cleaned data, the ordinal encoder, and the inferred
-        feature modalities.
+        A tuple containing the cleaned data, the ordinal encoder, the inferred
+        feature modalities, and the fitted date-expansion encoders (empty when
+        no `DATE`-modality column was expanded).
     """
+    X, feature_schema, date_encoders = expand_date_features(X, feature_schema)
+    assert feature_schema is not None
+
     cat_indices = feature_schema.indices_for(FeatureModality.CATEGORICAL)
 
     # Ensure categories are ordinally encoded
@@ -144,6 +151,7 @@ def clean_data(
             np.array(X, dtype=np.float64, order="F", copy=True),
             ord_encoder,
             feature_schema,
+            date_encoders,
         )
 
     # Will convert inferred categorical indices to category dtype,
@@ -158,7 +166,7 @@ def clean_data(
         passthrough_inf=passthrough_inf,
     )
 
-    return X_numpy, ord_encoder, feature_schema
+    return X_numpy, ord_encoder, feature_schema, date_encoders
 
 
 def coerce_nullable_dtypes_to_numpy(X: pd.DataFrame) -> pd.DataFrame:

--- a/src/tabpfn/preprocessing/date_encoding.py
+++ b/src/tabpfn/preprocessing/date_encoding.py
@@ -1,0 +1,126 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
+"""Expand a detected `DATE` column into calendar features via `skrub.DatetimeEncoder`.
+
+Only reached when `InferenceConfig.USE_DATES` is on: `detect_feature_modalities`
+already demotes a date-like column to `CATEGORICAL`/`TEXT` when it is off, since
+nothing would consume `FeatureModality.DATE` otherwise.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pandas as pd
+
+from tabpfn.preprocessing.datamodel import FeatureModality
+
+if TYPE_CHECKING:
+    import numpy as np
+    from skrub import DatetimeEncoder
+
+    from tabpfn.preprocessing.datamodel import FeatureSchema
+
+#: Fitted (encoder, output column names) per original column index.
+FittedDateEncoders = dict[int, tuple[Any, list[str]]]
+
+
+def make_datetime_encoder() -> DatetimeEncoder:
+    """Build the encoder that turns a datetime column into calendar features.
+
+    Returns:
+        An encoder producing the year, the day of year, the seconds since epoch,
+        and the cyclical month, day and weekday pairs, plus the time of day when
+        the column carries one.
+    """
+    # Imported here rather than at module scope: skrub depends on matplotlib, and
+    # importing it eagerly would pull a plotting stack into every `import tabpfn`.
+    from skrub import DatetimeEncoder  # noqa: PLC0415
+
+    return DatetimeEncoder(
+        resolution="second",
+        add_weekday=True,
+        add_day_of_year=True,
+        periodic_encoding="circular",
+    )
+
+
+def expand_date_features(
+    X: np.ndarray,
+    feature_schema: FeatureSchema | None,
+    *,
+    fitted: FittedDateEncoders | None = None,
+) -> tuple[np.ndarray, FeatureSchema | None, FittedDateEncoders]:
+    """Expand every `DATE`-modality column into numbers, via `DatetimeEncoder`.
+
+    A genuine single-column transformer (`.fit(series)`), not
+    `skrub.TableVectorizer`: the type decision was already made by
+    `detect_feature_modalities`, so no automatic detection is wanted here, only
+    the feature engineering. Unconditionally safe to call: a no-op whenever
+    there is no `DATE`-tagged column, which is always true when `USE_DATES` is
+    off, since detection already demoted everything by then.
+
+    Args:
+        X: The data, before any dtype fixing.
+        feature_schema: The schema from `detect_feature_modalities`. Only
+            consulted when `fitted` is `None` (the fit-time path); at predict
+            time the encoders already fitted carry everything they need, so
+            this may be left `None`.
+        fitted: Previously fitted `(encoder, output_names)` pairs keyed by
+            original column index, to reuse at predict time. `None` fits new
+            ones instead (the fit-time path).
+
+    Returns:
+        The (possibly wider) data, the updated schema (unchanged, and possibly
+        `None`, at predict time), and the fitted encoders to store and pass
+        back in as `fitted` at predict time.
+    """
+    if fitted is not None:
+        to_expand = sorted(fitted)
+    else:
+        assert feature_schema is not None, "feature_schema is required to fit"
+        to_expand = sorted(feature_schema.indices_for(FeatureModality.DATE))
+    if not to_expand:
+        return X, feature_schema, fitted or {}
+
+    frame = pd.DataFrame(X, copy=False).reset_index(drop=True)
+    new_fitted: FittedDateEncoders = {}
+    encoded_blocks: list[pd.DataFrame] = []
+    for index in to_expand:
+        # Renamed to a plain string regardless of what the frame's own column
+        # labels are: skrub's encoder builds its output feature names from the
+        # input series' `.name`, and a bare `pd.DataFrame(ndarray)` has integer
+        # column labels, which `DatetimeEncoder` cannot concatenate a suffix onto.
+        column = frame.iloc[:, index].rename(str(index))
+        # `format="mixed"` matters here, not just for speed: without it,
+        # `to_datetime` infers one format from an early value and coerces every
+        # later value that doesn't match it to NaT, even genuinely valid dates
+        # (verified: a column mixing "2020-01-01" and "2020-06-15 13:45:30"
+        # silently drops the second to NaT under the default format inference).
+        column = pd.to_datetime(column, errors="coerce", format="mixed")
+        if fitted is not None:
+            encoder, names = fitted[index]
+            encoded = pd.DataFrame(encoder.transform(column)).set_axis(names, axis=1)
+        else:
+            assert feature_schema is not None
+            encoder = make_datetime_encoder()
+            raw_encoded = pd.DataFrame(encoder.fit_transform(column))
+            prefix = feature_schema.features[index].name
+            names = [f"{prefix}_{i}" for i in range(raw_encoded.shape[1])]
+            encoded = raw_encoded.set_axis(names, axis=1)
+            new_fitted[index] = (encoder, names)
+        encoded_blocks.append(encoded.reset_index(drop=True))
+
+    remaining = frame.drop(columns=frame.columns[to_expand])
+    out = pd.concat([remaining, *encoded_blocks], axis=1)
+
+    schema = feature_schema
+    if fitted is None:
+        assert schema is not None
+        schema = schema.remove_columns(to_expand)
+        for _, names in new_fitted.values():
+            schema = schema.append_columns(
+                FeatureModality.NUMERICAL, len(names), names=names
+            )
+
+    return out.to_numpy(), schema, (fitted if fitted is not None else new_fitted)

--- a/src/tabpfn/preprocessing/modality_detection.py
+++ b/src/tabpfn/preprocessing/modality_detection.py
@@ -41,6 +41,7 @@ def detect_feature_modalities(
     min_unique_for_numerical: int,
     min_cardinality_for_text: int,
     provided_categorical_indices: Sequence[int] | None = None,
+    use_dates: bool = False,
 ) -> FeatureSchema:
     """Infer each feature's modality, using heuristics and declared categoricals.
 
@@ -60,6 +61,9 @@ def detect_feature_modalities(
         min_cardinality_for_text: Unique-value count above which a candidate
             string column (not parsed as a number or date) is `TEXT` rather than
             `CATEGORICAL` -- independent of the two thresholds above.
+        use_dates: Whether a detected date column is left as `DATE` for the
+            caller to expand, rather than demoted to `CATEGORICAL`/`TEXT`. Does
+            not otherwise change what counts as a date (see `_resolve_dates`).
 
     Returns:
         The inferred `FeatureSchema`.
@@ -80,45 +84,57 @@ def detect_feature_modalities(
             big_enough_n_to_infer_cat=big_enough_n_to_infer_cat,
         )
         features.append(Feature(name=feature_name, modality=feat_modality))
-    feature_schema = FeatureSchema(features=features)
-    _warn_on_multimodal(
-        feature_schema, declared_cat_indices=provided_categorical_indices
-    )
-    return _demote_dates_for_now(
-        feature_schema,
+    feature_schema, demoted_date_columns = _resolve_dates(
+        FeatureSchema(features=features),
         X,
+        use_dates=use_dates,
         provided_categorical_indices=provided_categorical_indices,
         max_unique_for_category=max_unique_for_category,
         min_unique_for_numerical=min_unique_for_numerical,
         min_cardinality_for_text=min_cardinality_for_text,
         big_enough_n_to_infer_cat=big_enough_n_to_infer_cat,
     )
+    _warn_on_multimodal(
+        feature_schema,
+        demoted_date_columns,
+        declared_cat_indices=provided_categorical_indices,
+    )
+    return feature_schema
 
 
-def _demote_dates_for_now(
+def _resolve_dates(
     feature_schema: FeatureSchema,
     X: np.ndarray,
     *,
+    use_dates: bool,
     provided_categorical_indices: Sequence[int] | None,
     max_unique_for_category: int,
     min_unique_for_numerical: int,
     min_cardinality_for_text: int,
     big_enough_n_to_infer_cat: bool,
-) -> FeatureSchema:
-    """Temporary: demote every detected `DATE` feature to `CATEGORICAL`/`TEXT`.
+) -> tuple[FeatureSchema, list[str]]:
+    """Decide what to do with every detected `DATE` feature.
 
-    Nothing expands a date into calendar features yet, so `DATE` isn't
-    consumable downstream -- demoted the same way a same-shaped non-date
-    string would be. A follow-up adding real date expansion should delete this
-    function outright. Called after `_warn_on_multimodal`, while the schema
-    still says `DATE`.
+    A low-cardinality date is always demoted to `CATEGORICAL`, via the same
+    `_detect_numeric_as_categorical` check a low-cardinality *number* already
+    gets, regardless of `use_dates`: a handful of repeating dates is a category,
+    not a signal worth expanding. Everything else is left tagged `DATE` when
+    `use_dates` is on, for the caller to expand into calendar features, or
+    demoted via the text-cardinality split when it is off, exactly as a
+    same-shaped non-date string would be.
+
+    Returns:
+        The updated schema, and the names of columns demoted by the
+        text-cardinality split (not the low-cardinality ones, which never
+        warrant a warning either) -- for the caller to warn about by name.
     """
     date_indices = feature_schema.indices_for(FeatureModality.DATE)
     if not date_indices:
-        return feature_schema
+        return feature_schema, []
 
     declared = set(provided_categorical_indices or ())
     features = list(feature_schema.features)
+    demoted_columns = []
     for index in date_indices:
         n_unique = _get_unique_with_sklearn_compatible_error(pd.Series(X[:, index]))
         if _detect_numeric_as_categorical(
@@ -128,15 +144,20 @@ def _demote_dates_for_now(
             min_unique_for_numerical=min_unique_for_numerical,
             big_enough_n_to_infer_cat=big_enough_n_to_infer_cat,
         ):
-            demoted = FeatureModality.CATEGORICAL
-        else:
-            demoted = (
-                FeatureModality.CATEGORICAL
-                if n_unique <= min_cardinality_for_text
-                else FeatureModality.TEXT
+            features[index] = dataclasses.replace(
+                features[index], modality=FeatureModality.CATEGORICAL
             )
+            continue
+        if use_dates:
+            continue
+        demoted = (
+            FeatureModality.CATEGORICAL
+            if n_unique <= min_cardinality_for_text
+            else FeatureModality.TEXT
+        )
         features[index] = dataclasses.replace(features[index], modality=demoted)
-    return FeatureSchema(features=features)
+        demoted_columns.append(features[index].name.removeprefix(INPUT_FEATURE_PREFIX))
+    return FeatureSchema(features=features), demoted_columns
 
 
 def _format_names_for_warning(names: list[str]) -> str:
@@ -150,38 +171,45 @@ def _format_names_for_warning(names: list[str]) -> str:
 
 def _warn_on_multimodal(
     feature_schema: FeatureSchema,
+    demoted_date_columns: list[str],
     *,
     declared_cat_indices: Sequence[int] | None = None,
 ) -> None:
-    """Warn about detected dates, then about any remaining free-text columns.
+    """Warn about demoted dates, then about any remaining free-text columns.
 
-    Called before `_demote_dates_for_now` acts on `DATE`, so a date column
-    isn't `TEXT` yet and needs no special-casing to avoid a double warning.
+    Called after `_resolve_dates`, so a column left tagged `DATE` (because
+    `use_dates` is on) is genuinely about to be expanded and gets no warning --
+    only `demoted_date_columns` (silently downgraded because `use_dates` is off)
+    does. A column demoted to `TEXT` by the cardinality split is excluded from
+    the free-text warning below, via `demoted_date_columns`, so it isn't
+    reported twice with remedies that don't apply to a date.
 
     Args:
-        feature_schema: The schema produced by detection, before `DATE` is acted on.
+        feature_schema: The schema `_resolve_dates` produced.
+        demoted_date_columns: Names of columns `_resolve_dates` demoted via the
+            text-cardinality split.
         declared_cat_indices: Indices passed as `categorical_features_indices`;
             never reported, since declaring a column categorical means the user
             already intends its non-numeric values as categories.
     """
-    date_columns = [
-        feature_schema.features[index].name.removeprefix(INPUT_FEATURE_PREFIX)
-        for index in feature_schema.indices_for(FeatureModality.DATE)
-    ]
-    if date_columns:
+    if demoted_date_columns:
         warnings.warn(
             f"These columns hold dates, which are not yet expanded into calendar "
             f"features, so they are read as plain categories or text: "
-            f"{_format_names_for_warning(date_columns)}.",
+            f"{_format_names_for_warning(demoted_date_columns)}.",
             UserWarning,
             stacklevel=6,
         )
 
     declared = set(declared_cat_indices or ())
+    already_reported = set(demoted_date_columns)
     text_names = [
-        feature.name.removeprefix(INPUT_FEATURE_PREFIX)
+        name
         for index, feature in enumerate(feature_schema.features)
-        if feature.modality is FeatureModality.TEXT and index not in declared
+        if feature.modality is FeatureModality.TEXT
+        and index not in declared
+        and (name := feature.name.removeprefix(INPUT_FEATURE_PREFIX))
+        not in already_reported
     ]
     if not text_names:
         return
@@ -214,7 +242,7 @@ def _detect_feature_modality(
     min_cardinality_for_text: int,
     big_enough_n_to_infer_cat: bool,
 ) -> FeatureModality:
-    """Decide a single column's modality; see `_demote_dates_for_now` for DATE."""
+    """Decide a single column's modality; see `_resolve_dates` for DATE."""
     # Early exit: once a prefix already clears every threshold below, the full
     # count would land in the same bucket, so skip scanning the rest.
     # min_cardinality_for_text is included since it can exceed the other two.

--- a/src/tabpfn/preprocessing/modality_detection.py
+++ b/src/tabpfn/preprocessing/modality_detection.py
@@ -352,6 +352,12 @@ def _is_date_like_pandas_series(s: pd.Series) -> bool:
     All-or-nothing, like `_is_numeric_pandas_series`. Only reached after the
     numeric check fails, so a numeric-looking date (e.g. `"20240101"`) is never
     reclassified here.
+
+    `format="mixed"` matters here, not just for speed: without it, `to_datetime`
+    infers one format from an early value and silently coerces every later
+    value that doesn't match it to NaT, even a genuinely valid date (verified: a
+    column mixing "2020-01-01" and "2020-06-15 13:45:30" drops the second to
+    NaT under the default format inference, with no warning at all).
     """
     non_null = s.dropna()
     if non_null.empty:
@@ -361,7 +367,7 @@ def _is_date_like_pandas_series(s: pd.Series) -> bool:
             # `to_datetime` warns when it cannot infer a format and falls back to
             # parsing value by value. This is only a probe, so that is noise.
             warnings.simplefilter("ignore")
-            parsed = pd.to_datetime(non_null, errors="coerce")
+            parsed = pd.to_datetime(non_null, errors="coerce", format="mixed")
     except (TypeError, ValueError):
         return False
     return bool(parsed.notna().all())

--- a/src/tabpfn/regressor.py
+++ b/src/tabpfn/regressor.py
@@ -81,6 +81,7 @@ from tabpfn.preprocessing import (
 )
 from tabpfn.preprocessing.clean import fix_dtypes, process_text_na_dataframe
 from tabpfn.preprocessing.datamodel import Feature, FeatureModality, FeatureSchema
+from tabpfn.preprocessing.date_encoding import FittedDateEncoders, expand_date_features
 from tabpfn.preprocessing.ensemble import (
     TabPFNEnsemblePreprocessor,
     scale_n_estimators_for_feature_coverage,
@@ -229,6 +230,11 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
 
     ordinal_encoder_: OrderPreservingColumnTransformer
     """The column transformer used to preprocess categorical data to be numeric."""
+
+    date_encoders_: FittedDateEncoders
+    """Fitted `DatetimeEncoder` per expanded `DATE` column (empty unless
+    `USE_DATES` is on and a date-like column was found), keyed by its original
+    column index."""
 
     eval_metric_: RegressorEvalMetrics
     """The validated evaluation metric to optimize for during prediction."""
@@ -880,14 +886,16 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
             max_unique_for_category=self.inference_config_.MAX_UNIQUE_FOR_CATEGORICAL_FEATURES,
             min_unique_for_numerical=self.inference_config_.MIN_UNIQUE_FOR_NUMERICAL_FEATURES,
             min_cardinality_for_text=self.inference_config_.MIN_CARDINALITY_FOR_TEXT,
+            use_dates=self.inference_config_.USE_DATES,
         )
-        X, ordinal_encoder, feature_schema = clean_data(
+        X, ordinal_encoder, feature_schema, date_encoders = clean_data(
             X=X,
             feature_schema=feature_schema,
             passthrough_inf=self.get_inference_config().PASSTHROUGH_INF,
         )
         self.inferred_feature_schema_ = feature_schema
         self.ordinal_encoder_ = ordinal_encoder
+        self.date_encoders_ = date_encoders
 
         # TODO: Introduce regressor target transformer that also keeps track of
         # target name
@@ -1489,6 +1497,9 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
             `znorm_space_bardist_` buckets, with the calibrated
             `ensemble_softmax_temperature_` applied.
         """
+        X, _, _ = expand_date_features(
+            X, feature_schema=None, fitted=self.date_encoders_
+        )
         cat_indices = self.inferred_feature_schema_.indices_for(
             FeatureModality.CATEGORICAL
         )
@@ -1715,6 +1726,9 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
             # Clean X_test as the standard predict path does, so DataFrames,
             # categoricals and NaNs behave identically.
             X_test = ensure_compatible_predict_input_sklearn(X_test, worker)  # noqa: PLW2901
+            X_test, _, _ = expand_date_features(  # noqa: PLW2901
+                X_test, feature_schema=None, fitted=worker.date_encoders_
+            )
             X_test = fix_dtypes(  # noqa: PLW2901
                 X_test,
                 cat_indices=worker.inferred_feature_schema_.indices_for(

--- a/tests/test_preprocessing/test_data_cleaning.py
+++ b/tests/test_preprocessing/test_data_cleaning.py
@@ -336,7 +336,7 @@ class TestTagFeaturesAndSanitizeData:
             n_numerical_features=len(modalities[FeatureModality.NUMERICAL]),
             n_categorical_features=len(modalities[FeatureModality.CATEGORICAL]),
         )
-        X_out, ord_encoder, _ = clean_data(
+        X_out, ord_encoder, _, _ = clean_data(
             X=input_data,
             feature_schema=schema,
         )
@@ -387,7 +387,7 @@ class TestTagFeaturesAndSanitizeData:
             n_numerical_features=len(modalities[FeatureModality.NUMERICAL]),
             n_categorical_features=len(modalities[FeatureModality.CATEGORICAL]),
         )
-        X_out, ord_encoder, _ = clean_data(
+        X_out, ord_encoder, _, _ = clean_data(
             X=input_data.values,
             feature_schema=schema,
         )
@@ -423,11 +423,11 @@ class TestTagFeaturesAndSanitizeData:
                 Feature(name="type", modality=FeatureModality.CATEGORICAL),
             ]
         )
-        X_out_first, _, feature_schema_first = clean_data(
+        X_out_first, _, feature_schema_first, _ = clean_data(
             X=df.values,
             feature_schema=schema,
         )
-        X_out_second, _, feature_schema_second = clean_data(
+        X_out_second, _, feature_schema_second, _ = clean_data(
             X=X_out_first,
             feature_schema=schema,
         )
@@ -769,7 +769,7 @@ def test__clean_data__numeric_array_converts_without_intermediate_copy(
     rng = np.random.default_rng(0)
     X = (rng.standard_normal((20, 4)) * 3).astype(dtype)
 
-    out, encoder, schema = clean_data(
+    out, encoder, schema, _ = clean_data(
         X=X, feature_schema=_numeric_schema(4), passthrough_inf=passthrough_inf
     )
 
@@ -794,7 +794,7 @@ def test__clean_data__non_finite_survive_the_numeric_shortcut(
     X[1, 2] = np.inf
     X[3, 0] = -np.inf
 
-    out, _, _ = clean_data(
+    out, _, _, _ = clean_data(
         X=X, feature_schema=_numeric_schema(3), passthrough_inf=passthrough_inf
     )
 
@@ -810,8 +810,8 @@ def test__clean_data__numeric_shortcut_matches_the_encoder_path() -> None:
     rng = np.random.default_rng(0)
     X = (rng.integers(0, 4, size=(50, 3))).astype("float64")
 
-    shortcut, _, _ = clean_data(X=X, feature_schema=_numeric_schema(3))
-    general, encoder, _ = clean_data(
+    shortcut, _, _, _ = clean_data(X=X, feature_schema=_numeric_schema(3))
+    general, encoder, _, _ = clean_data(
         X=X, feature_schema=_numeric_schema(3, cat_indices=(0,))
     )
 
@@ -1007,7 +1007,7 @@ def test__clean_data__mixed_columns_take_the_assembly_path() -> None:
         "tabpfn.preprocessing.clean._encode_into_preallocated",
         wraps=clean_module._encode_into_preallocated,
     ) as assembled:
-        out, _encoder, _ = clean_data(X=X, feature_schema=schema)
+        out, _encoder, _, _ = clean_data(X=X, feature_schema=schema)
 
     assert assembled.call_count == 1, "fell back to ColumnTransformer.fit_transform"
     # Numeric columns keep their own values, in their own positions -- the thing the
@@ -1032,7 +1032,7 @@ def test__clean_data__assembly_fits_the_encoder_sklearn_would_have() -> None:
         X.copy(), cat_indices=schema.indices_for(FeatureModality.CATEGORICAL)
     )
 
-    _, assembled, _ = clean_data(X=X, feature_schema=schema)
+    _, assembled, _, _ = clean_data(X=X, feature_schema=schema)
     reference = get_ordinal_encoder()
     reference.fit_transform(frame)
 
@@ -1057,7 +1057,7 @@ def test__clean_data__assembly_matches_the_column_transformer_exactly() -> None:
         X.copy(), cat_indices=schema.indices_for(FeatureModality.CATEGORICAL)
     )
 
-    assembled, _, _ = clean_data(X=X, feature_schema=schema)
+    assembled, _, _, _ = clean_data(X=X, feature_schema=schema)
     expected = get_ordinal_encoder().fit_transform(frame).astype(np.float64)
 
     np.testing.assert_array_equal(assembled, expected)

--- a/tests/test_preprocessing/test_date_encoding.py
+++ b/tests/test_preprocessing/test_date_encoding.py
@@ -1,0 +1,192 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
+"""Tests for `expand_date_features`."""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from tabpfn import TabPFNClassifier, TabPFNRegressor
+from tabpfn.preprocessing.datamodel import Feature, FeatureModality, FeatureSchema
+from tabpfn.preprocessing.date_encoding import expand_date_features
+
+N = 20
+
+
+def _numeric_and_date_schema() -> FeatureSchema:
+    return FeatureSchema(
+        features=[
+            Feature(name="input_num", modality=FeatureModality.NUMERICAL),
+            Feature(name="input_signed_on", modality=FeatureModality.DATE),
+        ]
+    )
+
+
+def _numeric_and_date_frame(dates: list[str]) -> np.ndarray:
+    return np.column_stack(
+        [np.arange(len(dates), dtype=object), np.array(dates, dtype=object)]
+    )
+
+
+def _dates(n: int = N) -> list[str]:
+    dates = pd.date_range("2020-01-01", periods=n, freq="D")
+    return dates.strftime("%Y-%m-%d").tolist()
+
+
+def test__no_date_columns__is_a_noop() -> None:
+    X = np.array([[1.0, 2.0], [3.0, 4.0]])
+    schema = FeatureSchema(
+        features=[
+            Feature(name="a", modality=FeatureModality.NUMERICAL),
+            Feature(name="b", modality=FeatureModality.NUMERICAL),
+        ]
+    )
+    X_out, schema_out, fitted = expand_date_features(X, schema)
+    assert X_out is X
+    assert schema_out is schema
+    assert fitted == {}
+
+
+def test__fit__removes_raw_column_and_appends_numeric_features() -> None:
+    X = _numeric_and_date_frame(_dates())
+    schema = _numeric_and_date_schema()
+
+    X_out, schema_out, fitted = expand_date_features(X, schema)
+
+    assert schema_out is not None
+    assert schema_out.indices_for(FeatureModality.DATE) == []
+    assert all(f.modality is FeatureModality.NUMERICAL for f in schema_out.features)
+    assert schema_out.num_columns == X_out.shape[1]
+    assert X_out.shape[0] == N
+    # More than just the original numeric column survives: the date expanded.
+    assert X_out.shape[1] > 2
+
+    assert list(fitted) == [1]
+    _encoder, names = fitted[1]
+    assert len(names) == X_out.shape[1] - 1
+    assert all(name.startswith("input_signed_on_") for name in names)
+    # Every expanded feature is real-valued for a fully populated date column.
+    assert np.isfinite(X_out[:, 1:].astype(float)).all()
+
+
+def test__predict__reapplies_fitted_encoder_positionally() -> None:
+    X_fit = _numeric_and_date_frame(_dates())
+    schema = _numeric_and_date_schema()
+    X_fit_out, _, fitted = expand_date_features(X_fit, schema)
+
+    X_test = _numeric_and_date_frame(_dates())
+    X_test_out, schema_out, fitted_out = expand_date_features(
+        X_test, feature_schema=None, fitted=fitted
+    )
+
+    assert schema_out is None
+    assert fitted_out is fitted
+    assert X_test_out.shape[1] == X_fit_out.shape[1]
+    # Same dates in, same encoded values out.
+    np.testing.assert_array_equal(
+        X_test_out[:, 1:].astype(float), X_fit_out[:, 1:].astype(float)
+    )
+
+
+def test__predict__value_that_no_longer_parses_as_a_date__becomes_nan() -> None:
+    """A predict-time column can drift dtype like any other fitted column; a
+    value that no longer parses coerces to NaN rather than crashing.
+    """
+    X_fit = _numeric_and_date_frame(_dates())
+    schema = _numeric_and_date_schema()
+    _, _, fitted = expand_date_features(X_fit, schema)
+
+    dates = _dates()
+    dates[3] = "not a date at all"
+    X_test = _numeric_and_date_frame(dates)
+
+    X_test_out, _, _ = expand_date_features(X_test, feature_schema=None, fitted=fitted)
+
+    assert np.isnan(X_test_out[3, 1:].astype(float)).all()
+    # Every other row is unaffected.
+    other_rows = [i for i in range(N) if i != 3]
+    assert np.isfinite(X_test_out[other_rows][:, 1:].astype(float)).all()
+
+
+def test__mixed_date_and_datetime_string_formats__all_parse() -> None:
+    """Regression: naive `pd.to_datetime` infers a format from an early value
+    and silently coerces a later, differently-shaped but valid value to NaT.
+    Verified directly: mixing "2020-01-01" and "2020-06-15 13:45:30" drops the
+    second to NaT under the default (non-"mixed") format inference.
+    """
+    dates = ["2020-01-01", "2020-06-15 13:45:30", "2021-12-31 23:59:59"]
+    X = _numeric_and_date_frame(dates)
+    schema = _numeric_and_date_schema()
+
+    X_out, _, _ = expand_date_features(X, schema)
+
+    assert np.isfinite(X_out[:, 1:].astype(float)).all()
+
+
+def _classification_or_regression_target(
+    estimator_cls: type, rng: np.random.Generator, n: int
+) -> np.ndarray:
+    if estimator_cls is TabPFNClassifier:
+        return rng.integers(0, 2, size=n)
+    return rng.normal(size=n)
+
+
+@pytest.mark.parametrize("estimator_cls", [TabPFNClassifier, TabPFNRegressor])
+def test__fit_predict__use_dates__expands_date_and_predicts(
+    estimator_cls: type,
+) -> None:
+    n = 60
+    rng = np.random.default_rng(0)
+    X = pd.DataFrame(
+        {
+            "num": rng.normal(size=n),
+            "signed_on": pd.date_range("2020-01-01", periods=n, freq="D").strftime(
+                "%Y-%m-%d"
+            ),
+        }
+    )
+    y = _classification_or_regression_target(estimator_cls, rng, n)
+
+    model = estimator_cls(
+        n_estimators=1, device="cpu", inference_config={"USE_DATES": True}
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        model.fit(X, y)
+
+    assert model.inferred_feature_schema_.indices_for(FeatureModality.DATE) == []
+    assert 1 in model.date_encoders_
+
+    if estimator_cls is TabPFNClassifier:
+        out = model.predict_proba(X)
+    else:
+        out = model.predict(X)
+    assert np.isfinite(out).all()
+
+
+def test__predict_proba_batched__use_dates__reapplies_encoder_on_worker() -> None:
+    """The ensemble-worker predict path also reapplies the fitted date encoder,
+    not just the direct-`self` path.
+    """
+    n = 60
+    rng = np.random.default_rng(0)
+    X = pd.DataFrame(
+        {
+            "num": rng.normal(size=n),
+            "signed_on": pd.date_range("2020-01-01", periods=n, freq="D").strftime(
+                "%Y-%m-%d"
+            ),
+        }
+    ).to_numpy(dtype=object)
+    y = rng.integers(0, 2, size=n)
+
+    clf = TabPFNClassifier(
+        n_estimators=1, device="cpu", inference_config={"USE_DATES": True}
+    )
+    proba = clf.predict_proba_batched([X], [y], [X[:5]])
+    assert proba.shape == (1, 5, 2)
+    assert np.isfinite(proba).all()

--- a/tests/test_preprocessing/test_modality_detection.py
+++ b/tests/test_preprocessing/test_modality_detection.py
@@ -493,11 +493,11 @@ class TestWarnOnMultimodal:
 
         with warnings.catch_warnings():
             warnings.simplefilter("error")
-            _warn_on_multimodal(schema)
+            _warn_on_multimodal(schema, [])
 
     def test__text_features__warn_with_column_names_and_remedies(self) -> None:
         with pytest.warns(UserWarning, match="look like free text") as record:
-            _warn_on_multimodal(_text_schema("review"))
+            _warn_on_multimodal(_text_schema("review"), [])
 
         message = str(record[0].message)
         # Column names are shown as the user wrote them, without the input_ prefix.
@@ -512,14 +512,14 @@ class TestWarnOnMultimodal:
         schema = _text_schema("sku", "review")
 
         with pytest.warns(UserWarning, match="look like free text") as record:
-            _warn_on_multimodal(schema, declared_cat_indices=[0])
+            _warn_on_multimodal(schema, [], declared_cat_indices=[0])
         message = str(record[0].message)
         assert "'review'" in message
         assert "'sku'" not in message
 
         with warnings.catch_warnings():
             warnings.simplefilter("error")
-            _warn_on_multimodal(schema, declared_cat_indices=[0, 1])
+            _warn_on_multimodal(schema, [], declared_cat_indices=[0, 1])
 
     def test__many_text_columns__message_is_truncated(self) -> None:
         n_extra = 5
@@ -527,7 +527,7 @@ class TestWarnOnMultimodal:
         schema = _text_schema(*(f"t{i}" for i in range(n_columns)))
 
         with pytest.warns(UserWarning, match="look like free text") as record:
-            _warn_on_multimodal(schema)
+            _warn_on_multimodal(schema, [])
 
         message = str(record[0].message)
         assert f"(and {n_extra} more)" in message
@@ -751,7 +751,7 @@ class TestDateLikeColumnDetection:
     def _numeric_column(self) -> np.ndarray:
         return np.random.default_rng(0).normal(size=self.n_rows)
 
-    def _detect(self, X: pd.DataFrame) -> FeatureSchema:
+    def _detect(self, X: pd.DataFrame, *, use_dates: bool = False) -> FeatureSchema:
         return detect_feature_modalities(
             X=X.to_numpy(dtype=object),
             feature_names=list(X.columns),
@@ -759,6 +759,7 @@ class TestDateLikeColumnDetection:
             max_unique_for_category=30,
             min_unique_for_numerical=4,
             min_cardinality_for_text=30,
+            use_dates=use_dates,
         )
 
     def _dates(self, n_unique: int) -> list[str]:
@@ -775,6 +776,29 @@ class TestDateLikeColumnDetection:
         X = pd.DataFrame({"num": self._numeric_column(), "date": self._dates(4)})
         with pytest.warns(UserWarning, match="hold dates"):
             schema = self._detect(X)
+        assert schema.features[1].modality is FeatureModality.CATEGORICAL
+
+    def test__use_dates__high_cardinality_date__stays_date_and_does_not_warn(
+        self,
+    ) -> None:
+        X = pd.DataFrame({"num": self._numeric_column(), "date": self._dates(60)})
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            schema = self._detect(X, use_dates=True)
+        assert schema.features[1].modality is FeatureModality.DATE
+
+    def test__use_dates__low_cardinality_date__is_still_categorical(self) -> None:
+        """A handful of repeating dates is a category, not worth expanding,
+        regardless of `use_dates` -- gated by `min_unique_for_numerical` (4 in
+        `_detect`), the same threshold a low-cardinality *number* is judged
+        against, strictly below which counts (3, not 4: see
+        `test__declared_categorical_date_column__is_categorical` for the
+        boundary already exercised on the `use_dates=False` side).
+        """
+        X = pd.DataFrame({"num": self._numeric_column(), "date": self._dates(3)})
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            schema = self._detect(X, use_dates=True)
         assert schema.features[1].modality is FeatureModality.CATEGORICAL
 
     def test__demoted_date__is_not_also_reported_as_free_text(self) -> None:

--- a/tests/test_preprocessing/test_modality_detection.py
+++ b/tests/test_preprocessing/test_modality_detection.py
@@ -842,6 +842,18 @@ class TestDateLikeColumnDetection:
         schema = self._detect(X)
         assert schema.features[1].modality is FeatureModality.NUMERICAL
 
+    def test__mixed_date_and_datetime_string_formats__is_still_a_date(self) -> None:
+        """Regression: naive `pd.to_datetime` infers a format from an early
+        value and silently coerces a later, differently-shaped but valid value
+        to NaT, which would otherwise fail the all-or-nothing date check.
+        """
+        values = self._dates(60)
+        values[0] = "2020-06-15 13:45:30"  # date-only pool plus one full datetime
+        X = pd.DataFrame({"num": self._numeric_column(), "date": values})
+        with pytest.warns(UserWarning, match="hold dates"):
+            schema = self._detect(X)
+        assert schema.features[1].modality is FeatureModality.TEXT
+
     def test__declared_categorical_date_column__is_categorical(self) -> None:
         """Declaring it categorical only wins within `max_unique_for_category`,
         exactly like a declared-categorical numeric column.


### PR DESCRIPTION
## What & why

Second slice of the stack, on top of #1205 (detection): a detected date can
now actually be expanded into calendar features via `skrub.DatetimeEncoder`,
behind a new `InferenceConfig.USE_DATES` flag that defaults to `False`. Off
(default), behavior is unchanged from #1205 -- a date is silently demoted and
warned about by name.

## How

- `InferenceConfig.USE_DATES`: new flag, default `False`.
- `detect_feature_modalities` gains `use_dates`, threaded to a reworked
  `_resolve_dates` (was `_demote_dates_for_now`): still detection-only in
  contract (`-> FeatureSchema`, never touches `X`) -- it decides whether to
  leave a column tagged `DATE` for the caller to expand, or demote it.
- New `date_encoding.py`: `make_datetime_encoder()` (lazy `skrub` import) and
  `expand_date_features()`, called unconditionally from `clean_data` (a no-op
  whenever there's no `DATE`-tagged column, always true when `USE_DATES` is
  off). Fits one `DatetimeEncoder` per date column, removes the raw column,
  appends the encoded output as `NUMERICAL` columns.
- `date_encoders_` (mirrors `ordinal_encoder_`'s lifecycle): fitted encoders
  keyed by original column index, reapplied positionally at predict time, on
  both the direct and ensemble-worker paths in `classifier.py`/`regressor.py`.
- `pyproject.toml`: added `skrub>=0.10,<0.11` as a hard dependency.

## Decisions

- No new "IRRELEVANT" modality: the raw column is fully removed
  (`FeatureSchema.remove_columns`) and the encoder's output appended
  (`append_columns`) -- the same pattern `remove_constant_features_step.py`
  already uses to drop a column outright.
- A low-cardinality date is always demoted to `CATEGORICAL` regardless of
  `USE_DATES`, via the same threshold a low-cardinality *number* already gets
  -- a handful of repeating dates is a category, not worth expanding.
- The warn-vs-demote call order flipped from #1205 (was warn-then-demote):
  the warning now needs to know whether a date was silently demoted
  (`USE_DATES` off, warn) or genuinely left for expansion (no warning), not
  just whether it was detected as a date.
- Fixed a real, verified bug found while building this: `pd.to_datetime`
  infers a format from an early value and silently coerces a later,
  differently-shaped but valid value to NaT with no warning (e.g. mixing
  `"2020-01-01"` and `"2020-06-15 13:45:30"`). `format="mixed"` fixes this in
  both date detection and expansion.

## Follow-ups

- `USE_TEXT` / `StringEncoder` -- separate slice, not touched here.
- The numeric-string-as-text ordinal-encoding bug from the original
  exploration -- separate, unrelated slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
