### PR TITLE
Reject non-numeric and non-date columns on a prefix, not the whole column

### DIFF
--- a/changelog/1208.changed.md
+++ b/changelog/1208.changed.md
@@ -1,0 +1,1 @@
+Speed up modality detection on large string columns. Deciding whether a column holds numbers or dates now stops at the first value that does not parse within a 1024-row prefix, instead of parsing every row first. Detection of a 1-million-row free-text column drops from roughly 14 seconds to under 20 milliseconds; the answers are unchanged.

--- a/src/tabpfn/preprocessing/modality_detection.py
+++ b/src/tabpfn/preprocessing/modality_detection.py
@@ -284,6 +284,18 @@ def _is_numeric_pandas_series(s: pd.Series) -> bool:
         return True
     if PANDAS_BELOW_3:
         return all(_is_numeric_or_missing_for_old_pandas(value) for value in s)
+    # The generator above stops at the first non-numeric value; `pd.to_numeric`
+    # coerces the whole column first, so reject on a prefix instead. See
+    # `_is_date_like_pandas_series` for why this cannot change the answer.
+    if len(s) > _EARLY_EXIT_PREFIX_ROWS and not _all_numeric_or_missing(
+        s.iloc[:_EARLY_EXIT_PREFIX_ROWS]
+    ):
+        return False
+    return _all_numeric_or_missing(s)
+
+
+def _all_numeric_or_missing(s: pd.Series) -> bool:
+    """Whether every value in `s` is a number, a spelling of one, or missing."""
     coerced = pd.to_numeric(s, errors="coerce")
     is_numeric_or_missing = coerced.notna() | s.isna()
     return bool(is_numeric_or_missing.all())
@@ -324,16 +336,36 @@ def _is_date_like_pandas_series(s: pd.Series) -> bool:
     All-or-nothing, like `_is_numeric_pandas_series`. Only reached after the
     numeric check fails, so a numeric-looking date (e.g. `"20240101"`) is never
     reclassified here.
+
+    A prefix rejects the column before the whole of it is parsed, which is exact
+    rather than approximate: one unparseable value settles the answer, and a text
+    column fails on its first. A clean prefix proves nothing, so it falls through
+    to the full parse. The prefix has to be the head specifically, since
+    `to_datetime` infers a format from the first non-null value and applies it to
+    every other one; a head starts at that same value, a sample need not.
     """
+    if len(s) > _EARLY_EXIT_PREFIX_ROWS and not _all_parse_as_dates(
+        s.iloc[:_EARLY_EXIT_PREFIX_ROWS].dropna()
+    ):
+        return False
     non_null = s.dropna()
     if non_null.empty:
         return False
+    return _all_parse_as_dates(non_null)
+
+
+def _all_parse_as_dates(s: pd.Series) -> bool:
+    """Whether every value in `s` parses as a date; vacuously true when empty.
+
+    An empty result matters for the prefix call: a head that is entirely missing
+    says nothing about the column, so it must fall through rather than reject.
+    """
     try:
         with warnings.catch_warnings():
             # `to_datetime` warns when it cannot infer a format and falls back to
             # parsing value by value. This is only a probe, so that is noise.
             warnings.simplefilter("ignore")
-            parsed = pd.to_datetime(non_null, errors="coerce")
+            parsed = pd.to_datetime(s, errors="coerce")
     except (TypeError, ValueError):
         return False
     return bool(parsed.notna().all())

--- a/tests/test_preprocessing/test_modality_detection.py
+++ b/tests/test_preprocessing/test_modality_detection.py
@@ -580,10 +580,19 @@ def test__prefix_rejection__agrees_with_parsing_the_whole_column(name: str) -> N
     ("helper_name", "detect", "passing_values"),
     [
         ("_all_parse_as_dates", _is_date_like_pandas_series, _dates_after),
-        (
+        pytest.param(
             "_all_numeric_or_missing",
             _is_numeric_pandas_series,
             lambda n: [str(i) for i in range(n)],
+            marks=pytest.mark.skipif(
+                PANDAS_BELOW_3,
+                reason=(
+                    "Below pandas 3 the numeric check walks values through an "
+                    "`all(...)` generator that already stops at the first "
+                    "non-numeric one, so it has no prefix guard to skip and never "
+                    "calls `_all_numeric_or_missing`."
+                ),
+            ),
         ),
     ],
 )

--- a/tests/test_preprocessing/test_modality_detection.py
+++ b/tests/test_preprocessing/test_modality_detection.py
@@ -12,6 +12,7 @@ import pandas as pd
 import pytest
 
 from tabpfn import TabPFNClassifier, TabPFNRegressor
+from tabpfn.preprocessing.clean import PANDAS_BELOW_3
 from tabpfn.preprocessing.datamodel import (
     INPUT_FEATURE_PREFIX,
     Feature,
@@ -22,6 +23,9 @@ from tabpfn.preprocessing.modality_detection import (
     _EARLY_EXIT_PREFIX_ROWS,
     _MAX_TEXT_COLUMNS_IN_WARNING,
     _detect_feature_modality,
+    _is_date_like_pandas_series,
+    _is_numeric_or_missing_for_old_pandas,
+    _is_numeric_pandas_series,
     _warn_on_multimodal,
     detect_feature_modalities,
 )
@@ -468,6 +472,108 @@ def test__early_exit_accounts_for_min_cardinality_for_text() -> None:
         min_cardinality_for_text=10,
     )
     assert result == FeatureModality.TEXT
+
+
+def _reference_is_date_like(s: pd.Series) -> bool:
+    """`_is_date_like_pandas_series` without the prefix rejection.
+
+    The prefix only skips work, so every answer must match this. Kept as a
+    literal copy of the pre-prefix implementation rather than expressed in terms
+    of the real one, so a change to the real one cannot silently change what
+    this compares against.
+    """
+    non_null = s.dropna()
+    if non_null.empty:
+        return False
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            parsed = pd.to_datetime(non_null, errors="coerce")
+    except (TypeError, ValueError):
+        return False
+    return bool(parsed.notna().all())
+
+
+def _reference_is_numeric(s: pd.Series) -> bool:
+    """`_is_numeric_pandas_series` without the prefix rejection."""
+    if pd.api.types.is_numeric_dtype(s.dtype):
+        return True
+    if PANDAS_BELOW_3:
+        return all(_is_numeric_or_missing_for_old_pandas(value) for value in s)
+    coerced = pd.to_numeric(s, errors="coerce")
+    return bool((coerced.notna() | s.isna()).all())
+
+
+def _dates_after(n: int, *, start: str = "2020-01-01") -> list[str]:
+    return list(pd.date_range(start, periods=n).strftime("%Y-%m-%d"))
+
+
+_PREFIX = _EARLY_EXIT_PREFIX_ROWS
+#: Columns whose prefix and tail disagree, so the prefix rejection either has to
+#: fire correctly or fall through. Named by where the disagreement sits.
+_PROBE_COLUMNS: dict[str, list[Any]] = {
+    # Fails on its very first value.
+    "free_text": [f"a fairly long sentence, number {i}" for i in range(_PREFIX + 500)],
+    # Clean prefix, one bad value the prefix can see.
+    "bad_inside_prefix": (
+        [*_dates_after(_PREFIX - 1), "not a date", *_dates_after(500)]
+    ),
+    # Clean prefix, one bad value only the full parse can see.
+    "bad_beyond_prefix": [*_dates_after(_PREFIX + 200), "not a date"],
+    # Prefix is one format, the tail another. `to_datetime` infers from the
+    # first value, so the tail coerces to NaT and the column is not a date.
+    "format_switches_beyond_prefix": (
+        _dates_after(_PREFIX + 10)
+        + list(pd.date_range("2020-01-01", periods=100).strftime("%d/%m/%Y"))
+    ),
+    # Entirely missing prefix: says nothing, so it must fall through.
+    "missing_prefix_then_dates": [None] * _PREFIX + _dates_after(200),
+    "missing_prefix_then_text": [None] * _PREFIX + ["not a date"] * 200,
+    "all_missing": [None] * (_PREFIX + 200),
+    # Numeric strings, with the offending value on either side of the prefix.
+    "numeric_strings": [str(i) for i in range(_PREFIX + 500)],
+    "non_numeric_inside_prefix": (
+        [str(i) for i in range(_PREFIX - 1)] + ["abc"] + [str(i) for i in range(500)]
+    ),
+    "non_numeric_beyond_prefix": [str(i) for i in range(_PREFIX + 200)] + ["abc"],
+}
+
+
+@pytest.mark.parametrize("name", list(_PROBE_COLUMNS))
+def test__prefix_rejection__agrees_with_parsing_the_whole_column(name: str) -> None:
+    """The prefix rejection is exact, not an approximation.
+
+    One unparseable value settles an all-or-nothing check, so rejecting on a
+    prefix can only skip work. A clean prefix proves nothing about the tail and
+    must fall through, including when the prefix is entirely missing.
+    """
+    s = pd.Series(_PROBE_COLUMNS[name], dtype=object)
+    assert _is_date_like_pandas_series(s) == _reference_is_date_like(s)
+    assert _is_numeric_pandas_series(s) == _reference_is_numeric(s)
+
+
+def test__prefix_rejection__does_not_change_short_column_behavior() -> None:
+    """A column no longer than the prefix skips the probe entirely."""
+    short = pd.Series(_dates_after(_PREFIX), dtype=object)
+    assert _is_date_like_pandas_series(short) is True
+    assert _is_date_like_pandas_series(short) == _reference_is_date_like(short)
+
+
+def test__date_probe__rejects_text_without_parsing_the_whole_column() -> None:
+    """Text is rejected off the prefix, so the tail is never parsed.
+
+    Guards the point of the change. A tail that would raise on parse proves the
+    full column was never reached; without the prefix rejection this raises.
+    """
+
+    class Unparseable:
+        def __str__(self) -> str:  # pragma: no cover - must never be reached
+            raise AssertionError("the tail must not be parsed")
+
+    s = pd.Series(
+        ["a fairly long sentence"] * _PREFIX + [Unparseable()] * 10, dtype=object
+    )
+    assert _is_date_like_pandas_series(s) is False
 
 
 def _text_schema(*names: str) -> FeatureSchema:

--- a/tests/test_preprocessing/test_modality_detection.py
+++ b/tests/test_preprocessing/test_modality_detection.py
@@ -12,6 +12,7 @@ import pandas as pd
 import pytest
 
 from tabpfn import TabPFNClassifier, TabPFNRegressor
+from tabpfn.preprocessing import modality_detection
 from tabpfn.preprocessing.clean import PANDAS_BELOW_3
 from tabpfn.preprocessing.datamodel import (
     INPUT_FEATURE_PREFIX,
@@ -508,38 +509,61 @@ def _dates_after(n: int, *, start: str = "2020-01-01") -> list[str]:
     return list(pd.date_range(start, periods=n).strftime("%Y-%m-%d"))
 
 
-_PREFIX = _EARLY_EXIT_PREFIX_ROWS
-#: Columns whose prefix and tail disagree, so the prefix rejection either has to
-#: fire correctly or fall through. Named by where the disagreement sits.
+#: Prefix these tests run the rejection at. The logic is identical at any size,
+#: so a smaller one than production keeps the columns below cheap to build and
+#: easy to reason about. Only `test__prefix_rejection__fires_within_the_real_prefix`
+#: uses the production value, since that is the one thing a shrunk prefix cannot
+#: check.
+_TEST_PREFIX_ROWS = 50
+
+
+@pytest.fixture
+def small_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Shrink the rejection prefix so test columns can stay a handful of rows."""
+    monkeypatch.setattr(
+        modality_detection, "_EARLY_EXIT_PREFIX_ROWS", _TEST_PREFIX_ROWS
+    )
+
+
+#: Columns whose prefix and tail disagree, so the rejection either has to fire
+#: correctly or fall through. Named by where the disagreement sits. Every column
+#: is longer than `_TEST_PREFIX_ROWS`, or the guard would not run at all.
+_TAIL = 10
+_NUMBERS = [str(i) for i in range(_TEST_PREFIX_ROWS + _TAIL)]
 _PROBE_COLUMNS: dict[str, list[Any]] = {
+    # Clean prefix and clean tail: the guard must fall through and answer True.
+    # Without this, a guard that rejects whenever the prefix is clean still
+    # agrees with the reference on every column that is genuinely not a date.
+    "dates": _dates_after(_TEST_PREFIX_ROWS + _TAIL),
     # Fails on its very first value.
-    "free_text": [f"a fairly long sentence, number {i}" for i in range(_PREFIX + 500)],
+    "text": [f"a sentence, number {i}" for i in range(_TEST_PREFIX_ROWS + _TAIL)],
     # Clean prefix, one bad value the prefix can see.
-    "bad_inside_prefix": (
-        [*_dates_after(_PREFIX - 1), "not a date", *_dates_after(500)]
-    ),
+    "bad_inside_prefix": [
+        *_dates_after(_TEST_PREFIX_ROWS - 1),
+        "not a date",
+        *_dates_after(_TAIL),
+    ],
     # Clean prefix, one bad value only the full parse can see.
-    "bad_beyond_prefix": [*_dates_after(_PREFIX + 200), "not a date"],
-    # Prefix is one format, the tail another. `to_datetime` infers from the
-    # first value, so the tail coerces to NaT and the column is not a date.
-    "format_switches_beyond_prefix": (
-        _dates_after(_PREFIX + 10)
-        + list(pd.date_range("2020-01-01", periods=100).strftime("%d/%m/%Y"))
-    ),
-    # Entirely missing prefix: says nothing, so it must fall through.
-    "missing_prefix_then_dates": [None] * _PREFIX + _dates_after(200),
-    "missing_prefix_then_text": [None] * _PREFIX + ["not a date"] * 200,
-    "all_missing": [None] * (_PREFIX + 200),
+    "bad_beyond_prefix": [*_dates_after(_TEST_PREFIX_ROWS + _TAIL), "not a date"],
+    # Prefix is one format, the tail another. `to_datetime` infers a format from
+    # the first value, so the tail coerces to NaT and this is not a date column.
+    "format_switches_beyond_prefix": [
+        *_dates_after(_TEST_PREFIX_ROWS + 1),
+        *pd.date_range("2020-06-01", periods=_TAIL).strftime("%d/%m/%Y"),
+    ],
+    # An entirely missing prefix says nothing, so it must fall through.
+    "missing_prefix_then_dates": [None] * _TEST_PREFIX_ROWS + _dates_after(_TAIL),
+    "missing_prefix_then_text": [None] * _TEST_PREFIX_ROWS + ["not a date"] * _TAIL,
+    "all_missing": [None] * (_TEST_PREFIX_ROWS + _TAIL),
     # Numeric strings, with the offending value on either side of the prefix.
-    "numeric_strings": [str(i) for i in range(_PREFIX + 500)],
-    "non_numeric_inside_prefix": (
-        [str(i) for i in range(_PREFIX - 1)] + ["abc"] + [str(i) for i in range(500)]
-    ),
-    "non_numeric_beyond_prefix": [str(i) for i in range(_PREFIX + 200)] + ["abc"],
+    "numeric_strings": _NUMBERS,
+    "non_numeric_inside_prefix": [*_NUMBERS[: _TEST_PREFIX_ROWS - 1], "abc", *_NUMBERS],
+    "non_numeric_beyond_prefix": [*_NUMBERS, "abc"],
 }
 
 
 @pytest.mark.parametrize("name", list(_PROBE_COLUMNS))
+@pytest.mark.usefixtures("small_prefix")
 def test__prefix_rejection__agrees_with_parsing_the_whole_column(name: str) -> None:
     """The prefix rejection is exact, not an approximation.
 
@@ -552,18 +576,72 @@ def test__prefix_rejection__agrees_with_parsing_the_whole_column(name: str) -> N
     assert _is_numeric_pandas_series(s) == _reference_is_numeric(s)
 
 
-def test__prefix_rejection__does_not_change_short_column_behavior() -> None:
-    """A column no longer than the prefix skips the probe entirely."""
-    short = pd.Series(_dates_after(_PREFIX), dtype=object)
-    assert _is_date_like_pandas_series(short) is True
-    assert _is_date_like_pandas_series(short) == _reference_is_date_like(short)
+@pytest.mark.parametrize(
+    ("helper_name", "detect", "passing_values"),
+    [
+        ("_all_parse_as_dates", _is_date_like_pandas_series, _dates_after),
+        (
+            "_all_numeric_or_missing",
+            _is_numeric_pandas_series,
+            lambda n: [str(i) for i in range(n)],
+        ),
+    ],
+)
+@pytest.mark.usefixtures("small_prefix")
+def test__prefix_rejection__skips_the_guard_on_a_short_column(
+    helper_name: str,
+    detect: Any,
+    passing_values: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A column no longer than the prefix is parsed once, not twice.
+
+    Counting the parses rather than the answer, since parsing twice gives the
+    same answer. A longer column that clears its prefix is parsed twice, which
+    is the cost this trade accepts.
+    """
+    real = getattr(modality_detection, helper_name)
+    parses = []
+
+    def counting(s: pd.Series) -> bool:
+        parses.append(len(s))
+        return real(s)
+
+    monkeypatch.setattr(modality_detection, helper_name, counting)
+
+    assert detect(pd.Series(passing_values(_TEST_PREFIX_ROWS), dtype=object)) is True
+    assert len(parses) == 1
+
+    parses.clear()
+    assert (
+        detect(pd.Series(passing_values(_TEST_PREFIX_ROWS + 2), dtype=object)) is True
+    )
+    assert len(parses) == 2
 
 
-def test__date_probe__rejects_text_without_parsing_the_whole_column() -> None:
-    """Text is rejected off the prefix, so the tail is never parsed.
+@pytest.mark.usefixtures("small_prefix")
+def test__prefix_rejection__reads_the_head_so_day_first_dates_survive() -> None:
+    """A real date column must not be rejected off an unrepresentative prefix.
 
-    Guards the point of the change. A tail that would raise on parse proves the
-    full column was never reached; without the prefix rejection this raises.
+    `to_datetime` infers a format from the first non-null value and applies it to
+    the rest, so a prefix starting anywhere else can infer a different format and
+    coerce valid values to `NaT`. Here `13/01/2020` pins `%d/%m/%Y` for the whole
+    column and every value parses, but a prefix starting at `06/03/2020` is
+    ambiguous, infers `%m/%d/%Y`, and rejects `13/01/2020` as month 13. Reading
+    the head keeps the prefix and the full pass in agreement; sampling would not.
+    """
+    s = pd.Series(["13/01/2020", "05/02/2020", "06/03/2020"] * 30, dtype=object)
+    assert _is_date_like_pandas_series(s) is True
+    assert _is_date_like_pandas_series(s) == _reference_is_date_like(s)
+
+
+def test__prefix_rejection__fires_within_the_real_prefix() -> None:
+    """The guard rejects off `_EARLY_EXIT_PREFIX_ROWS`, not some other length.
+
+    The tests above shrink the prefix, so this is the one that exercises the
+    production value. A tail that raises when parsed proves the full column was
+    never reached, which only holds if the guard rejected inside the leading
+    `_EARLY_EXIT_PREFIX_ROWS` rows.
     """
 
     class Unparseable:
@@ -571,7 +649,8 @@ def test__date_probe__rejects_text_without_parsing_the_whole_column() -> None:
             raise AssertionError("the tail must not be parsed")
 
     s = pd.Series(
-        ["a fairly long sentence"] * _PREFIX + [Unparseable()] * 10, dtype=object
+        ["a fairly long sentence"] * _EARLY_EXIT_PREFIX_ROWS + [Unparseable()] * 10,
+        dtype=object,
     )
     assert _is_date_like_pandas_series(s) is False
 


### PR DESCRIPTION
## What & why

Modality detection asks two all-or-nothing questions about every column: is
every value a number, and is every value a date? Both were answered by coercing
all n rows first (`errors="coerce"`, which turns failures into `NaN`/`NaT`) and
only then checking whether anything had failed.

But a single failing value settles an all-or-nothing question, and a free-text
column fails on its very first value. So we parsed a million values to learn what
value one already told us.

It is worse for dates than for numbers. When `to_datetime` cannot infer a format
from the first value it leaves its vectorised path and parses one value at a time
through `dateutil`, in interpreted Python, at roughly 14 µs per value. The
`UserWarning` the code suppresses is pandas announcing exactly that.

Measured at 1M rows on one column: the date check cost **13.8 s** on a free-text
column, and the numeric check another **240 ms**. Neither was gated by anything.
The existing `_EARLY_EXIT_PREFIX_ROWS` shortcut, despite the name, only ever
covered the distinct-value count at line 231.

## How

Reject on a 1024-row prefix before committing to the full pass, in both
functions:

```python
if len(s) > _EARLY_EXIT_PREFIX_ROWS and not _all_parse_as_dates(
    s.iloc[:_EARLY_EXIT_PREFIX_ROWS].dropna()
):
    return False
```

This is the same move #1137 made for the distinct count, applied to the two
passes it did not cover, reusing the same constant. The parse bodies move into
`_all_numeric_or_missing` and `_all_parse_as_dates` so the prefix and the full
column go through identical code rather than two copies that can drift.

Measured at 1M rows on one column, per detection pass (Apple M5, macOS 26.3,
python 3.12.12, pandas 3.0.5, single process):

| column | numeric check | date check |
| -- | -- | -- |
| free text, all unique | 240.0 ms to **0.5 ms** | 13,807.5 ms to **14.4 ms** |
| ISO dates | 222.7 ms to **0.3 ms** | 57.5 ms to 64.3 ms |
| 4-value category | 218.5 ms to **0.3 ms** | 42.6 ms to **0.6 ms** |

Whole-column detection: free text 14,049 ms to 15 ms, ISO dates 280 ms to 65 ms,
low-cardinality category 276 ms to 16 ms. The numeric check collapses further
than the prefix size suggests because on a string column the *first* value
already fails, so it rejects at value one rather than value 1024.

Reading the rows the other way, since it is easy to misread: 13.8 s was the
**date check on a free-text column**, not the cost of a date column. A genuine
date column was 57.5 ms. Across nine real date formats at 1M rows the worst was
658 ms (`Sun, 02 Jul 2023`), so there is no date-shaped case at seconds scale.

Nothing changes for columns at or below 1024 rows: the guard is skipped and the
code runs exactly as before.

## Decisions

**This is exact, not an approximation.** A prefix can only ever prove `False`,
because one failing value settles an all-or-nothing check. A clean prefix proves
nothing about the tail, so it falls through to the same full pass as before.
There is no path that answers `True` without having parsed the entire column.

**The prefix has to be the head, not a sample.** `to_datetime` infers a format
from the first non-null value and applies it to every other one, so a value's
verdict depends on what precedes it. A test pins this to a concrete case:
`['13/01/2020', '05/02/2020', '06/03/2020']` is a real date column, because value
one is unambiguously day-first and fixes `%d/%m/%Y` for the rest. A prefix
starting at `06/03/2020` is ambiguous, infers `%m/%d/%Y`, and rejects
`13/01/2020` as month 13. A head starts where the full pass starts, so the two
cannot disagree. Sampling can, and now fails the suite.

**An all-missing prefix falls through rather than rejecting**, since it says
nothing about the column. `_all_parse_as_dates` is therefore vacuously true on
empty input, and that is load-bearing rather than incidental.

**Slice before dropping NA.** `s.dropna()` on a 1M-row column costs 9.7 ms, while
parsing 1024 values costs 0.2 ms. Doing the full `dropna()` first would put a
10 ms floor under every column; slicing first keeps the reject path off the full
column entirely.

**Cost accepted:** a genuine date column now parses its prefix twice, about 7 ms
more at 1M rows. Every other column shape gains.

**On the tests.** The core one asserts both functions agree with verbatim copies
of the pre-prefix implementations, across 11 column shapes whose prefix and tail
disagree: a bad value inside the prefix, beyond it, a format switch beyond it, an
all-missing prefix followed by real dates, an all-missing column, a clean date
column, and the numeric equivalents. The copies are kept verbatim rather than
expressed in terms of the real functions, so changing one cannot silently move
what the other is compared against.

These tests shrink the prefix to 50 via a fixture so the columns stay small; one
test keeps the production constant, since a shrunk prefix cannot check that the
guard rejects off `_EARLY_EXIT_PREFIX_ROWS` rather than some other length. A
further test counts parses rather than answers, because parsing twice gives the
same answer and would otherwise go unnoticed. That case is skipped below
pandas 3, where the numeric check walks an `all(...)` generator that already
stops at the first non-numeric value and so has no guard to skip.

Verified on the environment CI's lowest-direct job actually resolves, python
3.10.19 with pandas 1.4.0, as well as locally on 3.12.12 with pandas 3.0.5.
Mutation testing was used to confirm the tests bite: inverting either guard,
making an empty prefix reject, dropping the length check, taking the prefix from
the tail, and replacing it with a random sample are each caught.

## Follow-ups

**`format="mixed"` is worth a look, but not here.** Passing it makes
`to_datetime` infer a format per element instead of once from the first value.
Measured at 200k rows on pandas 3.0.5:

| column | current (inferred) | `format="mixed"` | `format="ISO8601"` |
| -- | -- | -- | -- |
| ISO dates | True, 14 ms | True, 19 ms | True, **8 ms** |
| `%m/%d/%Y` dates | True, 95 ms | True, **23 ms** | **False**, 31 ms |
| mixed-format dates | **False**, 41 ms | **True**, 781 ms | False, 25 ms |
| free text | False, 2836 ms (warns) | False, 2759 ms | False, **35 ms** |

Three things fall out. It closes a real detection gap, since a column mixing
`2024-01-15` with `15/01/2024` is genuinely dates and we currently answer False.
It removes the need to suppress the warning, because passing the option is an
explicit opt-in to per-element parsing. And it makes verdicts
context-independent, which would retire the head-versus-sample constraint above.

Two catches keep it out of this PR. First, it is silently wrong on our declared
floor: `pyproject.toml` allows `pandas>=1.4.0`, and on pandas 1.5.3 the option
does not exist, so `"mixed"` is taken as a literal strftime string and
`['2024-01-15', '15/01/2024']` both coerce to `NaT`. Not an error, just a silent
False for every column, which would switch date detection off entirely. It needs
a version guard. Second, it changes *which* columns are `DATE`. That is invisible
today, since every `DATE` is demoted in `_demote_dates_for_now`, but it becomes
material the moment #1207 lands real calendar-feature expansion. It belongs
there, with the rest of the date semantics.

`format="ISO8601"` is the surprise in that table: it rejects free text in 35 ms
rather than 2836 ms, because it uses the strict C parser and never reaches
`dateutil`. A large reject-path win with no prefix trick at all, but it narrows
"date" to ISO only, so `%m/%d/%Y` columns stop being dates. Also a behaviour
change, also not this PR.

**A detection gap found while measuring, unrelated to performance.** European
dotted dates are not recognised at all:

```python
pd.to_datetime(['02.07.2023', '25.12.2023', '14.03.2024'], errors='coerce')
# [Timestamp('2023-02-07'), NaT, NaT]
```

Day/month ambiguity makes pandas infer `%m.%d.%Y` from `02.07.2023`, so
`25.12.2023` is month 25 and coerces to `NaT`, the all-or-nothing check fails,
and the column is read as a plain category or text. Note the first value is also
silently misparsed as 7 February rather than 2 July. Cosmetic today, since every
`DATE` is demoted; not cosmetic once #1207 builds features from it. Same root
cause as `format="mixed"` above, which fixes it.

**The remaining bottleneck moves rather than disappearing.** `X` arrives as a
single ndarray, so one text column forces the whole array to object dtype and
every column then takes the pandas path. Genuinely-numeric columns still pay a
full `to_numeric` (240 ms per 1M rows per column) that a prefix cannot
short-circuit, because their values really are numeric, purely to rediscover a
dtype the input `DataFrame` already knew. Threading per-column dtype through from
validation would remove it. For a 1M x 20 table with 3 text columns, detection
goes from about 46 s to about 4.1 s with this PR, and that residual 4.1 s is
entirely the 17 numeric columns paying that cost.

**Parsing only distinct values** would help tall date columns, which this PR does
not speed up: 502 ms to 28 ms at 1M rows for `%m/%d/%Y`. But it is useless on
free text, where every value is unique, and actively worse on all-distinct
timestamps (74 ms to 149 ms), so it needs gating on the `n_unique` the caller
already computes. Left out here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
