### PR TITLE
perf: fuse float64 upcast with defensive copy

### DIFF
--- a/changelog/1218.changed.md
+++ b/changelog/1218.changed.md
@@ -1,0 +1,1 @@
+`clean_data` no longer casts a numeric input to float64; the preprocessing pipeline widens its own copy instead, cutting peak host RAM on a 1M x 2000 float32 fit + predict from 26.1 GB to 15.4 GB with identical outputs.

--- a/src/tabpfn/classifier.py
+++ b/src/tabpfn/classifier.py
@@ -77,7 +77,7 @@ from tabpfn.preprocessing import (
     clean_data,
     generate_classification_ensemble_configs,
 )
-from tabpfn.preprocessing.clean import fix_dtypes, process_text_na_dataframe
+from tabpfn.preprocessing.clean import clean_data_transform
 from tabpfn.preprocessing.datamodel import Feature, FeatureModality, FeatureSchema
 from tabpfn.preprocessing.ensemble import (
     TabPFNEnsemblePreprocessor,
@@ -1096,14 +1096,11 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
             # (_raw_predict) before the per-member preprocessors run, so non-numeric
             # inputs (DataFrames, categoricals, NaNs) are handled identically.
             X_test = ensure_compatible_predict_input_sklearn(X_test, worker)  # noqa: PLW2901
-            X_test = fix_dtypes(  # noqa: PLW2901
+            X_test = clean_data_transform(  # noqa: PLW2901
                 X_test,
                 cat_indices=worker.inferred_feature_schema_.indices_for(
                     FeatureModality.CATEGORICAL
                 ),
-            )
-            X_test = process_text_na_dataframe(  # noqa: PLW2901
-                X=X_test,
                 ord_encoder=getattr(worker, "ordinal_encoder_", None),
             )
             members = worker.executor_.ensemble_members
@@ -1385,14 +1382,11 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
 
         if not self.differentiable_input:
             X = ensure_compatible_predict_input_sklearn(X, self)
-            X = fix_dtypes(
+            X = clean_data_transform(
                 X,
                 cat_indices=self.inferred_feature_schema_.indices_for(
                     FeatureModality.CATEGORICAL
                 ),
-            )
-            X = process_text_na_dataframe(
-                X=X,
                 ord_encoder=getattr(self, "ordinal_encoder_", None),
                 passthrough_inf=self.get_inference_config().PASSTHROUGH_INF,
             )

--- a/src/tabpfn/preprocessing/clean.py
+++ b/src/tabpfn/preprocessing/clean.py
@@ -122,20 +122,6 @@ def _encoder_selects_nothing(
     return ord_encoder is None or not ord_encoder.selected_columns()
 
 
-def _cast_to_float64_table(X: np.ndarray) -> np.ndarray:
-    """Convert `X` to the float64 table the rest of the wrapper expects.
-
-    One allocation, straight into the array that is returned. Going through
-    pandas instead would wrap `X` in a float64 frame that is then copied back
-    out, holding two full-size buffers to produce one -- 5.33 GB of avoidable
-    transient on a 333,333 x 2,000 predict.
-
-    F order because that is what a single-block frame's `to_numpy` hands back,
-    and column-major is what the per-column steps downstream read.
-    """
-    return np.array(X, dtype=np.float64, order="F", copy=True)
-
-
 def clean_data_transform(
     X: np.ndarray | pd.DataFrame,
     *,
@@ -163,7 +149,7 @@ def clean_data_transform(
         # `passthrough_inf` makes no difference here: it records the +/-inf cells,
         # NaNs them so the encoder does not choke, and writes them back at the same
         # positions afterwards -- an exact round trip when nothing is encoded.
-        return _cast_to_float64_table(X)
+        return X
 
     return process_text_na_dataframe(
         X=fix_dtypes(X=X, cat_indices=cat_indices),
@@ -204,7 +190,7 @@ def clean_data(
         # single row: with no column selected it learns nothing from the values,
         # only the column bookkeeping.
         ord_encoder.fit(fix_dtypes(X=X[:1], cat_indices=cat_indices))
-        return _cast_to_float64_table(X), ord_encoder, feature_schema
+        return X, ord_encoder, feature_schema
 
     # Will convert inferred categorical indices to category dtype,
     # to be picked up by the ord_encoder, as well

--- a/src/tabpfn/preprocessing/clean.py
+++ b/src/tabpfn/preprocessing/clean.py
@@ -98,6 +98,80 @@ def _cast_columns(
     return X.astype(dict.fromkeys(columns, dtype), **_ASTYPE_KEEPS_UNCAST_COLUMNS)
 
 
+def _is_plain_numeric_array(X: np.ndarray | pd.DataFrame) -> bool:
+    """Whether `X` is a numpy array of a dtype that casts straight to float64.
+
+    Such an array carries no dtype to infer, no category to map and no string
+    cell to NA-handle, so cleaning it is a single cast (`_cast_to_float64_table`)
+    provided nothing is encoded either.
+    """
+    return isinstance(X, np.ndarray) and X.dtype.kind in FAST_CONVERTIBLE_DTYPE_KINDS
+
+
+def _encoder_selects_nothing(
+    ord_encoder: OrderPreservingColumnTransformer | None,
+) -> bool:
+    """Whether a *fitted* encoder would leave every column alone.
+
+    Asked of the encoder rather than of the incoming frame's categorical indices,
+    because the two can disagree: a column detected as text is encoded at fit but
+    never appears in `indices_for(FeatureModality.CATEGORICAL)`, and a column that
+    was string at fit can arrive numeric at predict. Only the encoder knows what
+    it was fitted to touch.
+    """
+    return ord_encoder is None or not ord_encoder.selected_columns()
+
+
+def _cast_to_float64_table(X: np.ndarray) -> np.ndarray:
+    """Convert `X` to the float64 table the rest of the wrapper expects.
+
+    One allocation, straight into the array that is returned. Going through
+    pandas instead would wrap `X` in a float64 frame that is then copied back
+    out, holding two full-size buffers to produce one -- 5.33 GB of avoidable
+    transient on a 333,333 x 2,000 predict.
+
+    F order because that is what a single-block frame's `to_numpy` hands back,
+    and column-major is what the per-column steps downstream read.
+    """
+    return np.array(X, dtype=np.float64, order="F", copy=True)
+
+
+def clean_data_transform(
+    X: np.ndarray | pd.DataFrame,
+    *,
+    cat_indices: Sequence[int | str] | None,
+    ord_encoder: OrderPreservingColumnTransformer | None,
+    passthrough_inf: bool = False,
+) -> np.ndarray:
+    """Clean data being predicted on, the way `clean_data` cleaned the training data.
+
+    The predict-time half of `clean_data`: the same dtype fixing and ordinal
+    encoding, driven by the encoder `clean_data` fitted rather than fitting one,
+    and taking the same single-cast shortcut when there is nothing to encode.
+
+    Args:
+        X: The data to clean.
+        cat_indices: Indices of the columns the encoder was fitted on.
+        ord_encoder: The encoder `clean_data` returned at fit time.
+        passthrough_inf: If True, +/-inf values are carried through the ordinal
+            encoding stage unchanged instead of crashing it.
+
+    Returns:
+        The cleaned data as a float64 array.
+    """
+    if _is_plain_numeric_array(X) and _encoder_selects_nothing(ord_encoder):
+        # `passthrough_inf` makes no difference here: it records the +/-inf cells,
+        # NaNs them so the encoder does not choke, and writes them back at the same
+        # positions afterwards -- an exact round trip when nothing is encoded.
+        return _cast_to_float64_table(X)
+
+    return process_text_na_dataframe(
+        X=fix_dtypes(X=X, cat_indices=cat_indices),
+        ord_encoder=ord_encoder,
+        passthrough_inf=passthrough_inf,
+    )
+
+
 def clean_data(
     X: np.ndarray,
     feature_schema: FeatureSchema,
@@ -122,30 +196,15 @@ def clean_data(
     # Ensure categories are ordinally encoded
     ord_encoder = get_ordinal_encoder()
 
-    if (
-        not cat_indices
-        and isinstance(X, np.ndarray)
-        and X.dtype.kind in FAST_CONVERTIBLE_DTYPE_KINDS
-    ):
-        # Nothing to encode and no dtype to infer, so the two steps below come out
-        # as a single cast: `fix_dtypes` would wrap `X` in a float64 frame that
-        # `process_text_na_dataframe` then copies straight back out, holding two
-        # full-size float64 buffers to produce one. Convert once, into the array
-        # that is returned.
-        #
-        # `passthrough_inf` makes no difference here: it records the +/-inf cells,
-        # NaNs them so the encoder does not choke, and writes them back at the same
-        # positions afterwards -- an exact round trip when nothing is encoded.
+    if not cat_indices and _is_plain_numeric_array(X):
+        # A numeric array holds no string cell, so with no categorical column
+        # declared there is nothing for the encoder to select.
         #
         # The encoder is still fit, since the caller keeps it for predict, but on a
         # single row: with no column selected it learns nothing from the values,
         # only the column bookkeeping.
         ord_encoder.fit(fix_dtypes(X=X[:1], cat_indices=cat_indices))
-        return (
-            np.array(X, dtype=np.float64, order="F", copy=True),
-            ord_encoder,
-            feature_schema,
-        )
+        return _cast_to_float64_table(X), ord_encoder, feature_schema
 
     # Will convert inferred categorical indices to category dtype,
     # to be picked up by the ord_encoder, as well

--- a/src/tabpfn/preprocessing/ensemble.py
+++ b/src/tabpfn/preprocessing/ensemble.py
@@ -925,16 +925,6 @@ def _get_lightgbm_model_cls(task_type: Literal["classifier", "regressor"]) -> ty
     )
 
 
-def _as_float64(X: np.ndarray) -> np.ndarray:
-    """Widen `X` to float64, without copying one that is float64 already.
-
-    The importance model bins each feature from the values it is handed, so the
-    ranking it produces depends on their dtype. `clean_data` no longer casts, so
-    widen here instead and keep the ranking the one a float64 table produced.
-    """
-    return np.asarray(X, dtype=np.float64)
-
-
 def _collect_importance_orderings(
     X: np.ndarray,
     y: np.ndarray,
@@ -954,7 +944,9 @@ def _collect_importance_orderings(
     n_samples = len(X)
 
     if n_samples <= max_samples:
-        ordering = fit_ordering_fn(_as_float64(X), y)
+        # The importance model bins each feature from the values it is handed,
+        # but `clean_data` no longer casts: not a no-op
+        ordering = fit_ordering_fn(np.asarray(X, dtype=np.float64), y)
         return [ordering] * n_estimators
 
     from sklearn.model_selection import train_test_split  # noqa: PLC0415
@@ -969,7 +961,9 @@ def _collect_importance_orderings(
             stratify=stratify,
             random_state=int(rng.integers(0, np.iinfo(np.int32).max)),
         )
-        orderings.append(fit_ordering_fn(_as_float64(X[idx]), y[idx]))
+        # The importance model bins each feature from the values it is handed,
+        # but `clean_data` no longer casts: not a no-op
+        orderings.append(fit_ordering_fn(np.asarray(X[idx], dtype=np.float64), y[idx]))
     return [orderings[i % n_subsamples] for i in range(n_estimators)]
 
 

--- a/src/tabpfn/preprocessing/ensemble.py
+++ b/src/tabpfn/preprocessing/ensemble.py
@@ -925,6 +925,16 @@ def _get_lightgbm_model_cls(task_type: Literal["classifier", "regressor"]) -> ty
     )
 
 
+def _as_float64(X: np.ndarray) -> np.ndarray:
+    """Widen `X` to float64, without copying one that is float64 already.
+
+    The importance model bins each feature from the values it is handed, so the
+    ranking it produces depends on their dtype. `clean_data` no longer casts, so
+    widen here instead and keep the ranking the one a float64 table produced.
+    """
+    return np.asarray(X, dtype=np.float64)
+
+
 def _collect_importance_orderings(
     X: np.ndarray,
     y: np.ndarray,
@@ -944,7 +954,7 @@ def _collect_importance_orderings(
     n_samples = len(X)
 
     if n_samples <= max_samples:
-        ordering = fit_ordering_fn(X, y)
+        ordering = fit_ordering_fn(_as_float64(X), y)
         return [ordering] * n_estimators
 
     from sklearn.model_selection import train_test_split  # noqa: PLC0415
@@ -959,7 +969,7 @@ def _collect_importance_orderings(
             stratify=stratify,
             random_state=int(rng.integers(0, np.iinfo(np.int32).max)),
         )
-        orderings.append(fit_ordering_fn(X[idx], y[idx]))
+        orderings.append(fit_ordering_fn(_as_float64(X[idx]), y[idx]))
     return [orderings[i % n_subsamples] for i in range(n_estimators)]
 
 

--- a/src/tabpfn/preprocessing/pipeline_interface.py
+++ b/src/tabpfn/preprocessing/pipeline_interface.py
@@ -452,7 +452,16 @@ class PreprocessingPipeline:
         """
         # Single copy to preserve immutability for the caller, avoiding N copies
         # inside the loop for steps that target specific modalities.
-        X = X.copy() if isinstance(X, np.ndarray) else X.clone()
+        #
+        # It is also where the float64 table is made. `clean_data` hands a numeric
+        # input back at its own dtype rather than casting it, so this is the only
+        # full-size float64 array the run holds; the widening is exact, so the steps
+        # below see the values they always saw.
+        X = (
+            X.astype(np.float64, order="C", copy=True)
+            if isinstance(X, np.ndarray)
+            else X.clone()
+        )
 
         # Record any +/-inf positions and replace them with NaN so the steps
         # (which assume finite/NaN input) can run, then write them back at the

--- a/src/tabpfn/preprocessing/pipeline_interface.py
+++ b/src/tabpfn/preprocessing/pipeline_interface.py
@@ -452,11 +452,7 @@ class PreprocessingPipeline:
         """
         # Single copy to preserve immutability for the caller, avoiding N copies
         # inside the loop for steps that target specific modalities.
-        #
-        # It is also where the float64 table is made. `clean_data` hands a numeric
-        # input back at its own dtype rather than casting it, so this is the only
-        # full-size float64 array the run holds; the widening is exact, so the steps
-        # below see the values they always saw.
+        # Fuse casting with copying for performance.
         X = (
             X.astype(np.float64, order="C", copy=True)
             if isinstance(X, np.ndarray)

--- a/src/tabpfn/regressor.py
+++ b/src/tabpfn/regressor.py
@@ -79,7 +79,7 @@ from tabpfn.preprocessing import (
     clean_data,
     generate_regression_ensemble_configs,
 )
-from tabpfn.preprocessing.clean import fix_dtypes, process_text_na_dataframe
+from tabpfn.preprocessing.clean import clean_data_transform
 from tabpfn.preprocessing.datamodel import Feature, FeatureModality, FeatureSchema
 from tabpfn.preprocessing.ensemble import (
     TabPFNEnsemblePreprocessor,
@@ -1492,9 +1492,9 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
         cat_indices = self.inferred_feature_schema_.indices_for(
             FeatureModality.CATEGORICAL
         )
-        X = fix_dtypes(X, cat_indices=cat_indices)
-        X = process_text_na_dataframe(
+        X = clean_data_transform(
             X,
+            cat_indices=cat_indices,
             ord_encoder=getattr(self, "ordinal_encoder_", None),
             passthrough_inf=self.get_inference_config().PASSTHROUGH_INF,
         )
@@ -1715,14 +1715,11 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
             # Clean X_test as the standard predict path does, so DataFrames,
             # categoricals and NaNs behave identically.
             X_test = ensure_compatible_predict_input_sklearn(X_test, worker)  # noqa: PLW2901
-            X_test = fix_dtypes(  # noqa: PLW2901
+            X_test = clean_data_transform(  # noqa: PLW2901
                 X_test,
                 cat_indices=worker.inferred_feature_schema_.indices_for(
                     FeatureModality.CATEGORICAL
                 ),
-            )
-            X_test = process_text_na_dataframe(  # noqa: PLW2901
-                X=X_test,
                 ord_encoder=getattr(worker, "ordinal_encoder_", None),
                 passthrough_inf=worker.inference_config_.PASSTHROUGH_INF,
             )

--- a/tests/test_classifier_interface.py
+++ b/tests/test_classifier_interface.py
@@ -1488,8 +1488,8 @@ def test__predict_proba_batched__rejects_mismatched_classes() -> None:
 def test__predict_proba_batched__matches_per_dataset_dataframe(device: str) -> None:
     """Batched prediction matches per-dataset on non-numeric DataFrame inputs.
 
-    The standard predict path runs fix_dtypes / process_text_na_dataframe /
-    ordinal encoding on X_test before the member preprocessors; predict_proba_batched
+    The standard predict path runs `clean_data_transform` -- dtype fixing and
+    ordinal encoding -- on X_test before the member preprocessors; predict_proba_batched
     must apply the same validation or non-numeric inputs would diverge from (or
     crash relative to) predict_proba. To actually exercise those paths the frames
     here mix dtypes that need conversion: a categorical-dtype column, an

--- a/tests/test_input_immutability.py
+++ b/tests/test_input_immutability.py
@@ -31,9 +31,12 @@ import pytest
 from tabpfn import TabPFNClassifier, TabPFNRegressor
 from tabpfn.preprocessing import pipeline_interface
 
-N_ROWS = 80
-N_TEST = 20
+N_ROWS = 12
+N_TEST = 6
 N_FEATURES = 5
+# Spacing of the missing values in the object column, kept at or below `N_TEST`
+# so the smaller split cannot come out without one.
+N_MISSING_EVERY = 5
 # +/-inf reaches the ordinal encoder only with this on; without it validation
 # rejects the input before any of the code under test runs.
 PASSTHROUGH_INF = {"PASSTHROUGH_INF": True}
@@ -62,7 +65,7 @@ def _object_mixed() -> np.ndarray:
     # Three levels, so it detects as categorical rather than as free text.
     X[:, 1] = [f"lvl{i % 3}" for i in range(n)]
     X[:, 2] = rng.integers(0, 5, n)
-    X[:, 3] = [None if i % 17 == 0 else f"k{i % 2}" for i in range(n)]
+    X[:, 3] = [None if i % N_MISSING_EVERY == 0 else f"k{i % 2}" for i in range(n)]
     return X
 
 

--- a/tests/test_input_immutability.py
+++ b/tests/test_input_immutability.py
@@ -1,0 +1,229 @@
+#  Copyright (c) Prior Labs GmbH 2026.
+
+"""Fitting and predicting must leave the caller's data exactly as it was.
+
+`clean_data` hands a numeric array straight back rather than casting it into one
+it owns, so the array the wrapper carries through `fit` *is* the caller's. What
+keeps that safe is `PreprocessingPipeline._process_steps` taking a private copy
+before any step mutates anything -- one guarantee, in one place, rather than a
+defensive copy at every boundary. Several things inside cleaning and preprocessing
+write in place quite deliberately (`_extract_inf_masks` NaNs out infinities,
+`process_text_na_dataframe` is documented to mutate the frame it is given), so the
+question is not whether anything mutates but whether any of it reaches back to the
+caller.
+
+Every input is checked, not just the training features: `y` is label-encoded and
+z-normalised on the way through, and the test features take a different route
+again -- through `clean_data_transform` and a fitted encoder rather than a fresh
+one. Each input kind below reaches cleaning by a different path: a plain numeric
+array takes the single-cast shortcut, an object array and a DataFrame go through
+pandas, and NaN and +/-inf are rewritten in place internally before the steps run.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from tabpfn import TabPFNClassifier, TabPFNRegressor
+from tabpfn.preprocessing import pipeline_interface
+
+N_ROWS = 80
+N_TEST = 20
+N_FEATURES = 5
+# +/-inf reaches the ordinal encoder only with this on; without it validation
+# rejects the input before any of the code under test runs.
+PASSTHROUGH_INF = {"PASSTHROUGH_INF": True}
+
+
+def _numeric(dtype: str) -> np.ndarray:
+    rng = np.random.default_rng(0)
+    return rng.standard_normal((N_ROWS + N_TEST, N_FEATURES)).astype(dtype)
+
+
+def _numeric_with_non_finite() -> np.ndarray:
+    X = _numeric("float64")
+    X[3, 1] = np.nan
+    X[7, 2] = np.inf
+    X[11, 0] = -np.inf
+    X[N_ROWS + 2, 4] = np.nan
+    X[N_ROWS + 5, 3] = np.inf
+    return X
+
+
+def _object_mixed() -> np.ndarray:
+    rng = np.random.default_rng(1)
+    n = N_ROWS + N_TEST
+    X = np.empty((n, 4), dtype=object)
+    X[:, 0] = rng.standard_normal(n)
+    # Three levels, so it detects as categorical rather than as free text.
+    X[:, 1] = [f"lvl{i % 3}" for i in range(n)]
+    X[:, 2] = rng.integers(0, 5, n)
+    X[:, 3] = [None if i % 17 == 0 else f"k{i % 2}" for i in range(n)]
+    return X
+
+
+def _dataframe_mixed() -> pd.DataFrame:
+    rng = np.random.default_rng(2)
+    n = N_ROWS + N_TEST
+    numeric = rng.standard_normal(n)
+    numeric[5] = np.nan
+    return pd.DataFrame(
+        {
+            "num": numeric,
+            "cat": pd.Categorical([f"c{i % 3}" for i in range(n)]),
+            "text": [f"s{i % 2}" for i in range(n)],
+            "count": rng.integers(0, 4, n),
+        }
+    )
+
+
+INPUTS = {
+    "numeric_float32": lambda: _numeric("float32"),
+    "numeric_float64": lambda: _numeric("float64"),
+    "numeric_with_nan_and_inf": _numeric_with_non_finite,
+    "object_mixed": _object_mixed,
+    "dataframe_mixed": _dataframe_mixed,
+}
+
+
+def _split(X: Any) -> tuple[Any, Any]:
+    """Train/test split that keeps the container type it was given."""
+    if isinstance(X, pd.DataFrame):
+        return X.iloc[:N_ROWS], X.iloc[N_ROWS:]
+    return X[:N_ROWS], X[N_ROWS:]
+
+
+def _snapshot(data: Any) -> Any:
+    """A copy to compare against afterwards, deep enough to catch a write."""
+    if isinstance(data, (pd.DataFrame, pd.Series)):
+        return data.copy(deep=True)
+    return data.copy()
+
+
+def _assert_unchanged(after: Any, before: Any, what: str) -> None:
+    """Bit-for-bit, with NaN comparing equal to NaN in the same place."""
+    if isinstance(after, pd.DataFrame):
+        pd.testing.assert_frame_equal(after, before, check_exact=True)
+    elif isinstance(after, pd.Series):
+        pd.testing.assert_series_equal(after, before, check_exact=True)
+    else:
+        np.testing.assert_array_equal(after, before, err_msg=f"{what} was mutated")
+
+
+@pytest.mark.parametrize(
+    "estimator_cls", [TabPFNClassifier, TabPFNRegressor], ids=lambda c: c.__name__
+)
+@pytest.mark.parametrize("input_kind", list(INPUTS), ids=list(INPUTS))
+def test__fit_predict__leave_every_input_untouched(
+    estimator_cls: type, input_kind: str
+) -> None:
+    """A whole fit + predict changes nothing the caller passed in."""
+    X_train, X_test = _split(INPUTS[input_kind]())
+    rng = np.random.default_rng(3)
+    y_train = (
+        rng.integers(0, 3, N_ROWS)
+        if estimator_cls is TabPFNClassifier
+        else rng.standard_normal(N_ROWS)
+    )
+
+    before = {
+        "X_train": _snapshot(X_train),
+        "X_test": _snapshot(X_test),
+        "y_train": _snapshot(y_train),
+    }
+
+    model = estimator_cls(
+        n_estimators=2,
+        device="cpu",
+        random_state=0,
+        inference_config=PASSTHROUGH_INF,
+    ).fit(X_train, y_train)
+    model.predict(X_test)
+    if estimator_cls is TabPFNClassifier:
+        model.predict_proba(X_test)
+
+    after = {"X_train": X_train, "X_test": X_test, "y_train": y_train}
+    for name, original in before.items():
+        _assert_unchanged(after[name], original, name)
+
+
+@pytest.mark.parametrize(
+    "estimator_cls", [TabPFNClassifier, TabPFNRegressor], ids=lambda c: c.__name__
+)
+def test__fit_predict__leave_a_pandas_target_untouched(estimator_cls: type) -> None:
+    """A `Series` target is label-encoded or z-normalised, never in place.
+
+    Separate from the sweep above because only a pandas target carries an index
+    and a name that a mutation could disturb as well as its values.
+    """
+    X = _numeric("float64")
+    X_train, X_test = _split(X)
+    rng = np.random.default_rng(4)
+    values = (
+        rng.integers(0, 3, N_ROWS)
+        if estimator_cls is TabPFNClassifier
+        else rng.standard_normal(N_ROWS)
+    )
+    y_train = pd.Series(values, name="target", index=[f"r{i}" for i in range(N_ROWS)])
+    before = _snapshot(y_train)
+
+    estimator_cls(n_estimators=2, device="cpu", random_state=0).fit(
+        X_train, y_train
+    ).predict(X_test)
+
+    _assert_unchanged(y_train, before, "y_train")
+
+
+def test__fit__copies_before_anything_writes_in_place(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The pipeline must copy before the first in-place writer sees the data.
+
+    Comparing the caller's array before and after `fit` is not enough to pin this.
+    `_extract_inf_masks` NaNs infinities out in place and `_restore_inf_masks`
+    writes them back at the end, so a missing copy corrupts the caller's array for
+    the duration of the call and then tidies up after itself -- measured, on a
+    build with the copy removed: `user_infs 2 -> 0` inside `_process_steps`, and
+    `infs 2` again by the time `fit` returns. Every end-to-end check in this module
+    passes against that build.
+
+    So watch the boundary instead of the outcome: whatever `_process_steps` hands
+    to the first in-place writer must not be the caller's object. That also covers
+    the case the round trip hides -- a step raising between the two, which would
+    leave the caller holding NaN where their infinities were.
+    """
+    X_train = _numeric_with_non_finite()[:N_ROWS].copy()
+    y_train = np.random.default_rng(5).integers(0, 3, N_ROWS)
+
+    seen: dict[str, bool] = {}
+    real_extract = pipeline_interface._extract_inf_masks
+
+    def spy(X: np.ndarray, feature_schema: Any) -> Any:
+        seen["ran"] = True
+        # `is`, not `shares_memory`: a view shares memory with its base, so the
+        # weaker question cannot tell a copy from a slice of the original.
+        seen["got_callers_array"] = X is X_train
+        return real_extract(X, feature_schema)
+
+    monkeypatch.setattr(pipeline_interface, "_extract_inf_masks", spy)
+
+    TabPFNClassifier(
+        n_estimators=1,
+        device="cpu",
+        random_state=0,
+        # Pinned rather than defaulted: dispatching preprocessing to worker
+        # processes would put the writes in a child, where they could not reach
+        # the caller's array whether the copy was there or not.
+        n_preprocessing_jobs=1,
+        inference_config=PASSTHROUGH_INF,
+    ).fit(X_train, y_train)
+
+    assert seen.get("ran"), (
+        "the in-place writer this guards never ran, so the test proved nothing; "
+        "point it at whatever replaced `_extract_inf_masks`"
+    )
+    assert seen["got_callers_array"] is False

--- a/tests/test_preprocessing/test_data_cleaning.py
+++ b/tests/test_preprocessing/test_data_cleaning.py
@@ -20,6 +20,7 @@ from tabpfn.preprocessing import (
 )
 from tabpfn.preprocessing.clean import (
     _is_single_float_block,
+    clean_data_transform,
     fix_dtypes,
     process_text_na_dataframe,
 )
@@ -1179,3 +1180,66 @@ def test__classifier_fit__native_datetime_column__known_unfixed_crash() -> None:
     clf = TabPFNClassifier(n_estimators=1, device="cpu")
     with pytest.raises(TabPFNValidationError, match="could not be promoted"):
         clf.fit(X, y)
+
+
+def test__clean_data_transform__matches_the_general_path_on_numeric_input() -> None:
+    """The single-cast shortcut produces exactly what going through pandas does.
+
+    `clean_data_transform` skips `fix_dtypes` + `process_text_na_dataframe` for a
+    numeric array that nothing is encoded from, to avoid holding two full-size
+    float64 buffers to produce one. The shortcut is only worth taking if it is
+    indistinguishable from the path it replaces -- values, dtype, memory order and
+    ownership, since callers write into the result in place.
+    """
+    rng = np.random.default_rng(0)
+    X = rng.standard_normal((40, 6)).astype(np.float32)
+    X[3, 2] = np.nan
+    encoder = get_ordinal_encoder()
+    encoder.fit(fix_dtypes(X=X[:1], cat_indices=None))
+
+    shortcut = clean_data_transform(X, cat_indices=None, ord_encoder=encoder)
+    general = process_text_na_dataframe(
+        X=fix_dtypes(X=X, cat_indices=None), ord_encoder=encoder
+    )
+
+    np.testing.assert_array_equal(shortcut, general)
+    assert shortcut.dtype == general.dtype == np.float64
+    assert shortcut.flags.f_contiguous == general.flags.f_contiguous
+    assert shortcut.flags.writeable
+    assert not np.shares_memory(shortcut, X)
+
+
+def test__clean_data_transform__still_encodes_a_text_column_fit_as_strings() -> None:
+    """A numeric predict array does not escape an encoder that was fitted on it.
+
+    The shortcut cannot be decided from the incoming array's categorical indices:
+    a column detected as *text* is ordinal-encoded at fit yet never appears in
+    `indices_for(CATEGORICAL)`, so a predict-time array of the same field arriving
+    numeric would look encoding-free while the fitted encoder still holds it. Gating
+    on the encoder keeps such a column on the general path, where its values are
+    matched against the fit-time categories instead of being read as raw numbers.
+    """
+    n, n_unique = 60, 30
+    # An object array, as `validate_data` hands one over for a mixed frame, so the
+    # encoder's column keys are the integer positions a numpy predict input has too.
+    X_fit = np.empty((n, 2), dtype=object)
+    X_fit[:, 0] = np.arange(n, dtype="float64")
+    X_fit[:, 1] = [f"s{i % n_unique}" for i in range(n)]
+    encoder = get_ordinal_encoder()
+    process_text_na_dataframe(
+        fix_dtypes(X=X_fit, cat_indices=None), ord_encoder=encoder, fit_encoder=True
+    )
+    assert encoder.selected_columns() == [1]
+
+    X_pred = np.column_stack(
+        [
+            np.arange(n, dtype="float64"),
+            np.array([float(i % n_unique) for i in range(n)], dtype="float64"),
+        ]
+    )
+
+    with pytest.warns(UserWarning, match="differs.*from fit time"):
+        out = clean_data_transform(X_pred, cat_indices=None, ord_encoder=encoder)
+
+    # Encoded against the fit categories, so the codes are not the raw numbers.
+    assert not np.array_equal(out[:, 1], X_pred[:, 1])

--- a/tests/test_preprocessing/test_data_cleaning.py
+++ b/tests/test_preprocessing/test_data_cleaning.py
@@ -345,7 +345,10 @@ class TestTagFeaturesAndSanitizeData:
         )
         assert isinstance(X_out, np.ndarray)
         assert X_out.shape == input_data.shape
-        assert X_out.dtype == np.float64
+        # Numeric, rather than float64 specifically: a numeric ndarray with nothing
+        # to encode is handed back at its own dtype, and the widening to float64
+        # happens in the copy the preprocessing pipeline takes before its steps run.
+        assert X_out.dtype.kind in "biuf"
         assert ord_encoder is not None
 
     @pytest.mark.parametrize(
@@ -742,11 +745,14 @@ def test__process_text_na_dataframe__string_against_numeric_fit_categories() -> 
 
 # --- all-numeric fast path ------------------------------------------------------
 #
-# A numeric ndarray with no categorical columns has nothing to ordinally encode, so
-# `clean_data` converts it straight to float64 instead of building the intermediate
-# DataFrame and copying it back out. These pin the properties that shortcut has to
-# keep: same values, same layout, an owned array, and an encoder that is fitted
-# exactly as the general path leaves it.
+# A numeric ndarray with no categorical columns has nothing to ordinally encode and
+# no dtype to infer, so `clean_data` hands it straight back instead of building an
+# intermediate DataFrame and copying it out into a float64 table of its own. The
+# widening happens later, in the copy `PreprocessingPipeline._process_steps` takes
+# before the steps mutate anything, so that table exists once rather than twice.
+# These pin what the shortcut owes: the same values, an encoder fitted exactly as
+# the general path leaves it, and -- since the array handed back is the caller's --
+# that nothing downstream writes into it.
 
 
 def _numeric_schema(n_cols: int, cat_indices: tuple[int, ...] = ()) -> FeatureSchema:
@@ -765,10 +771,19 @@ def _numeric_schema(n_cols: int, cat_indices: tuple[int, ...] = ()) -> FeatureSc
 
 @pytest.mark.parametrize("dtype", ["float32", "float64", "int64", "bool", "float16"])
 @pytest.mark.parametrize("passthrough_inf", [False, True])
-def test__clean_data__numeric_array_converts_without_intermediate_copy(
+def test__clean_data__numeric_array_is_handed_back_untouched(
     dtype: str, *, passthrough_inf: bool
 ) -> None:
-    """The shortcut returns exactly the float64 cast of its input."""
+    """The shortcut neither copies nor casts: cleaning such an array is a no-op.
+
+    The float64 table the steps read is made by
+    `PreprocessingPipeline._process_steps`, which copies before the steps mutate
+    it. Making one here as well would keep a second full-size table alive for the
+    whole of `fit` -- 10.67 GB of it on the profiled shape, under everything else
+    fit does. What that leaves is a contract: nobody writes into the array handed
+    back, since it is the caller's own
+    (`test__fit_predict__do_not_write_into_the_callers_array`).
+    """
     rng = np.random.default_rng(0)
     X = (rng.standard_normal((20, 4)) * 3).astype(dtype)
 
@@ -776,12 +791,8 @@ def test__clean_data__numeric_array_converts_without_intermediate_copy(
         X=X, feature_schema=_numeric_schema(4), passthrough_inf=passthrough_inf
     )
 
-    np.testing.assert_array_equal(out, X.astype(np.float64))
-    assert out.dtype == np.float64
+    assert out is X
     assert schema.num_columns == 4
-    # Owned and writeable: callers mutate the cleaned array in place downstream.
-    assert not np.shares_memory(out, X)
-    assert out.flags.writeable
     # Nothing was selected for encoding, so the encoder learned no categories.
     assert not hasattr(encoder.named_transformers_["encoder"], "categories_")
     assert encoder.n_features_in_ == 4
@@ -822,8 +833,9 @@ def test__clean_data__numeric_shortcut_matches_the_encoder_path() -> None:
     # the original small integers, so the two agree everywhere.
     assert encoder.named_transformers_["encoder"].categories_[0].size == 4
     np.testing.assert_array_equal(shortcut, general)
-    assert shortcut.dtype == general.dtype
-    assert shortcut.flags.f_contiguous == general.flags.f_contiguous
+    # Only the values have to agree. The shortcut hands the caller's array back,
+    # so its dtype and layout are the caller's, while the general path builds its
+    # own float64 frame and gets pandas' column-major one.
 
 
 def test__fix_dtypes__numeric_array_stays_consolidated() -> None:
@@ -1203,10 +1215,10 @@ def test__clean_data_transform__matches_the_general_path_on_numeric_input() -> N
     )
 
     np.testing.assert_array_equal(shortcut, general)
-    assert shortcut.dtype == general.dtype == np.float64
-    assert shortcut.flags.f_contiguous == general.flags.f_contiguous
-    assert shortcut.flags.writeable
-    assert not np.shares_memory(shortcut, X)
+    assert general.dtype == np.float64
+    # The shortcut hands the caller's array straight back rather than casting it;
+    # the widening happens in the copy the pipeline takes before the steps run.
+    assert shortcut is X
 
 
 def test__clean_data_transform__still_encodes_a_text_column_fit_as_strings() -> None:
@@ -1243,3 +1255,44 @@ def test__clean_data_transform__still_encodes_a_text_column_fit_as_strings() -> 
 
     # Encoded against the fit categories, so the codes are not the raw numbers.
     assert not np.array_equal(out[:, 1], X_pred[:, 1])
+
+
+def test__fit_predict__do_not_write_into_the_callers_array() -> None:
+    """Neither fit nor predict may change the array they were handed.
+
+    `clean_data` hands a numeric array back uncopied, so the array the wrapper
+    carries through `fit` *is* the caller's. What keeps that safe is the copy
+    `PreprocessingPipeline._process_steps` takes before any step mutates
+    anything -- and this is the test that says so, rather than the copy
+    `clean_data` used to make on the way past.
+    """
+    rng = np.random.default_rng(0)
+    X = rng.standard_normal((80, 5)).astype(np.float32)
+    X[2, 3] = np.nan
+    y = rng.integers(0, 2, 80)
+    before = X.copy()
+
+    model = TabPFNClassifier(n_estimators=2, device="cpu", random_state=0).fit(X, y)
+    model.predict_proba(X)
+
+    np.testing.assert_array_equal(X, before)
+
+
+def test__fit_predict__a_float32_input_predicts_as_its_float64_equal() -> None:
+    """The input's dtype does not reach the steps, so it cannot change the output.
+
+    `clean_data` no longer widens, but the pipeline's copy does, and widening a
+    float32 value to float64 is exact. So the same table offered at either
+    precision has to come out the same, bit for bit -- which is what makes the
+    move of the cast a memory change rather than a numerical one.
+    """
+    rng = np.random.default_rng(0)
+    X32 = rng.standard_normal((80, 5)).astype(np.float32)
+    X64 = X32.astype(np.float64)
+    y = rng.integers(0, 2, 80)
+
+    def proba(X: np.ndarray) -> np.ndarray:
+        model = TabPFNClassifier(n_estimators=2, device="cpu", random_state=0)
+        return model.fit(X, y).predict_proba(X)
+
+    np.testing.assert_array_equal(proba(X32), proba(X64))


### PR DESCRIPTION
## Issue

[RES-2439 — Reduce the RAM footprint of the wrapper](https://linear.app/priorlabs/issue/RES-2439/reduce-the-ram-footprint-of-the-wrapper)

## Motivation and Context

**What**

- `clean_data` no longer copies a numeric input to float64. The preprocessing pipeline already copies the table before it runs, so that copy does the conversion instead.
- `predict` now uses the same shortcut, as `clean_data_transform`.

**Why**

- The float64 table was 10.67 GB on a 666,667 x 2,000 float32 fit, and stayed in memory for all of `fit`.
- `predict` built two float64 copies where one was needed.

**How**

- float32 to float64 is exact, so every step sees the same values and the ensemble members are bit-identical.
- The feature-importance model converts its own subsample, so its ranking does not change either.

---

## Public API Changes

-   [x] No Public API changes
-   [ ] Yes, Public API changes (Details below)

`clean_data` / `clean_data_transform` now return a numeric input's own dtype rather than always float64. Neither is exported from `tabpfn`, and `fit` / `predict` outputs are unchanged — but flagging it in case you read that boundary as public.

---

## How Has This Been Tested?

Peak host RSS over a full fit + predict at 1M x 2000 float32, one estimator, `tabpfn_v3`, measured with the wrapper profiler in fomo-fitting:

| stage | before | after |
| :--- | ---: | ---: |
| `total: fit + predict` | 26.10 GB | **15.44 GB** |
| `clean_data` retained | 10.67 GB | 0.01 GB |
| `predict` transient | 10.67 GB | 1.61 GB |

<details><summary>Gates against f213434d, 666,667 x 2,000, outputs/members identical on every cell</summary>

Every cell runs both sides of its own comparison in one allocation, on 16 vCPU / 128 GB with 8 threads, so a delta is never contaminated by which machine it landed on. `current` is the repo environment (python 3.14, numpy 2.5.2, pandas 3.0.5), which is also the `highest` end of the supported range; `lowest` is python 3.10, numpy 1.22.0, pandas 1.4.0.

| gate | mix | transient RSS | median wall time |
| :--- | :--- | :--- | :--- |
| `clean_data --stage predict`, current | numeric | 21.33 → 0.00 GB | 13.486 → 0.000 s |
| | half-string | 27.34 → 27.34 GB | 158.5 → 143.7 s |
| | numeric-object | 22.02 → 22.02 GB | 160.0 → 159.4 s |
| `clean_data --stage predict`, lowest | numeric | 21.33 → 0.00 GB | 13.577 → 0.000 s |
| | half-string | 27.34 → 27.34 GB | 263.5 → 264.0 s |
| | numeric-object | 26.69 → 26.68 GB | 276.2 → 278.7 s |
| `clean_data --stage fit`, current | numeric | 10.67 → 0.00 GB | 6.337 → 0.005 s |
| | half-string | 18.78 → 18.78 GB | 222.5 → 218.7 s |
| | numeric-object | 22.03 → 22.03 GB | 171.6 → 163.9 s |
| `clean_data --stage fit`, lowest | numeric | 10.67 → 0.00 GB | 5.621 → 0.003 s |
| | half-string | 18.78 → 18.78 GB | 344.2 → 347.9 s |
| | numeric-object | 26.70 → 26.70 GB | 345.1 → 337.6 s |
| `bench_ensemble_preprocessing`, current | numeric | 12.01 → 12.01 GB | 10.944 → 5.315 s (**−51.4%**) |
| | half-string | 28.01 → 28.01 GB | no change |
| | numeric-object | 12.01 → 12.01 GB | 11.104 → 11.338 s |
| `bench_ensemble_preprocessing`, lowest | numeric | 12.01 → 12.01 GB | 16.420 → 8.816 s (**−46.3%**) |
| | half-string | 28.01 → 28.01 GB | 231.4 → 240.6 s |
| | numeric-object | 12.01 → 12.01 GB | 16.292 → 16.583 s |

The numeric cells of `clean_data` now measure a no-op: for a numeric input with nothing to encode, cleaning costs nothing at either end of the range, and the widening moved into the per-member copy. `bench_ensemble_preprocessing` is the gate that sees where that work landed — and it halves there, on both pandas 1.4 and pandas 3, with members identical.

The object mixes are unchanged on RAM to three significant figures. Their wall times scatter a few percent either way and should be read as no change: at this shape a single half-string ensemble comparison is not resolvable at the 5% tolerance — five repeats of the same two commits gave +17.0%, +4.3%, +0.02%, +1.7%, −6.3%, with the reference alone spanning 80.6–116.7 s across allocations.

The gate changes these numbers were produced with live on `arthur/benchmarking-update` (`scripts/` only), which is why this branch touches no benchmarks.

</details>

- `tests/test_input_immutability.py`: a sweep over both estimators x five input kinds asserting `X_train`, `X_test` and `y_train` come back bit-identical, plus a check that the pipeline copies before the first in-place writer — verified to fail against a build with that copy removed, since the sweep alone does not (`_extract_inf_masks` corrupts the caller's array and `_restore_inf_masks` tidies up before `fit` returns).
- `test__clean_data_transform__*` in `test_data_cleaning.py`: the shortcut matches the general path exactly, and does not skip an encoder fitted on a *text* column — a bug the first version of this had, since text is encoded at fit yet never appears in `indices_for(CATEGORICAL)`.

Full suite: 1809 passed, 145 skipped, 12 xfailed.

---

## Checklist

-   [x] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [x] A changelog entry has been added (see `changelog/README.md`), or "no changelog needed" label requested.
-   [x] The code follows the project's style guidelines.
-   [x] I have considered the impact of these changes on the public API.

---





