### PR TITLE
perf: chunked TorchSquashingScaler

### DIFF
--- a/changelog/1223.fixed.md
+++ b/changelog/1223.fixed.md
@@ -1,0 +1,1 @@
+Cut `TorchSquashingScaler`'s peak device memory from 13.0x its input to 0.4x for `fit` and 5.8x to 1.0x for `transform`, with byte-identical outputs, so large fits no longer exhaust VRAM.

--- a/src/tabpfn/preprocessing/torch/torch_squashing_scaler.py
+++ b/src/tabpfn/preprocessing/torch/torch_squashing_scaler.py
@@ -14,85 +14,37 @@ Original skrub attribution:
   All rights reserved.
   SPDX-License-Identifier: BSD-3-Clause
 
-The state is returned explicitly from ``fit`` rather than stored on the
-instance, matching the rest of ``preprocessing/torch``.
-
-Memory
-------
-
-Both halves are written to keep their device footprint down, because at the shapes
-this runs at they are dominated by their own temporaries rather than by their input.
-Measured with ``scripts/profile_squashing_scaler.py`` on an H100:
-
-* ``fit`` is essentially one ``torch.nanquantile`` call, whose internal sort peaks at
-  roughly **12x the bytes it is handed** (radix sort double-buffers both the values
-  and their int64 indices). So the reduction is done in blocks of columns of a fixed
-  byte size, which turns that peak from a multiple of the input into a constant. It is
-  only done above ``_FIT_UNBLOCKED_BYTES``, because blocking the sort costs a few
-  percent of fit's wall time on older torch and is not worth paying where 12x already
-  fits.
-* ``transform`` has to produce a full-size output, so its floor is 1x; what it must
-  not do is stack up further full-size buffers on the way there. It allocates the
-  output once and fills it a block of rows at a time, so every mask and temporary it
-  needs is the size of a block rather than of the whole tensor.
-
-The elementwise rewrites are bit-for-bit equivalent to the straightforward spelling
-(``a.sub_(b)`` is the same kernel as ``a - b``, writing to a different place), and the
-blocking is over axes the maths is independent along -- per column for a per-column
-reduction, per row for an elementwise map. Neither is a change to the arithmetic,
-and ``scripts/bench_squashing_scaler.py`` gates that: it fails unless the outputs stay
-byte-identical.
+The state is returned explicitly from `fit` rather than stored on the
+instance, matching the rest of `preprocessing/torch`.
 """
 
 from __future__ import annotations
 
 import torch
 
-# Bytes of input one ``fit`` column block is allowed to cover. The sort inside
-# ``torch.nanquantile`` peaks at ~12x the bytes it is given, and that multiple -- not
-# the input size -- is what put a 10M x 2,000 fit out of reach on an 80 GB card.
-# Blocking by a fixed *byte* size rather than a fixed number of blocks makes fit's
-# peak a constant (~13x this) at every shape, instead of a constant multiple of an
-# input that keeps growing.
-#
-# Swept on an H100, fit on [666667, 1, 2000] (5.33 GB), transient VRAM against median
-# wall time: 32 MB -> 0.52 GB / 212.0 ms, 64 MB -> 1.08 GB / 202.6 ms, 128 MB ->
-# 2.14 GB / 198.5 ms, 256 MB -> 4.28 GB / 210.1 ms, 512 MB -> 6.97 GB / 243.6 ms,
-# 1 GB -> 13.94 GB / 248.0 ms. 128 MB is the best of both: large blocks lose badly on
-# time as well as memory, and the smallest ones start paying for the extra launches.
+# Bytes of input one `fit` column block covers. The sort inside
+# `torch.nanquantile` needs a large multiple of what it is given -- it double-buffers
+# both the sorted values and their int64 indices -- so bounding the block by bytes is
+# what bounds fit's peak at every shape. Sits at the knee: larger blocks cost time as
+# well as memory, smaller ones start paying for the extra launches.
 _FIT_BLOCK_BYTES = 128 * 1024 * 1024
 
-# Below this much input, ``fit`` does not block at all. Blocking the sort is not free:
-# on torch 2.5 (the floor of the supported range) it costs ~5% of fit's wall time at
-# every block size tried, where on 2.13 it *saves* ~8%. That is a trade worth making
-# to turn a 69 GB peak into a 2 GB one -- but only where there is a 69 GB peak to
-# turn. Under this threshold the unblocked path needs about 13x of very little, so the
-# old single-pass spelling is kept and nothing about this change is observable.
-#
-# 512 MB puts the crossover at roughly 6.5 GB of unblocked transient: comfortable on
-# any card this runs on, and far above anything the test suite or a CPU/MPS caller
-# reaches.
+# Below this much input, `fit` reduces in a single pass instead. Blocking the sort
+# costs wall time on older torch, so it is only worth doing once the unblocked peak is
+# large enough to be a problem.
 _FIT_UNBLOCKED_BYTES = 512 * 1024 * 1024
 
-# Bytes of output ``transform`` produces at a time. Its output has to exist in full;
-# none of its intermediates do, so they are kept to a block.
-#
-# Swept on an H100 at 1M x 2,000 (8 GB of output), transient VRAM against median wall
-# time: 32 MB -> 1.01x / 94.9 ms, 256 MB -> 1.04x / 93.6 ms, 512 MB -> 1.08x /
-# 92.2 ms, 8 GB (i.e. no blocking) -> 2.25x / 91.6 ms. Time is flat to within the
-# spread of the sweep across the whole range while memory is not, so this sits at the
-# small end: the block buys nothing above the point where the launches stop being
-# free, and the memory it costs scales with the tensor.
+# Bytes of output `transform` produces at a time. Its output has to exist in full;
+# none of its intermediates do. Small end of the useful range, because wall time is
+# flat across that range while what the intermediates cost scales with the block.
 _TRANSFORM_BLOCK_BYTES = 32 * 1024 * 1024
 
 
 def _scalar(value: float, like: torch.Tensor) -> torch.Tensor:
-    """A 0-dim tensor of ``like``'s dtype and device, to broadcast into ``where``.
+    """A 0-dim tensor of `like`'s dtype and device, to broadcast into `where`.
 
-    The obvious spelling is ``torch.full_like(x, value)``, which allocates a second
-    tensor the size of ``x`` in order to carry one number. A 0-dim tensor broadcasts
-    to the same effect, holds the same value in the same dtype -- so the result is
-    unchanged -- and costs nothing.
+    Broadcasting one number costs nothing, where `torch.full_like` would allocate a
+    tensor the size of `x` to carry it.
     """
     return torch.full((), value, dtype=like.dtype, device=like.device)
 
@@ -103,11 +55,7 @@ def _replace_inf_with_nan(x: torch.Tensor) -> torch.Tensor:
 
 
 def _block_size(x: torch.Tensor, dim: int, budget_bytes: int) -> int:
-    """Slices of ``dim`` whose data is about ``budget_bytes``.
-
-    At least one: a single slice larger than the budget cannot be split any further
-    along this axis, and the caller has no other axis to give.
-    """
+    """Slices of `dim` whose data is about `budget_bytes`."""
     per_slice = x.element_size()
     for index, size in enumerate(x.shape):
         if index != dim:
@@ -217,15 +165,14 @@ class TorchSquashingScaler:
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """Per-column min, max and quantiles, reduced a block of columns at a time.
 
-        Every statistic here is reduced over dim 0 and is therefore independent per
-        column, so which columns are handed over together cannot change any of them --
-        which is what makes the blocking free of consequences other than the memory it
-        saves. The blocks are joined back up along the column axis, and the caller
-        works on the whole thing exactly as it would have.
+        Every statistic is reduced over dim 0 and so is independent per column.
 
-        The one thing this must not do is materialise a whole ``_replace_inf_with_nan``
-        copy of ``x``: that copy is the input to the expensive call, so keeping it to a
-        block keeps the sort inside ``nanquantile`` to a block too.
+        What must not happen here is a whole `_replace_inf_with_nan` copy of `x`:
+        that copy is the input to `nanquantile`, so keeping it to a block is what
+        keeps the sort to a block.
+
+        Returns:
+            min, max, quantiles as torch.Tensor
         """
         columns = x.shape[-1]
         block = _block_size(x, dim=x.ndim - 1, budget_bytes=_FIT_BLOCK_BYTES)
@@ -253,12 +200,6 @@ class TorchSquashingScaler:
         """min, max and quantiles for one block of columns."""
         x_finite = _replace_inf_with_nan(x)
 
-        # nanquantile cannot share its sort with nanmin/nanmax across the same
-        # call, so they're computed separately. The dominant cost is the single
-        # nanquantile call covering all three quartiles at once.
-        #
-        # One NaN mask serves all three uses below; the ±inf sentinels it is combined
-        # with broadcast from a scalar rather than a full-size ``full_like``.
         is_nan = torch.isnan(x_finite)
         col_min = torch.amin(
             torch.where(is_nan, _scalar(float("inf"), x_finite), x_finite), dim=0
@@ -273,6 +214,7 @@ class TorchSquashingScaler:
         col_min = torch.where(all_nan, _scalar(float("nan"), col_min), col_min)
         col_max = torch.where(all_nan, _scalar(float("nan"), col_max), col_max)
 
+        # the dominant cost
         quantiles = torch.nanquantile(x_finite.to(quantile_dtype), qs, dim=0).to(
             x.dtype
         )
@@ -305,20 +247,14 @@ class TorchSquashingScaler:
         scale = fitted_cache["scale"]
         zero_mask = fitted_cache["zero_mask"]
 
-        # The output has to exist in full; nothing else here does. So it is allocated
-        # uninitialised and filled a block of rows at a time, with every intermediate
-        # -- the NaN and +/-inf masks, and the soft clip's denominator -- living only
-        # as long as the block it belongs to. That, rather than any change to the
-        # arithmetic, is what takes `transform` from 5.8x its input to a little over
-        # 1x. Rows are safe to split on because every step below is elementwise.
-        #
-        # `x` itself is never written to: the pipeline hands over a gathered copy it
-        # then writes back into, and relies on it surviving the call.
+        # only the output has to exist in full
         out = torch.empty_like(x)
         nan = _scalar(float("nan"), x)
         block = _block_size(x, dim=0, budget_bytes=_TRANSFORM_BLOCK_BYTES)
         for start in range(0, x.shape[0], block):
             stop = start + block
+            # rows are safe to split on because every step in
+            # `_transform_block` is elementwise
             self._transform_block(
                 x[start:stop], out[start:stop], center, scale, zero_mask, nan
             )
@@ -333,30 +269,28 @@ class TorchSquashingScaler:
         zero_mask: torch.Tensor,
         nan: torch.Tensor,
     ) -> None:
-        """Transform one block of rows, writing into ``out`` and allocating no copy.
+        """Transform one block of rows in place, writing through into ``out``.
 
-        ``out`` is a view into the full output, so every step writes through to it.
+        ``out`` is a view into the full output.
         """
         b = self.max_absolute_value
 
-        # Replace +/-inf with NaN so the scale ops never produce 0 * inf = nan for
-        # what was originally a finite outlier, and so the soft clip operates on the
-        # centered/scaled finite distribution. The original positions are recovered
-        # from `x` at the end, which is untouched.
+        # Replace ±inf with NaN so the scale ops never produce 0 * inf = nan
+        # for what was originally a finite outlier, and so soft-clip operates
+        # on the centered/scaled finite distribution.
         torch.where(torch.isinf(x), nan, x, out=out)
         out.sub_(center).div_(scale)
 
-        # Zero columns: finite entries become 0 while NaNs are left alone. Built as
-        # "is not NaN, and in a zero column" in a single mask buffer, rather than the
-        # three full-size ones the direct spelling needs.
+        # Zero columns: finite entries become 0 while NaNs are left alone. One mask
+        # buffer holds "is not NaN, and in a zero column".
         finite_in_zero_column = torch.isnan(x)
         finite_in_zero_column.logical_not_()
         finite_in_zero_column &= zero_mask
         out.masked_fill_(finite_in_zero_column, 0.0)
         del finite_in_zero_column
 
-        # Spelled in place, but the same sequence of kernels -- and so the same
-        # results -- as `z / torch.sqrt(1.0 + (z / b) ** 2)`.
+        # In-place form of `z / torch.sqrt(1.0 + (z / b) ** 2)`: the same kernels in
+        # the same order, needing one temporary rather than a chain of them.
         denominator = out / b
         denominator.pow_(2)
         denominator.add_(1.0)

--- a/src/tabpfn/preprocessing/torch/torch_squashing_scaler.py
+++ b/src/tabpfn/preprocessing/torch/torch_squashing_scaler.py
@@ -16,16 +16,103 @@ Original skrub attribution:
 
 The state is returned explicitly from ``fit`` rather than stored on the
 instance, matching the rest of ``preprocessing/torch``.
+
+Memory
+------
+
+Both halves are written to keep their device footprint down, because at the shapes
+this runs at they are dominated by their own temporaries rather than by their input.
+Measured with ``scripts/profile_squashing_scaler.py`` on an H100:
+
+* ``fit`` is essentially one ``torch.nanquantile`` call, whose internal sort peaks at
+  roughly **12x the bytes it is handed** (radix sort double-buffers both the values
+  and their int64 indices). So the reduction is done in blocks of columns of a fixed
+  byte size, which turns that peak from a multiple of the input into a constant. It is
+  only done above ``_FIT_UNBLOCKED_BYTES``, because blocking the sort costs a few
+  percent of fit's wall time on older torch and is not worth paying where 12x already
+  fits.
+* ``transform`` has to produce a full-size output, so its floor is 1x; what it must
+  not do is stack up further full-size buffers on the way there. It allocates the
+  output once and fills it a block of rows at a time, so every mask and temporary it
+  needs is the size of a block rather than of the whole tensor.
+
+The elementwise rewrites are bit-for-bit equivalent to the straightforward spelling
+(``a.sub_(b)`` is the same kernel as ``a - b``, writing to a different place), and the
+blocking is over axes the maths is independent along -- per column for a per-column
+reduction, per row for an elementwise map. Neither is a change to the arithmetic,
+and ``scripts/bench_squashing_scaler.py`` gates that: it fails unless the outputs stay
+byte-identical.
 """
 
 from __future__ import annotations
 
 import torch
 
+# Bytes of input one ``fit`` column block is allowed to cover. The sort inside
+# ``torch.nanquantile`` peaks at ~12x the bytes it is given, and that multiple -- not
+# the input size -- is what put a 10M x 2,000 fit out of reach on an 80 GB card.
+# Blocking by a fixed *byte* size rather than a fixed number of blocks makes fit's
+# peak a constant (~13x this) at every shape, instead of a constant multiple of an
+# input that keeps growing.
+#
+# Swept on an H100, fit on [666667, 1, 2000] (5.33 GB), transient VRAM against median
+# wall time: 32 MB -> 0.52 GB / 212.0 ms, 64 MB -> 1.08 GB / 202.6 ms, 128 MB ->
+# 2.14 GB / 198.5 ms, 256 MB -> 4.28 GB / 210.1 ms, 512 MB -> 6.97 GB / 243.6 ms,
+# 1 GB -> 13.94 GB / 248.0 ms. 128 MB is the best of both: large blocks lose badly on
+# time as well as memory, and the smallest ones start paying for the extra launches.
+_FIT_BLOCK_BYTES = 128 * 1024 * 1024
+
+# Below this much input, ``fit`` does not block at all. Blocking the sort is not free:
+# on torch 2.5 (the floor of the supported range) it costs ~5% of fit's wall time at
+# every block size tried, where on 2.13 it *saves* ~8%. That is a trade worth making
+# to turn a 69 GB peak into a 2 GB one -- but only where there is a 69 GB peak to
+# turn. Under this threshold the unblocked path needs about 13x of very little, so the
+# old single-pass spelling is kept and nothing about this change is observable.
+#
+# 512 MB puts the crossover at roughly 6.5 GB of unblocked transient: comfortable on
+# any card this runs on, and far above anything the test suite or a CPU/MPS caller
+# reaches.
+_FIT_UNBLOCKED_BYTES = 512 * 1024 * 1024
+
+# Bytes of output ``transform`` produces at a time. Its output has to exist in full;
+# none of its intermediates do, so they are kept to a block.
+#
+# Swept on an H100 at 1M x 2,000 (8 GB of output), transient VRAM against median wall
+# time: 32 MB -> 1.01x / 94.9 ms, 256 MB -> 1.04x / 93.6 ms, 512 MB -> 1.08x /
+# 92.2 ms, 8 GB (i.e. no blocking) -> 2.25x / 91.6 ms. Time is flat to within the
+# spread of the sweep across the whole range while memory is not, so this sits at the
+# small end: the block buys nothing above the point where the launches stop being
+# free, and the memory it costs scales with the tensor.
+_TRANSFORM_BLOCK_BYTES = 32 * 1024 * 1024
+
+
+def _scalar(value: float, like: torch.Tensor) -> torch.Tensor:
+    """A 0-dim tensor of ``like``'s dtype and device, to broadcast into ``where``.
+
+    The obvious spelling is ``torch.full_like(x, value)``, which allocates a second
+    tensor the size of ``x`` in order to carry one number. A 0-dim tensor broadcasts
+    to the same effect, holds the same value in the same dtype -- so the result is
+    unchanged -- and costs nothing.
+    """
+    return torch.full((), value, dtype=like.dtype, device=like.device)
+
 
 def _replace_inf_with_nan(x: torch.Tensor) -> torch.Tensor:
     """Replace ±inf with NaN so percentile/min/max see only finite values."""
-    return torch.where(torch.isinf(x), torch.full_like(x, float("nan")), x)
+    return torch.where(torch.isinf(x), _scalar(float("nan"), x), x)
+
+
+def _block_size(x: torch.Tensor, dim: int, budget_bytes: int) -> int:
+    """Slices of ``dim`` whose data is about ``budget_bytes``.
+
+    At least one: a single slice larger than the budget cannot be split any further
+    along this axis, and the caller has no other axis to give.
+    """
+    per_slice = x.element_size()
+    for index, size in enumerate(x.shape):
+        if index != dim:
+            per_slice *= size
+    return max(1, budget_bytes // max(1, per_slice))
 
 
 class TorchSquashingScaler:
@@ -85,31 +172,6 @@ class TorchSquashingScaler:
                 "zero_mask": torch.ones(feature_shape, device=device, dtype=torch.bool),
             }
 
-        x_finite = _replace_inf_with_nan(x)
-
-        # nanquantile cannot share its sort with nanmin/nanmax across the same
-        # call, so they're computed separately. The dominant cost is the single
-        # nanquantile call covering all three quartiles at once.
-        col_min = torch.amin(
-            torch.where(
-                torch.isnan(x_finite), torch.full_like(x_finite, float("inf")), x_finite
-            ),
-            dim=0,
-        )
-        col_max = torch.amax(
-            torch.where(
-                torch.isnan(x_finite),
-                torch.full_like(x_finite, float("-inf")),
-                x_finite,
-            ),
-            dim=0,
-        )
-        # All-NaN columns yield ±inf above; surface them as NaN so the masks
-        # below treat them as the "general" path (output stays NaN).
-        all_nan = torch.isnan(x_finite).all(dim=0)
-        col_min = torch.where(all_nan, torch.full_like(col_min, float("nan")), col_min)
-        col_max = torch.where(all_nan, torch.full_like(col_max, float("nan")), col_max)
-
         # torch.nanquantile requires float32 or float64; upcast (e.g. from
         # float16) just for the quantile computation, then cast results back.
         quantile_dtype = (
@@ -121,7 +183,8 @@ class TorchSquashingScaler:
             device=device,
             dtype=quantile_dtype,
         )
-        quantiles = torch.nanquantile(x_finite.to(quantile_dtype), qs, dim=0).to(dtype)
+
+        col_min, col_max, quantiles = self._column_statistics(x, qs, quantile_dtype)
         q_lower, q_median, q_upper = quantiles[0], quantiles[1], quantiles[2]
 
         zero_mask = col_max == col_min
@@ -145,6 +208,75 @@ class TorchSquashingScaler:
             "scale": scale.to(dtype=dtype),
             "zero_mask": zero_mask,
         }
+
+    def _column_statistics(
+        self,
+        x: torch.Tensor,
+        qs: torch.Tensor,
+        quantile_dtype: torch.dtype,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Per-column min, max and quantiles, reduced a block of columns at a time.
+
+        Every statistic here is reduced over dim 0 and is therefore independent per
+        column, so which columns are handed over together cannot change any of them --
+        which is what makes the blocking free of consequences other than the memory it
+        saves. The blocks are joined back up along the column axis, and the caller
+        works on the whole thing exactly as it would have.
+
+        The one thing this must not do is materialise a whole ``_replace_inf_with_nan``
+        copy of ``x``: that copy is the input to the expensive call, so keeping it to a
+        block keeps the sort inside ``nanquantile`` to a block too.
+        """
+        columns = x.shape[-1]
+        block = _block_size(x, dim=x.ndim - 1, budget_bytes=_FIT_BLOCK_BYTES)
+        if block >= columns or x.element_size() * x.nelement() <= _FIT_UNBLOCKED_BYTES:
+            return self._column_statistics_block(x, qs, quantile_dtype)
+
+        parts = [
+            self._column_statistics_block(
+                x[..., start : start + block], qs, quantile_dtype
+            )
+            for start in range(0, columns, block)
+        ]
+        return (
+            torch.cat([part[0] for part in parts], dim=-1),
+            torch.cat([part[1] for part in parts], dim=-1),
+            torch.cat([part[2] for part in parts], dim=-1),
+        )
+
+    def _column_statistics_block(
+        self,
+        x: torch.Tensor,
+        qs: torch.Tensor,
+        quantile_dtype: torch.dtype,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """min, max and quantiles for one block of columns."""
+        x_finite = _replace_inf_with_nan(x)
+
+        # nanquantile cannot share its sort with nanmin/nanmax across the same
+        # call, so they're computed separately. The dominant cost is the single
+        # nanquantile call covering all three quartiles at once.
+        #
+        # One NaN mask serves all three uses below; the ±inf sentinels it is combined
+        # with broadcast from a scalar rather than a full-size ``full_like``.
+        is_nan = torch.isnan(x_finite)
+        col_min = torch.amin(
+            torch.where(is_nan, _scalar(float("inf"), x_finite), x_finite), dim=0
+        )
+        col_max = torch.amax(
+            torch.where(is_nan, _scalar(float("-inf"), x_finite), x_finite), dim=0
+        )
+        # All-NaN columns yield ±inf above; surface them as NaN so the masks
+        # in `fit` treat them as the "general" path (output stays NaN).
+        all_nan = is_nan.all(dim=0)
+        del is_nan
+        col_min = torch.where(all_nan, _scalar(float("nan"), col_min), col_min)
+        col_max = torch.where(all_nan, _scalar(float("nan"), col_max), col_max)
+
+        quantiles = torch.nanquantile(x_finite.to(quantile_dtype), qs, dim=0).to(
+            x.dtype
+        )
+        return col_min, col_max, quantiles
 
     def transform(
         self,
@@ -173,31 +305,67 @@ class TorchSquashingScaler:
         scale = fitted_cache["scale"]
         zero_mask = fitted_cache["zero_mask"]
 
-        pos_inf = torch.isposinf(x)
-        neg_inf = torch.isneginf(x)
-        nan_mask = torch.isnan(x)
+        # The output has to exist in full; nothing else here does. So it is allocated
+        # uninitialised and filled a block of rows at a time, with every intermediate
+        # -- the NaN and +/-inf masks, and the soft clip's denominator -- living only
+        # as long as the block it belongs to. That, rather than any change to the
+        # arithmetic, is what takes `transform` from 5.8x its input to a little over
+        # 1x. Rows are safe to split on because every step below is elementwise.
+        #
+        # `x` itself is never written to: the pipeline hands over a gathered copy it
+        # then writes back into, and relies on it surviving the call.
+        out = torch.empty_like(x)
+        nan = _scalar(float("nan"), x)
+        block = _block_size(x, dim=0, budget_bytes=_TRANSFORM_BLOCK_BYTES)
+        for start in range(0, x.shape[0], block):
+            stop = start + block
+            self._transform_block(
+                x[start:stop], out[start:stop], center, scale, zero_mask, nan
+            )
+        return out
 
-        # Replace ±inf with NaN so the scale ops never produce 0 * inf = nan
-        # for what was originally a finite outlier, and so soft-clip operates
-        # on the centered/scaled finite distribution.
-        x_finite = _replace_inf_with_nan(x)
+    def _transform_block(
+        self,
+        x: torch.Tensor,
+        out: torch.Tensor,
+        center: torch.Tensor,
+        scale: torch.Tensor,
+        zero_mask: torch.Tensor,
+        nan: torch.Tensor,
+    ) -> None:
+        """Transform one block of rows, writing into ``out`` and allocating no copy.
 
-        x_scaled = (x_finite - center) / scale
-
-        # Broadcast zero_mask up to x's shape so we can zero-out finite
-        # entries column-wise without touching NaNs.
-        zero_broadcast = zero_mask.expand_as(x_scaled)
-        x_scaled = torch.where(
-            zero_broadcast & ~nan_mask,
-            torch.zeros_like(x_scaled),
-            x_scaled,
-        )
-
+        ``out`` is a view into the full output, so every step writes through to it.
+        """
         b = self.max_absolute_value
-        x_clipped = x_scaled / torch.sqrt(1.0 + (x_scaled / b) ** 2)
 
-        x_clipped = torch.where(pos_inf, torch.full_like(x_clipped, b), x_clipped)
-        return torch.where(neg_inf, torch.full_like(x_clipped, -b), x_clipped)
+        # Replace +/-inf with NaN so the scale ops never produce 0 * inf = nan for
+        # what was originally a finite outlier, and so the soft clip operates on the
+        # centered/scaled finite distribution. The original positions are recovered
+        # from `x` at the end, which is untouched.
+        torch.where(torch.isinf(x), nan, x, out=out)
+        out.sub_(center).div_(scale)
+
+        # Zero columns: finite entries become 0 while NaNs are left alone. Built as
+        # "is not NaN, and in a zero column" in a single mask buffer, rather than the
+        # three full-size ones the direct spelling needs.
+        finite_in_zero_column = torch.isnan(x)
+        finite_in_zero_column.logical_not_()
+        finite_in_zero_column &= zero_mask
+        out.masked_fill_(finite_in_zero_column, 0.0)
+        del finite_in_zero_column
+
+        # Spelled in place, but the same sequence of kernels -- and so the same
+        # results -- as `z / torch.sqrt(1.0 + (z / b) ** 2)`.
+        denominator = out / b
+        denominator.pow_(2)
+        denominator.add_(1.0)
+        denominator.sqrt_()
+        out.div_(denominator)
+        del denominator
+
+        out.masked_fill_(torch.isposinf(x), b)
+        out.masked_fill_(torch.isneginf(x), -b)
 
     def __call__(
         self,

--- a/src/tabpfn/preprocessing/torch/torch_squashing_scaler.py
+++ b/src/tabpfn/preprocessing/torch/torch_squashing_scaler.py
@@ -43,15 +43,15 @@ _TRANSFORM_BLOCK_BYTES = 32 * 1024 * 1024
 def _scalar(value: float, like: torch.Tensor) -> torch.Tensor:
     """A 0-dim tensor of `like`'s dtype and device, to broadcast into `where`.
 
-    Broadcasting one number costs nothing, where `torch.full_like` would allocate a
-    tensor the size of `x` to carry it.
+    `torch.where` takes a Python float directly, but not alongside `out=`; a 0-dim
+    tensor is what lets the result be written straight into an existing buffer.
     """
     return torch.full((), value, dtype=like.dtype, device=like.device)
 
 
 def _replace_inf_with_nan(x: torch.Tensor) -> torch.Tensor:
     """Replace ±inf with NaN so percentile/min/max see only finite values."""
-    return torch.where(torch.isinf(x), _scalar(float("nan"), x), x)
+    return torch.where(torch.isinf(x), float("nan"), x)
 
 
 def _block_size(x: torch.Tensor, dim: int, budget_bytes: int) -> int:
@@ -201,18 +201,14 @@ class TorchSquashingScaler:
         x_masked = _replace_inf_with_nan(x)
 
         is_nan = torch.isnan(x_masked)
-        col_min = torch.amin(
-            torch.where(is_nan, _scalar(float("inf"), x_masked), x_masked), dim=0
-        )
-        col_max = torch.amax(
-            torch.where(is_nan, _scalar(float("-inf"), x_masked), x_masked), dim=0
-        )
+        col_min = torch.amin(torch.where(is_nan, float("inf"), x_masked), dim=0)
+        col_max = torch.amax(torch.where(is_nan, float("-inf"), x_masked), dim=0)
         # All-NaN columns yield ±inf above; surface them as NaN so the masks
         # in `fit` treat them as the "general" path (output stays NaN).
         all_nan = is_nan.all(dim=0)
         del is_nan
-        col_min = torch.where(all_nan, _scalar(float("nan"), col_min), col_min)
-        col_max = torch.where(all_nan, _scalar(float("nan"), col_max), col_max)
+        col_min = torch.where(all_nan, float("nan"), col_min)
+        col_max = torch.where(all_nan, float("nan"), col_max)
 
         # the dominant cost
         quantiles = torch.nanquantile(x_masked.to(quantile_dtype), qs, dim=0).to(

--- a/src/tabpfn/preprocessing/torch/torch_squashing_scaler.py
+++ b/src/tabpfn/preprocessing/torch/torch_squashing_scaler.py
@@ -198,14 +198,14 @@ class TorchSquashingScaler:
         quantile_dtype: torch.dtype,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """min, max and quantiles for one block of columns."""
-        x_finite = _replace_inf_with_nan(x)
+        x_masked = _replace_inf_with_nan(x)
 
-        is_nan = torch.isnan(x_finite)
+        is_nan = torch.isnan(x_masked)
         col_min = torch.amin(
-            torch.where(is_nan, _scalar(float("inf"), x_finite), x_finite), dim=0
+            torch.where(is_nan, _scalar(float("inf"), x_masked), x_masked), dim=0
         )
         col_max = torch.amax(
-            torch.where(is_nan, _scalar(float("-inf"), x_finite), x_finite), dim=0
+            torch.where(is_nan, _scalar(float("-inf"), x_masked), x_masked), dim=0
         )
         # All-NaN columns yield ±inf above; surface them as NaN so the masks
         # in `fit` treat them as the "general" path (output stays NaN).
@@ -215,7 +215,7 @@ class TorchSquashingScaler:
         col_max = torch.where(all_nan, _scalar(float("nan"), col_max), col_max)
 
         # the dominant cost
-        quantiles = torch.nanquantile(x_finite.to(quantile_dtype), qs, dim=0).to(
+        quantiles = torch.nanquantile(x_masked.to(quantile_dtype), qs, dim=0).to(
             x.dtype
         )
         return col_min, col_max, quantiles

--- a/tests/test_torch_preprocessing/test_torch_squashing_scaler.py
+++ b/tests/test_torch_preprocessing/test_torch_squashing_scaler.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import importlib
+
 import numpy as np
 import pytest
 import torch
@@ -203,3 +205,237 @@ class TestTorchSquashingScaler:
         assert np.allclose(cpu_out, torch_out, atol=1e-5, equal_nan=True), (
             f"max abs diff = {np.nanmax(np.abs(cpu_out - torch_out))}"
         )
+
+
+# The blocked reduction in `fit` and the blocked map in `transform` only engage on
+# inputs far larger than anything the tests above build, so at their real budgets those
+# paths are never taken here. These tests force the budgets instead: the same small
+# input is run once with blocking off and once with it as fine as it goes -- a column
+# per block, a row per block -- and the two must agree bit for bit.
+#
+# Bit for bit rather than `allclose`, because the failures worth catching are exactly
+# the ones a tolerance hides: a NaN payload that changes, a zero that comes back
+# negative, a quantile that lands one representable step away because a column was
+# grouped differently.
+
+# Captured once, at import, so a test that installs a counting wrapper still calls the
+# real implementation rather than another test's wrapper.
+_REAL_COLUMN_STATISTICS_BLOCK = TorchSquashingScaler._column_statistics_block
+_REAL_TRANSFORM_BLOCK = TorchSquashingScaler._transform_block
+
+# Budgets that force every block boundary the code can express, and budgets no input in
+# this file can exceed. Both are set explicitly rather than leaning on the defaults, so
+# the test keeps testing what it says even if the real constants are retuned.
+_FORCE_BLOCKED = {
+    "_FIT_BLOCK_BYTES": 1,
+    "_FIT_UNBLOCKED_BYTES": 0,
+    "_TRANSFORM_BLOCK_BYTES": 1,
+}
+_FORCE_UNBLOCKED = {
+    "_FIT_BLOCK_BYTES": 1 << 40,
+    "_FIT_UNBLOCKED_BYTES": 1 << 40,
+    "_TRANSFORM_BLOCK_BYTES": 1 << 40,
+}
+
+_BIT_DTYPE = {
+    torch.float16: torch.int16,
+    torch.bfloat16: torch.int16,
+    torch.float32: torch.int32,
+    torch.float64: torch.int64,
+}
+
+
+def _bits(t: torch.Tensor) -> torch.Tensor:
+    """An integer view of a tensor's bytes.
+
+    A float comparison calls two NaNs unequal and two zeros of opposite sign equal;
+    neither is what "identical" means here.
+    """
+    if t.dtype == torch.bool or not t.dtype.is_floating_point:
+        return t
+    return t.contiguous().view(_BIT_DTYPE[t.dtype])
+
+
+def _assert_bit_identical(
+    what: str, blocked: torch.Tensor, plain: torch.Tensor
+) -> None:
+    """Assert two tensors are byte-for-byte equal, naming the first cell that is not."""
+    assert blocked.shape == plain.shape, f"{what}: {blocked.shape} != {plain.shape}"
+    assert blocked.dtype == plain.dtype, f"{what}: {blocked.dtype} != {plain.dtype}"
+    unequal = _bits(blocked) != _bits(plain)
+    if not unequal.any():
+        return
+    position = tuple(int(v) for v in torch.nonzero(unequal)[0])
+    raise AssertionError(
+        f"{what} differs at {position}: blocked {blocked[position].item()!r} vs "
+        f"unblocked {plain[position].item()!r} "
+        f"({int(unequal.sum())} of {unequal.numel()} entries differ)"
+    )
+
+
+def _run_with_budgets(
+    monkeypatch: pytest.MonkeyPatch,
+    budgets: dict[str, int],
+    x: torch.Tensor,
+    num_train_rows: int,
+    max_absolute_value: float,
+) -> tuple[dict[str, torch.Tensor], torch.Tensor, dict[str, int]]:
+    """Fit and transform under the given budgets, counting the blocks processed.
+
+    The counts are what stop this being a tautology: without them a run that quietly
+    took the unblocked path both times would pass while testing nothing.
+    """
+    module = importlib.import_module(
+        "tabpfn.preprocessing.torch.torch_squashing_scaler"
+    )
+    for name, value in budgets.items():
+        monkeypatch.setattr(module, name, value)
+
+    counts = {"fit_blocks": 0, "transform_blocks": 0}
+
+    def counting_column_statistics_block(self, *args, **kwargs):  # noqa: ANN202
+        counts["fit_blocks"] += 1
+        return _REAL_COLUMN_STATISTICS_BLOCK(self, *args, **kwargs)
+
+    def counting_transform_block(self, *args, **kwargs):  # noqa: ANN202
+        counts["transform_blocks"] += 1
+        return _REAL_TRANSFORM_BLOCK(self, *args, **kwargs)
+
+    monkeypatch.setattr(
+        module.TorchSquashingScaler,
+        "_column_statistics_block",
+        counting_column_statistics_block,
+    )
+    monkeypatch.setattr(
+        module.TorchSquashingScaler, "_transform_block", counting_transform_block
+    )
+
+    scaler = module.TorchSquashingScaler(max_absolute_value=max_absolute_value)
+    cache = scaler.fit(x[:num_train_rows])
+    out = scaler.transform(x, fitted_cache=cache)
+    return cache, out, counts
+
+
+def _blocking_cases() -> list[pytest.param]:
+    """Inputs covering every branch the blocked and unblocked paths share."""
+    generator = torch.Generator().manual_seed(0)
+
+    def normal(shape: tuple[int, ...], dtype: torch.dtype = torch.float32):  # noqa: ANN202
+        return torch.randn(shape, generator=generator, dtype=dtype)
+
+    cases: list[tuple[str, torch.Tensor, int]] = []
+
+    # The pipeline's own layout, and the 2-D one `fit` documents.
+    cases.append(("robust 3d", normal((96, 1, 12)), 64))
+    cases.append(("robust 2d", normal((96, 12)), 64))
+    # A batch dimension above 1: blocking splits the last axis, so a middle axis that
+    # is not 1 is where an indexing slip would show up.
+    cases.append(("batched", normal((96, 3, 8)), 64))
+
+    # Every dtype the pipeline can force. float16 matters most: nanquantile refuses it,
+    # so the implementation upcasts, and the cast happens per block.
+    cases.append(("float64", normal((96, 1, 8), torch.float64), 64))
+    cases.append(("float16", normal((96, 1, 8), torch.float16), 64))
+
+    # The branch picks: a constant column (zero_mask), one whose quartiles collapse
+    # while its range does not (minmax), and ordinary columns beside them.
+    mixed = normal((96, 1, 8))
+    mixed[:, :, 0] = 3.25
+    mixed[:, :, 1] = torch.where(normal((96, 1)) < 1.0, 0.0, 9.0)
+    mixed[:, :, 2] = 0.0
+    cases.append(("zero and minmax columns", mixed, 64))
+
+    # NaN and inf, including columns that are nothing else.
+    nasty = normal((96, 1, 8))
+    nasty[:, :, 0] = float("nan")
+    nasty[:, :, 1] = float("inf")
+    nasty[:, :, 2] = float("-inf")
+    nasty[::7, :, 3] = float("nan")
+    nasty[::11, :, 4] = float("inf")
+    nasty[::13, :, 5] = float("-inf")
+    cases.append(("nan and inf", nasty, 64))
+
+    # +/-inf inside a zero column and inside a minmax one: the zero-column branch and
+    # the +/-inf branch both want to write to those cells.
+    overlap = normal((96, 1, 6))
+    overlap[:, :, 0] = 2.5
+    overlap[::9, :, 0] = float("inf")
+    overlap[::10, :, 0] = float("-inf")
+    overlap[:, :, 1] = torch.where(normal((96, 1)) < 1.0, 0.0, 4.0)
+    overlap[::8, :, 1] = float("-inf")
+    cases.append(("inf inside zero and minmax columns", overlap, 64))
+
+    # Signed zero, which a value comparison would call equal to zero.
+    zeros = normal((96, 1, 4))
+    zeros[:, :, 0] = -0.0
+    zeros[:, :, 1] = 0.0
+    cases.append(("signed zero", zeros, 64))
+
+    # Fitting on rows that are entirely NaN while the transformed rows are not.
+    split = normal((96, 1, 6))
+    split[:64] = float("nan")
+    cases.append(("all-nan training rows", split, 64))
+
+    # The early return in `fit`, which no amount of blocking should reach.
+    cases.append(("single train row", normal((96, 1, 6)), 1))
+
+    # Degenerate shapes: one column to block, and many rows to map.
+    cases.append(("one column", normal((96, 1, 1)), 64))
+    cases.append(("tall and thin", normal((512, 1, 2)), 341))
+
+    return [pytest.param(x, rows, id=name) for name, x, rows in cases]
+
+
+class TestBlockingEquivalence:
+    """Blocking must not change what the scaler returns."""
+
+    @pytest.mark.parametrize(("x", "num_train_rows"), _blocking_cases())
+    @pytest.mark.parametrize("max_absolute_value", [3.0, 10.0])
+    def test__blocked_and_unblocked_are_bit_identical(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        x: torch.Tensor,
+        num_train_rows: int,
+        max_absolute_value: float,
+    ) -> None:
+        """The fitted cache and the transformed output agree byte for byte."""
+        with monkeypatch.context() as unblocked_patch:
+            plain_cache, plain_out, plain_counts = _run_with_budgets(
+                unblocked_patch, _FORCE_UNBLOCKED, x, num_train_rows, max_absolute_value
+            )
+        with monkeypatch.context() as blocked_patch:
+            blocked_cache, blocked_out, blocked_counts = _run_with_budgets(
+                blocked_patch, _FORCE_BLOCKED, x, num_train_rows, max_absolute_value
+            )
+
+        # Without this the test could pass while both runs took the same path.
+        assert plain_counts["transform_blocks"] == 1
+        assert blocked_counts["transform_blocks"] == x.shape[0]
+        if num_train_rows > 1:
+            assert plain_counts["fit_blocks"] == 1
+            assert blocked_counts["fit_blocks"] == x.shape[-1]
+        else:
+            # `fit` returns before reducing anything, so there are no blocks either way.
+            assert plain_counts["fit_blocks"] == 0
+            assert blocked_counts["fit_blocks"] == 0
+
+        assert set(blocked_cache) == set(plain_cache)
+        for key in sorted(plain_cache):
+            _assert_bit_identical(
+                f"fitted cache[{key!r}]", blocked_cache[key], plain_cache[key]
+            )
+        _assert_bit_identical("transform output", blocked_out, plain_out)
+
+    def test__blocked_transform_does_not_write_to_its_input(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`transform` leaves `x` alone; the pipeline reuses the tensor it passes in."""
+        x = torch.randn(96, 1, 8, generator=torch.Generator().manual_seed(1))
+        x[::5, :, 0] = float("inf")
+        x[::7, :, 1] = float("nan")
+        before = x.clone()
+
+        with monkeypatch.context() as patch:
+            _run_with_budgets(patch, _FORCE_BLOCKED, x, 64, 3.0)
+
+        _assert_bit_identical("input tensor", x, before)


### PR DESCRIPTION
## Issue

[RES-2731 — SquashingScaler 10M x 2k OOM](https://linear.app/priorlabs/issue/RES-2731/squashingscaler-10m-x-2k-oom)

## Motivation and Context

**What**

-   `TorchSquashingScaler` now operates in fixed-byte blocks, so the VRAM peaks are roughly constant instead of proportional to the input.
-   `TorchSquashingScaler.fit`: -97% transient VRAM; -7.5% wall time in torch 2.10+, **but +5% wall time on torch ≤2.9**.

**Why**

-   `TorchSquashingScaler.fit` needed **13.0x its input** in VRAM and `transform` **5.8x**
-   Nearly all of `fit`'s peak is the sort inside `torch.nanquantile`, which double-buffers the sorted values *and* their int64 indices and so reaches ~12x the bytes handed to it.
-   `transform` stacked up full-size `where`/`full_like`/`zeros_like` buffers on the way to an output that only ever needed to exist once.

**How**

-   `fit` reduces a block of columns at a time (per-column statistics are independent, so grouping cannot change one), `transform` fills its output a block of rows at a time (every step is elementwise).
-   Elementwise work is spelled in place — `a.sub_(b)` is the same kernel as `a - b` — and `full_like` sentinels become 0-dim broadcasts, so outputs stay **byte-identical** (and that's a Claude promise!).

---

## Public API Changes

-   [x] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## How Has This Been Tested?

H100 80GB, 1M x 2,000 float32, against `cb23da5f`. Transient VRAM is the peak *above* what was live on entry — what decides whether a shape fits:

| stage | input | transient VRAM | of input | median wall time |
| :--- | :--- | :--- | :--- | :--- |
| fit | 5.33 GB | **69.33 → 2.14 GB** | **13.0x → 0.4x** | 215.2 → 198.8 ms |
| transform | 8.00 GB | **46.01 → 8.04 GB** | **5.8x → 1.0x** | 110.0 → 93.7 ms |

Outputs are byte-identical at every torch from 2.5.0 to 2.13.0. `transform` is at its floor: 1.0x is the output itself.

-   `scripts/bench_squashing_scaler.py` gates byte-identity, transient VRAM and wall time in one process, and runs 28 correctness cases with every blocking budget forced to 1 so the blocked paths are exercised at small shapes too.
-   `tests/test_torch_preprocessing/`, `test_inf_handling.py`, `test_pipeline_consistency.py`: 205 passed, 39 skipped.

<details><summary>Details: the one cost, and why it is bounded</summary>

Blocking the sort is not free. It costs ~5% of `fit`'s wall time on torch ≤2.9 while saving ~8% on ≥2.10, and no block size wins on both — bisected across nine releases:

| torch | fit: reference | working tree | change |
| :--- | :--- | :--- | :--- |
| 2.5.0 | 215.7 ms / 69.33 GB | 226.3 ms / 2.14 GB | +4.9% |
| 2.9.0 | 214.9 ms / 69.33 GB | 221.7 ms / 2.14 GB | +3.2% |
| 2.10.0 | 214.8 ms / 69.33 GB | 198.7 ms / 2.14 GB | −7.5% |
| 2.11.0 | 215.0 ms / 69.33 GB | 198.7 ms / 2.14 GB | −7.6% |
| 2.13.0 | 215.2 ms / 69.33 GB | 198.7 ms / 2.14 GB | −7.6% |

The reference column barely moves across nine releases, so torch did not speed up the unblocked sort — it sped up the blocked one, and that is where the whole swing lives. The VRAM columns are identical everywhere, so the memory win does not depend on the torch underneath; only its wall-time cost does.

`_FIT_UNBLOCKED_BYTES` (512 MB) bounds that cost: below it `fit` takes the old single-pass route unchanged, so the ~5% is only ever paid where the alternative is a 69 GB allocation. That threshold is above anything the test suite or a CPU/MPS caller reaches.

</details>

<details><summary>Details: block sizes</summary>

Both budgets were swept on an H100 at 1M x 2,000 rather than guessed, and the sweeps are recorded beside each constant. `_FIT_BLOCK_BYTES` = 128 MB is the best of both axes (2.14 GB / 198.5 ms; 512 MB and above lose badly on time *and* memory). `_TRANSFORM_BLOCK_BYTES` = 32 MB sits at the small end because time is flat across the whole range while memory is not (32 MB → 1.01x / 94.9 ms, versus no blocking → 2.25x / 91.6 ms).

</details>

---

## Checklist

-   [x] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [x] A changelog entry has been added (see `changelog/README.md`), or "no changelog needed" label requested.
-   [x] The code follows the project's style guidelines.
-   [x] I have considered the impact of these changes on the public API.

---