### PR TITLE
Use a single importance ordering for every estimator

### DIFF
--- a/changelog/1229.fixed.md
+++ b/changelog/1229.fixed.md
@@ -1,0 +1,8 @@
+- Fixed importance-based feature subsampling losing its feature-coverage
+  guarantee on datasets above `FEATURE_IMPORTANCE_MAX_SAMPLES` (100k rows),
+  where one importance ordering was fit per row subsample and each estimator
+  ended up drawing its non-top features from a private pool. A single ordering
+  is now fit and shared by every estimator, so the balanced round-robin covers
+  all features on both sides of that threshold. Results change for fits using
+  `gini_feature_importance` (directly or via `"auto"`) on datasets larger than
+  100k rows.

--- a/changelog/1229.fixed.md
+++ b/changelog/1229.fixed.md
@@ -1,8 +1,1 @@
-- Fixed importance-based feature subsampling losing its feature-coverage
-  guarantee on datasets above `FEATURE_IMPORTANCE_MAX_SAMPLES` (100k rows),
-  where one importance ordering was fit per row subsample and each estimator
-  ended up drawing its non-top features from a private pool. A single ordering
-  is now fit and shared by every estimator, so the balanced round-robin covers
-  all features on both sides of that threshold. Results change for fits using
-  `gini_feature_importance` (directly or via `"auto"`) on datasets larger than
-  100k rows.
+Above 100k rows, importance-based feature subsampling gave every estimator its own feature ranking and its own sampling pool, so some features ended up in no ensemble member at all even when the combined feature budget covered them. A single shared ranking now restores full coverage, and replaces up to `n_estimators` LightGBM fits with one. Results change for `gini_feature_importance` fits (directly or via `"auto"`) above 100k rows.

--- a/src/tabpfn/preprocessing/ensemble.py
+++ b/src/tabpfn/preprocessing/ensemble.py
@@ -178,7 +178,7 @@ class TabPFNEnsemblePreprocessor:
             c.preprocess_config.max_features_per_estimator for c in self.configs
         ]
 
-        importance_feature_orders: list[np.ndarray] | None = None
+        importance_feature_order: np.ndarray | None = None
         needs_subsampling = any(
             s < n_total_features for s in max_features_per_estimator
         )
@@ -207,11 +207,10 @@ class TabPFNEnsemblePreprocessor:
             cat_indices = (
                 self.feature_schema.indices_for(FeatureModality.CATEGORICAL) or None
             )
-            importance_feature_orders = _compute_feature_importance_order(
+            importance_feature_order = _compute_feature_importance_order(
                 X=X_train,
                 y=y_train,
                 task_type=task_type,
-                n_estimators=len(self.configs),
                 categorical_feature_indices=cat_indices,
                 rng=rng_features,
             )
@@ -224,7 +223,7 @@ class TabPFNEnsemblePreprocessor:
             rng=rng_features,
             feature_subsampling_method=feature_subsampling_method,
             constant_feature_count=constant_feature_count,
-            importance_feature_orders=importance_feature_orders,
+            importance_feature_order=importance_feature_order,
             importance_top_k_count=resolved_top_k,
         )
 
@@ -642,7 +641,7 @@ def _get_subsample_feature_indices(
     rng: np.random.Generator,
     feature_subsampling_method: FeatureSubsamplingMethod,
     constant_feature_count: int = 50,
-    importance_feature_orders: list[np.ndarray] | None = None,
+    importance_feature_order: np.ndarray | None = None,
     importance_top_k_count: int = 150,
 ) -> list[np.ndarray | None]:
     """Get the indices of the features to subsample for each estimator.
@@ -658,8 +657,8 @@ def _get_subsample_feature_indices(
             "balanced", "random", or "constant_and_balanced".
         constant_feature_count: Number of leading features to always include
             when using the "constant_and_balanced" method.
-        importance_feature_orders: Unique feature orderings sorted most->least
-            important, cycled across estimators. Produced by
+        importance_feature_order: Feature indices sorted most->least important,
+            shared by every estimator. Produced by
             ``_compute_feature_importance_order``.
         importance_top_k_count: Number of top features always included per estimator.
             Only used when feature_subsampling_method is "feature_importance".
@@ -714,14 +713,14 @@ def _get_subsample_feature_indices(
             subsample_sizes, n_total_features, rng, constant_feature_count
         )
     if feature_subsampling_method == FeatureSubsamplingMethod.GINI_FEATURE_IMPORTANCE:
-        if importance_feature_orders is None:
+        if importance_feature_order is None:
             # top_k covers all features — importance ordering is irrelevant, fall back
             # to balanced subsampling for variety across estimators.
             return _subsample_features_balanced(subsample_sizes, n_total_features, rng)
         return _subsample_features_importance_based(
             subsample_sizes,
             n_total_features,
-            importance_feature_orders,
+            importance_feature_order,
             importance_top_k_count,
             rng,
         )
@@ -867,37 +866,31 @@ def _subsample_features_constant_and_balanced(
 def _subsample_features_importance_based(
     subsample_sizes: list[int],
     n_total_features: int,
-    importance_feature_orders: list[np.ndarray],
+    importance_feature_order: np.ndarray,
     top_k_count: int,
     rng: np.random.Generator,
 ) -> list[np.ndarray | None]:
-    """Always include top-K important features; randomly sample the rest.
+    """Always include top-K important features; fill the rest from a balanced pool.
 
-    Each estimator uses its own importance ordering from ``importance_feature_orders``,
-    cycling through the list when there are more estimators than orderings.
+    Every estimator shares one importance ordering, so the non-top features are
+    dealt round-robin from a single pool: each is drawn once before any is drawn
+    twice, and the ensemble covers all of them whenever the combined budget allows.
 
     Args:
         subsample_sizes: Number of input features to select per estimator.
         n_total_features: Total number of features in the dataset.
-        importance_feature_orders: Unique feature orderings sorted most->least
-            important, cycled across estimators. Produced by
-            ``_compute_feature_importance_order``.
+        importance_feature_order: Feature indices sorted most->least important.
+            Produced by ``_compute_feature_importance_order``.
         top_k_count: Number of top features always included per estimator.
         rng: Random number generator.
     """
     n_top = min(top_k_count, n_total_features)
-
-    n_orderings = len(importance_feature_orders)
-    # One balanced pool per unique ordering so estimators sharing the same ordering
-    # cover its remaining features evenly across the ensemble.
-    pools: dict[int, list[int]] = {i: [] for i in range(n_orderings)}
+    top_features = importance_feature_order[:n_top]
+    remaining_features = importance_feature_order[n_top:]
+    pool: list[int] = []
 
     result: list[np.ndarray | None] = []
-    for i, size in enumerate(subsample_sizes):
-        ordering_idx = i % n_orderings
-        importance_feature_order = importance_feature_orders[ordering_idx]
-        top_features = importance_feature_order[:n_top]
-        remaining_features = importance_feature_order[n_top:]
+    for size in subsample_sizes:
         if size >= n_total_features:
             result.append(None)
             continue
@@ -906,9 +899,8 @@ def _subsample_features_importance_based(
             result.append(np.sort(top_features[:size]))
             continue
         # Always include all top features, fill remaining budget via balanced pool.
-        remaining_budget = size - n_top
-        slots, pools[ordering_idx] = _draw_balanced_from_pool(
-            pools[ordering_idx], remaining_budget, len(remaining_features), rng
+        slots, pool = _draw_balanced_from_pool(
+            pool, size - n_top, len(remaining_features), rng
         )
         sampled = remaining_features[np.array(slots)]
         result.append(np.sort(np.concatenate([top_features, sampled])))
@@ -927,45 +919,38 @@ def _get_lightgbm_model_cls(task_type: Literal["classifier", "regressor"]) -> ty
     )
 
 
-def _collect_importance_orderings(
+def _fit_importance_ordering(
     X: np.ndarray,
     y: np.ndarray,
     task_type: Literal["classifier", "regressor"],
-    n_estimators: int,
     max_samples: int,
     fit_ordering_fn: Callable[[np.ndarray, np.ndarray], np.ndarray],
     rng: np.random.Generator,
-) -> list[np.ndarray]:
-    """Run ``fit_ordering_fn`` once per unique subsample and return the orderings.
+) -> np.ndarray:
+    """Fit one feature-importance ordering, subsampling rows to ``max_samples``.
 
-    Datasets within ``max_samples`` yield a single ordering; larger datasets
-    yield up to ``n_estimators`` orderings fit on independent subsamples.
-    Consumers cycle through the list, so estimators sharing an entry share one
-    subsampling pool.
+    ``max_samples`` is a compute budget for the importance model, so larger
+    datasets are subsampled to it (stratified for classification) before fitting.
+    The single ordering is shared by every estimator, which is what lets
+    ``_subsample_features_importance_based`` deal their non-top features from one
+    pool and so cover every feature across the ensemble.
     """
     n_samples = len(X)
 
-    if n_samples <= max_samples:
-        # The importance model bins each feature from the values it is handed,
-        # but `clean_data` no longer casts: not a no-op
-        return [fit_ordering_fn(np.asarray(X, dtype=np.float64), y)]
+    if n_samples > max_samples:
+        from sklearn.model_selection import train_test_split  # noqa: PLC0415
 
-    from sklearn.model_selection import train_test_split  # noqa: PLC0415
-
-    n_subsamples = min(n_estimators, n_samples // max_samples + 1)
-    stratify = y if task_type == "classifier" else None
-    orderings = []
-    for _ in range(n_subsamples):
         idx, _ = train_test_split(
             np.arange(n_samples),
             train_size=max_samples,
-            stratify=stratify,
+            stratify=y if task_type == "classifier" else None,
             random_state=int(rng.integers(0, np.iinfo(np.int32).max)),
         )
-        # The importance model bins each feature from the values it is handed,
-        # but `clean_data` no longer casts: not a no-op
-        orderings.append(fit_ordering_fn(np.asarray(X[idx], dtype=np.float64), y[idx]))
-    return orderings
+        X, y = X[idx], y[idx]
+
+    # The importance model bins each feature from the values it is handed,
+    # but `clean_data` no longer casts: not a no-op
+    return fit_ordering_fn(np.asarray(X, dtype=np.float64), y)
 
 
 def _compute_feature_importance_order(
@@ -973,29 +958,26 @@ def _compute_feature_importance_order(
     y: np.ndarray,
     task_type: Literal["classifier", "regressor"],
     *,
-    n_estimators: int,
     max_samples: int = FEATURE_IMPORTANCE_MAX_SAMPLES,
     n_tree_estimators: int = 50,
     categorical_feature_indices: list[int] | None = None,
     rng: np.random.Generator,
-) -> list[np.ndarray]:
+) -> np.ndarray:
     """Rank features by LightGBM gain importance.
 
     Args:
         X: Training features, shape (n_samples, n_features).
         y: Training targets, shape (n_samples,).
         task_type: ``"classifier"`` or ``"regressor"`` (matches TabPFN estimator_type).
-        n_estimators: Upper bound on the number of orderings computed.
-        max_samples: Row budget per importance model fit.
+        max_samples: Row budget for the importance model fit.
         n_tree_estimators: Number of trees in LightGBM models.
         categorical_feature_indices: Column indices of categorical features
             passed natively to LightGBM.
         rng: Random number generator.
 
     Returns:
-        The unique orderings, each an array of feature indices sorted from most
-        to least important. Estimators are assigned orderings by cycling
-        through the list.
+        Array of feature indices sorted from most to least important, shared by
+        every estimator.
     """
     model_cls = _get_lightgbm_model_cls(task_type)
     cat_feature: list[int] | str = categorical_feature_indices or "auto"
@@ -1012,9 +994,7 @@ def _compute_feature_importance_order(
         model.fit(X_fit, y_fit, categorical_feature=cat_feature)
         return np.argsort(model.feature_importances_)[::-1].copy()
 
-    return _collect_importance_orderings(
-        X, y, task_type, n_estimators, max_samples, _fit_ordering, rng
-    )
+    return _fit_importance_ordering(X, y, task_type, max_samples, _fit_ordering, rng)
 
 
 def generate_classification_ensemble_configs(  # noqa: PLR0913

--- a/src/tabpfn/preprocessing/ensemble.py
+++ b/src/tabpfn/preprocessing/ensemble.py
@@ -872,9 +872,8 @@ def _subsample_features_importance_based(
 ) -> list[np.ndarray | None]:
     """Always include top-K important features; fill the rest from a balanced pool.
 
-    Every estimator shares one importance ordering, so the non-top features are
-    dealt round-robin from a single pool: each is drawn once before any is drawn
-    twice, and the ensemble covers all of them whenever the combined budget allows.
+    All estimators share one ordering, so the non-top features are dealt from a
+    single pool: each is drawn once before any is drawn twice.
 
     Args:
         subsample_sizes: Number of input features to select per estimator.
@@ -927,13 +926,9 @@ def _fit_importance_ordering(
     fit_ordering_fn: Callable[[np.ndarray, np.ndarray], np.ndarray],
     rng: np.random.Generator,
 ) -> np.ndarray:
-    """Fit one feature-importance ordering, subsampling rows to ``max_samples``.
+    """Fit one feature-importance ordering, on at most ``max_samples`` rows.
 
-    ``max_samples`` is a compute budget for the importance model, so larger
-    datasets are subsampled to it (stratified for classification) before fitting.
-    The single ordering is shared by every estimator, which is what lets
-    ``_subsample_features_importance_based`` deal their non-top features from one
-    pool and so cover every feature across the ensemble.
+    The subsample is stratified for classification.
     """
     n_samples = len(X)
 

--- a/tests/test_preprocessing/test_ensemble.py
+++ b/tests/test_preprocessing/test_ensemble.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sys
 import warnings
+from collections.abc import Callable
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -23,9 +24,9 @@ from tabpfn.preprocessing.datamodel import Feature, FeatureModality
 from tabpfn.preprocessing.ensemble import (
     DEFAULT_N_ESTIMATORS,
     TabPFNEnsemblePreprocessor,
-    _collect_importance_orderings,
     _compute_feature_importance_order,
     _draw_balanced_from_pool,
+    _fit_importance_ordering,
     _get_subsample_feature_indices,
     _get_subsample_indices_for_estimators,
     _resolve_feature_subsampling_method,
@@ -719,7 +720,7 @@ def test__subsample_features_importance_based__top_k_always_present():
     result = _subsample_features_importance_based(
         subsample_sizes=subsample_sizes,
         n_total_features=n_features,
-        importance_feature_orders=[importance_order],
+        importance_feature_order=importance_order,
         top_k_count=top_k,
         rng=rng,
     )
@@ -740,7 +741,7 @@ def test__subsample_features_importance_based__no_subsampling_when_budget_ge_tot
     result = _subsample_features_importance_based(
         subsample_sizes=[10, 10],
         n_total_features=n_features,
-        importance_feature_orders=[importance_order],
+        importance_feature_order=importance_order,
         top_k_count=5,
         rng=rng,
     )
@@ -755,7 +756,7 @@ def test__subsample_features_importance_based__budget_less_than_top_k():
     result = _subsample_features_importance_based(
         subsample_sizes=[3],
         n_total_features=n_features,
-        importance_feature_orders=[importance_order],
+        importance_feature_order=importance_order,
         top_k_count=10,
         rng=rng,
     )
@@ -773,7 +774,7 @@ def test__subsample_features_importance_based__budget_equal_to_top_k():
     result = _subsample_features_importance_based(
         subsample_sizes=[top_k],
         n_total_features=n_features,
-        importance_feature_orders=[importance_order],
+        importance_feature_order=importance_order,
         top_k_count=top_k,
         rng=rng,
     )
@@ -800,7 +801,7 @@ def test__subsample_features_importance_based__remaining_budget_balanced_across_
     result = _subsample_features_importance_based(
         subsample_sizes=[budget] * n_estimators,
         n_total_features=n_features,
-        importance_feature_orders=[importance_order],
+        importance_feature_order=importance_order,
         top_k_count=top_k,
         rng=rng,
     )
@@ -824,46 +825,6 @@ def test__subsample_features_importance_based__remaining_budget_balanced_across_
     )
 
 
-def test__subsample_features_importance_based__two_orderings_have_independent_pools():
-    """Estimators with different orderings draw from separate balanced pools."""
-    rng = np.random.default_rng(1)
-    n_features = 20
-    top_k = 4
-    budget = 10
-    n_estimators = 30  # 15 per ordering
-
-    # Two non-overlapping orderings
-    order_a = np.arange(n_features)  # top: 0-3, remaining: 4-19
-    order_b = np.arange(n_features)[::-1].copy()  # top: 19-16, remaining: 15-0
-
-    result = _subsample_features_importance_based(
-        subsample_sizes=[budget] * n_estimators,
-        n_total_features=n_features,
-        importance_feature_orders=[order_a, order_b],
-        top_k_count=top_k,
-        rng=rng,
-    )
-
-    counts_a = dict.fromkeys(range(top_k, n_features), 0)  # remaining for order_a
-    counts_b = dict.fromkeys(range(n_features - top_k), 0)  # remaining for order_b
-
-    for i, indices in enumerate(result):
-        assert indices is not None
-        assert len(indices) == budget
-        if i % 2 == 0:  # uses order_a
-            for idx in indices:
-                if idx in counts_a:
-                    counts_a[idx] += 1
-        else:  # uses order_b
-            for idx in indices:
-                if idx in counts_b:
-                    counts_b[idx] += 1
-
-    # Each pool should have covered all its remaining features
-    assert all(c > 0 for c in counts_a.values())
-    assert all(c > 0 for c in counts_b.values())
-
-
 def test__get_subsample_feature_indices__feature_importance_method():
     """GINI_FEATURE_IMPORTANCE method routes correctly and includes top-K."""
     pipeline = MagicMock()
@@ -882,7 +843,7 @@ def test__get_subsample_feature_indices__feature_importance_method():
         max_features_per_estimator=[20, 20, 20],
         rng=rng,
         feature_subsampling_method=FeatureSubsamplingMethod.GINI_FEATURE_IMPORTANCE,
-        importance_feature_orders=[importance_order],
+        importance_feature_order=importance_order,
         importance_top_k_count=top_k,
     )
 
@@ -907,7 +868,7 @@ def test__get_subsample_feature_indices__feature_importance_none_order_falls_bac
         max_features_per_estimator=[20, 20, 20],
         rng=np.random.default_rng(0),
         feature_subsampling_method=FeatureSubsamplingMethod.GINI_FEATURE_IMPORTANCE,
-        importance_feature_orders=None,
+        importance_feature_order=None,
     )
     # Should return valid index arrays (balanced fallback), not raise
     assert len(result) == 3
@@ -1137,15 +1098,11 @@ def test___compute_feature_importance_order__classification():
     # Make feature 0 highly predictive
     y = (X[:, 0] > 0).astype(int)
 
-    orders = _compute_feature_importance_order(
-        X=X, y=y, task_type="classifier", n_estimators=4, rng=rng
-    )
+    order = _compute_feature_importance_order(X=X, y=y, task_type="classifier", rng=rng)
 
-    assert len(orders) == 1
-    for order in orders:
-        assert order.shape == (n_features,)
-        assert set(order) == set(range(n_features)), "All feature indices must appear"
-    assert orders[0][0] == 0
+    assert order.shape == (n_features,)
+    assert set(order) == set(range(n_features)), "All feature indices must appear"
+    assert order[0] == 0
 
 
 @skip_on_macos
@@ -1156,15 +1113,11 @@ def test___compute_feature_importance_order__regression():
     X = rng.standard_normal((n_samples, n_features))
     y = X[:, 2] * 3.0 + rng.standard_normal(n_samples) * 0.1
 
-    orders = _compute_feature_importance_order(
-        X=X, y=y, task_type="regressor", n_estimators=4, rng=rng
-    )
+    order = _compute_feature_importance_order(X=X, y=y, task_type="regressor", rng=rng)
 
-    assert len(orders) == 1
-    for order in orders:
-        assert order.shape == (n_features,)
-        assert set(order) == set(range(n_features))
-    assert orders[0][0] == 2
+    assert order.shape == (n_features,)
+    assert set(order) == set(range(n_features))
+    assert order[0] == 2
 
 
 @skip_on_macos
@@ -1175,52 +1128,81 @@ def test___compute_feature_importance_order__subsamples_large_datasets():
     X = rng.standard_normal((n_samples, n_features))
     y = rng.integers(0, 2, n_samples)
 
-    orders = _compute_feature_importance_order(
+    order = _compute_feature_importance_order(
         X=X,
         y=y,
         task_type="classifier",
-        n_estimators=8,
         max_samples=50,
         rng=rng,
     )
-    # min(n_estimators, n_samples // max_samples + 1) unique orderings
-    assert len(orders) == 5
-    for order in orders:
-        assert order.shape == (n_features,)
-        assert set(order) == set(range(n_features))
+    assert order.shape == (n_features,)
+    assert set(order) == set(range(n_features))
 
 
-def test___collect_importance_orderings__small_data_returns_single_ordering():
-    orders = _collect_importance_orderings(
+def _spy_fit_ordering(
+    rows_seen: list[int],
+) -> Callable[[np.ndarray, np.ndarray], np.ndarray]:
+    """fit_ordering_fn that records how many rows each fit was given."""
+
+    def fit(X_fit: np.ndarray, _y: np.ndarray) -> np.ndarray:
+        rows_seen.append(len(X_fit))
+        return np.arange(X_fit.shape[1])
+
+    return fit
+
+
+def test___fit_importance_ordering__small_data_uses_every_row():
+    rows_seen: list[int] = []
+    order = _fit_importance_ordering(
         X=np.zeros((100, 6)),
         y=np.zeros(100),
         task_type="regressor",
-        n_estimators=4,
         max_samples=200,
-        fit_ordering_fn=lambda _X, _y: np.arange(6),
+        fit_ordering_fn=_spy_fit_ordering(rows_seen),
         rng=np.random.default_rng(0),
     )
 
-    assert len(orders) == 1
+    assert rows_seen == [100]
+    assert order.shape == (6,)
 
 
-def test__subsample_features_importance_based__collected_orderings_cover_all_features():
-    """Estimators sharing a collected ordering draw from one shared pool."""
+def test___fit_importance_ordering__large_data_fits_once_on_max_samples():
+    """Above max_samples the rows are subsampled, but only one fit is run."""
+    rows_seen: list[int] = []
+    order = _fit_importance_ordering(
+        X=np.zeros((500, 6)),
+        y=np.zeros(500),
+        task_type="regressor",
+        max_samples=100,
+        fit_ordering_fn=_spy_fit_ordering(rows_seen),
+        rng=np.random.default_rng(0),
+    )
+
+    assert rows_seen == [100]
+    assert order.shape == (6,)
+
+
+@pytest.mark.parametrize("n_samples", [50, 500])
+def test__subsample_features_importance_based__covers_all_features(n_samples):
+    """Every feature reaches some estimator, on both sides of ``max_samples``.
+
+    Above ``max_samples`` this used to fit one ordering per estimator, giving each
+    a private pool and degenerating to independent uniform draws.
+    """
     n_features, top_k, size, n_estimators = 12, 4, 8, 2
 
     for seed in range(20):
         rng = np.random.default_rng(seed)
-        orders = _collect_importance_orderings(
-            X=np.zeros((50, n_features)),
-            y=np.zeros(50),
+        order = _fit_importance_ordering(
+            X=np.zeros((n_samples, n_features)),
+            y=np.zeros(n_samples),
             task_type="regressor",
-            n_estimators=n_estimators,
             max_samples=100,
             fit_ordering_fn=lambda _X, _y: np.arange(n_features),
             rng=rng,
         )
         subsampled = _subsample_features_importance_based(
-            [size] * n_estimators, n_features, orders, top_k, rng
+            [size] * n_estimators, n_features, order, top_k, rng
         )
 
         # Combined budget covers all features: 2 * (8 - 4) top-up draws == the
@@ -1383,78 +1365,6 @@ def test__end_to_end__feature_importance_subsampling():
     for member in members:
         assert member.feature_indices is not None
         assert len(member.feature_indices) <= max_features
-
-
-def test__subsample_features_importance_based__different_orderings_yield_different_indices():  # noqa: E501
-    """When multiple distinct orderings are given, different estimators get different top-K."""  # noqa: E501
-    rng = np.random.default_rng(0)
-    n_features = 20
-    top_k = 5
-    budget = 10
-
-    # Two opposite orderings: first says features 0-4 are top, second says 15-19 are top
-    order_a = np.arange(n_features)  # top features: 0,1,2,3,4
-    order_b = np.arange(n_features)[::-1].copy()  # top features: 19,18,17,16,15
-
-    result = _subsample_features_importance_based(
-        subsample_sizes=[budget, budget],
-        n_total_features=n_features,
-        importance_feature_orders=[order_a, order_b],
-        top_k_count=top_k,
-        rng=rng,
-    )
-
-    assert result[0] is not None
-    assert result[1] is not None
-    top_k_a = set(order_a[:top_k])  # {0,1,2,3,4}
-    top_k_b = set(order_b[:top_k])  # {15,16,17,18,19}
-    # Estimator 0 must include all of order_a's top-K
-    assert top_k_a.issubset(set(result[0]))
-    # Estimator 1 must include all of order_b's top-K
-    assert top_k_b.issubset(set(result[1]))
-    # The two selections must differ (no overlap in guaranteed-included features)
-    assert top_k_a.isdisjoint(top_k_b), (
-        "Top-K sets must be disjoint for opposite orderings"
-    )
-    assert set(result[0]) != set(result[1]), (
-        "Estimators should have different feature sets"
-    )
-
-
-@skip_on_macos
-def test___compute_feature_importance_order__gini_large_dataset_yields_diverse_orderings():  # noqa: E501
-    """With data > max_samples, independent subsamples produce diverse orderings."""
-    rng = np.random.default_rng(42)
-    small_max_samples = 500
-    n_samples = (
-        small_max_samples * 6
-    )  # clearly larger → multiple independent subsamples
-    n_features = 10
-    # Pure noise so each subsample fit produces a different ranking
-    X = rng.standard_normal((n_samples, n_features))
-    y = rng.integers(0, 2, n_samples)
-
-    n_estimators = 6
-    orders = _compute_feature_importance_order(
-        X=X,
-        y=y,
-        task_type="classifier",
-        n_estimators=n_estimators,
-        max_samples=small_max_samples,
-        rng=rng,
-    )
-
-    assert len(orders) == n_estimators
-    for order in orders:
-        assert order.shape == (n_features,)
-        assert set(order) == set(range(n_features))
-
-    # With multiple independent subsamples on noisy data, not all orderings should
-    # be identical
-    unique_first_features = {order[0] for order in orders}
-    assert len(unique_first_features) > 1, (
-        "Independent subsamples on noise should produce diverse feature rankings"
-    )
 
 
 @skip_on_macos

--- a/tests/test_preprocessing/test_ensemble.py
+++ b/tests/test_preprocessing/test_ensemble.py
@@ -1375,30 +1375,25 @@ def test___compute_feature_importance_order__lightgbm():
     X = rng.standard_normal((n_samples, n_features))
     y = (X[:, 5] > 0).astype(int)
 
-    orderings = _compute_feature_importance_order(
+    order = _compute_feature_importance_order(
         X=X,
         y=y,
         task_type="classifier",
-        n_estimators=3,
         rng=rng,
     )
 
-    assert len(orderings) == 1
-    for order in orderings:
-        assert len(order) == n_features
-        assert order[0] == 5
+    assert len(order) == n_features
+    assert order[0] == 5
 
     # With categorical indices — no crash.
-    orderings_cat = _compute_feature_importance_order(
+    order_cat = _compute_feature_importance_order(
         X=np.abs(X),  # non-negative for LightGBM categorical handling
         y=y,
         task_type="classifier",
-        n_estimators=2,
         categorical_feature_indices=[0, 1],
         rng=rng,
     )
-    assert len(orderings_cat) == 1
-    assert len(orderings_cat[0]) == n_features
+    assert len(order_cat) == n_features
 
 
 @skip_on_macos
@@ -1413,18 +1408,15 @@ def test___compute_feature_importance_order__handles_nan():
     nan_mask = rng.random((n_samples, n_features)) < 0.1
     X[nan_mask] = np.nan
 
-    orderings = _compute_feature_importance_order(
+    order = _compute_feature_importance_order(
         X=X,
         y=y,
         task_type="classifier",
-        n_estimators=2,
         rng=rng,
     )
 
-    assert len(orderings) == 1
-    for order in orderings:
-        assert len(order) > 0
-        assert not np.isnan(order).any()
+    assert len(order) > 0
+    assert not np.isnan(order).any()
 
 
 def test__generate_regression_ensemble_configs__target_transforms_not_shared():

--- a/tests/test_preprocessing/test_ensemble.py
+++ b/tests/test_preprocessing/test_ensemble.py
@@ -1184,11 +1184,7 @@ def test___fit_importance_ordering__large_data_fits_once_on_max_samples():
 
 @pytest.mark.parametrize("n_samples", [50, 500])
 def test__subsample_features_importance_based__covers_all_features(n_samples):
-    """Every feature reaches some estimator, on both sides of ``max_samples``.
-
-    Above ``max_samples`` this used to fit one ordering per estimator, giving each
-    a private pool and degenerating to independent uniform draws.
-    """
+    """Every feature reaches some estimator, on both sides of ``max_samples``."""
     n_features, top_k, size, n_estimators = 12, 4, 8, 2
 
     for seed in range(20):


### PR DESCRIPTION
Before this PR, above 100K rows we compute feature importance on a different subset of 100K rows for each estimators. This adds diversity but:
- makes the machinery to have topK features + balanced repartitions of other features more complex, as the top k features are different for each estimator
- can we quite costly. See in the claude summary below, but for 2K features for instance, 8 estimators --> 8 orderings --> 8 x 7s on a good cpu.

So IMO we should just use one shared feature importance, computed once on a 100K subset.

I don't have a strong opinion on the exact number of rows to use for subsampling, would also be fine with e.g 200K (it's sublinear, seems to be rougly 50% more expensive than 100K).

Also tell me if you think this needs more evaluation.


## Claude summary

Stacked on #1141.

## Evaluation

Evaluated internally across the affected large/wide datasets, A/B against `main` with the same checkpoint, seed and splits. Headline: **accuracy unchanged within noise, fit time down 26-37%** on the datasets measured so far. Numbers and method in [RES-2773](https://linear.app/priorlabs/issue/RES-2773).

## Summary

#1141 restores the shared balanced pool for importance-based feature subsampling, but only below `FEATURE_IMPORTANCE_MAX_SAMPLES` (100k rows). Above it, `_collect_importance_orderings` fits one LightGBM model per independent 100k subsample, so estimators get *different* orderings. Since the consumer keys its pools by ordering, that splits the ensemble into `n_orderings` non-cooperating groups — and once `n_samples >= n_estimators * max_samples` every estimator has a private pool again, exactly the pre-#913 behaviour.

That regime is the one that ships: `auto` selects `gini_feature_importance` only when `n_samples > AUTO_FEATURE_SUBSAMPLING_IMPORTANCE_MIN_SAMPLES` (100_000), and `_collect_importance_orderings` takes its single-ordering branch only when `n_samples <= max_samples` (100_000). The two conditions are exactly complementary, so **under `auto` the single-ordering path is unreachable**.

Measured, 28 features / top-4 / budget 8 / 6 estimators, sized so one shared pool covers the tail exactly (mean features never seen by any estimator, 50 seeds):

| dataset | orderings | main | #1141 | this PR |
|---|---|---|---|---|
| 50k | 1 | 7.74 | 0.00 | 0.00 |
| 150k | 2 | 6.76 | 5.22 | 0.00 |
| 300k | 4 | 4.86 | 4.46 | 0.00 |
| 600k | 6 | 3.74 | 3.74 | 0.00 |

## Change

Fit one ordering, subsampling rows to `max_samples` when the dataset is larger. `_subsample_features_importance_based` collapses to a single shared pool, which makes it structurally identical to `_subsample_features_balanced` and `_subsample_features_constant_and_balanced`. Net -16 lines in `ensemble.py`.

Also drops up to `n_estimators - 1` LightGBM fits.

## Cost

`_collect_importance_orderings` ran `min(n_estimators, n_samples // max_samples + 1)` LightGBM fits; this PR runs one. Each fit is on `max_samples` (100k) rows, so the saving is `(k - 1)` fits of:

| features | one ordering @ 100k rows |
|---|---|
| 100 | 0.65s |
| 200 | 0.96s |
| 500 | 1.98s |
| 1000 | 3.64s |
| 2000 | 7.01s |

So ~2s saved per dropped ordering at 500 features, up to ~7s at 2000. With `n_estimators` capped at 32 by `MAX_AUTO_SCALED_N_ESTIMATORS`, the worst case removed is ~31 x 7s. The stratified `train_test_split` in front of each fit is negligible (0.02s at 200k rows, 0.10s at 1M).

Measured on 18 cores, synthetic Gaussian features, `n_estimators=50` trees, `n_jobs=-1`; real data with native categoricals will move the constants but not the shape.

## Why not keep the distinct orderings

The multi-ordering design (#908) predates the pool (#913, one day later): #908 filled the non-top budget with `rng.choice(...)`, so distinct orderings cost nothing. #913 added the coverage guarantee without reconciling the two, scoping its comment to estimators *sharing* an ordering. Coverage and per-subsample diversity want opposite things, and every extra ordering subtracts proportionally from coverage.

Keeping both is possible — put the pool in global feature-index space so it is ordering-agnostic — but it is more machinery, and it needs `scale_n_estimators_for_feature_coverage` to provision `n_total_features` draws rather than `n_total_features - top_k`. Happy to go that way instead if the diversity is worth it; there are no benchmarks on record either way.

## Follow-ups (not in this PR)

- **The 100k cap looks far too low.** LightGBM is sublinear in rows, so `FEATURE_IMPORTANCE_MAX_SAMPLES` is buying much less than it costs in ranking quality (time / LightGBM peak memory on top of X):

  | rows | 200 features | 500 features |
  |---|---|---|
  | 100k | 0.94s / 368 MB | 1.98s / 898 MB |
  | 200k | 1.64s / 701 MB | 3.41s / 1438 MB |
  | 500k | 2.39s / 739 MB | 5.50s / 1688 MB |
  | 1M | 3.70s / 1043 MB | 9.17s / 2113 MB |
  | 2M | 6.45s / 1474 MB | 16.86s / 2913 MB |

  20x the rows costs ~7-8x the time and ~4x the memory. At 500 features a single fit on all 1M rows (9.2s) is cheaper than the 8 x 100k fits this PR removes (~15.8s) while using 10x the data, and ranking fidelity to a full-data fit rises from 85.7% at 100k to 97.8% at 1M on synthetic data. Cost tracks rows x features (~3 bytes/cell at scale), so a cell budget would be better calibrated than a row count.
- `scale_n_estimators_for_feature_coverage` computes `ceil(n_features / max_features)`, ignoring that top-K is pre-committed in every estimator; the tail needs `ceil((n_features - k) / (size - k))`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017V5aMgmDFAJxP5ymimD3vG




