### PR TITLE
Widen the skrub requirement to >=0.7,<0.11

### DIFF
--- a/changelog/1231.changed.md
+++ b/changelog/1231.changed.md
@@ -1,0 +1,1 @@
+Widen the `skrub` dependency from the 0.10 series to 0.7 or newer.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
   "filelock>=3.11.0",
   "lightgbm>=4.4",
   # Capped: skrub is pre-1.0 and its minor releases change transformer behavior.
-  "skrub>=0.10,<0.11",
+  "skrub>=0.7,<0.11",
   # For plotting utils; skrub already pulls it in transitively anyway.
   "matplotlib>=3.6.1",
   "mlx>=0.29.3; sys_platform == 'darwin' and platform_machine == 'arm64'",


### PR DESCRIPTION
`skrub` is currently required at `>=0.10,<0.11`. That is stricter than the code needs, and it forces a resolution conflict for anyone installing TabPFN alongside a package that depends on an older `skrub`.

## Motivation and Context

TabPFN uses exactly two `skrub` transformers, `DatetimeEncoder` and `StringEncoder`, and both are unchanged over `0.7.0` to `0.10.1`:

-   **Signatures are identical.** Every argument TabPFN passes exists in `0.7.0` with the same default. `StringEncoder` gained one optional argument in `0.7.2`, `vocabulary`, whose default reproduces the earlier behavior.
-   **Output is identical.** Comparing `0.7.2` against `0.10.1` on the same `pandas`, `numpy` and `scikit-learn` versions gives the same column names and the same values: for datetimes carrying a time component, for midnight-only dates, and for `StringEncoder` under both `fit_transform` and a subsequent `transform`.

The `<0.11` cap stays, as `skrub` is pre-1.0.

Resolution was checked against both dependency sets in `ci.yml`, and both import cleanly:

| `--resolution` | `skrub` | `joblib` |
| --- | --- | --- |
| `highest` | 0.10.1 | 1.6.0 |
| `lowest-direct` | 0.7.0 | 1.2.0 |

One combination inside the widened range does not import: `skrub<=0.10.0` imports `joblib.externals.cloudpickle`, which `joblib` 1.6.0 removed, and `skrub` declares no `joblib` bound of its own until `0.10.1`. Neither CI dependency set produces that pair, and a default install resolves `skrub` to `0.10.1`, so no `joblib` bound is added here. An environment that holds `skrub` below `0.10.1` while allowing `joblib` 1.6 needs its own `joblib<1.6`.

---

## Public API Changes

-   [x] No Public API changes
-   [ ] Yes, Public API changes (Details below)

---

## Checklist

-   [x] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [x] A changelog entry has been added (see `changelog/README.md`), or "no changelog needed" label requested.
-   [x] The code follows the project's style guidelines.
-   [x] I have considered the impact of these changes on the public API.
