### PR TITLE
Reject eval_metric='log_loss' with tune_decision_thresholds=True

### DIFF
--- a/changelog/1239.breaking.md
+++ b/changelog/1239.breaking.md
@@ -1,0 +1,1 @@
+`eval_metric="log_loss"` combined with `tune_decision_thresholds=True` now raises instead of silently optimizing accuracy. The threshold search scores hard labels, and log loss over clipped hard labels is a constant multiple of the error rate. Use `calibrate_temperature=True`, which optimizes log loss directly.

--- a/src/tabpfn/classifier.py
+++ b/src/tabpfn/classifier.py
@@ -1348,6 +1348,18 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
                 UserWarning,
                 stacklevel=2,
             )
+        elif (
+            self.eval_metric_ is ClassifierEvalMetrics.LOG_LOSS
+            and tuning_config_resolved.tune_decision_thresholds
+        ):
+            raise ValueError(
+                "eval_metric='log_loss' does not support "
+                "tune_decision_thresholds=True: the threshold search scores hard "
+                "labels, under which log loss reduces to a multiple of the error "
+                "rate, so it tunes for accuracy instead. Pass "
+                "calibrate_temperature=True, which optimizes log loss directly, "
+                "or tune_decision_thresholds=False."
+            )
 
         holdout_raw_logits, holdout_y_true = self._compute_holdout_validation_data(
             X=X,

--- a/src/tabpfn/classifier.py
+++ b/src/tabpfn/classifier.py
@@ -1354,11 +1354,9 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
         ):
             raise ValueError(
                 "eval_metric='log_loss' does not support "
-                "tune_decision_thresholds=True: the threshold search scores hard "
-                "labels, under which log loss reduces to a multiple of the error "
-                "rate, so it tunes for accuracy instead. Pass "
-                "calibrate_temperature=True, which optimizes log loss directly, "
-                "or tune_decision_thresholds=False."
+                "tune_decision_thresholds=True. Pass calibrate_temperature=True, "
+                "which optimizes log loss directly, or "
+                "tune_decision_thresholds=False."
             )
 
         holdout_raw_logits, holdout_y_true = self._compute_holdout_validation_data(

--- a/tests/test_classifier_interface.py
+++ b/tests/test_classifier_interface.py
@@ -1292,6 +1292,65 @@ def test__fit_with_roc_auc_metric_with_threshold_tuning__raises() -> None:
         clf.fit(X, y)
 
 
+def test__fit_with_log_loss_metric_with_threshold_tuning__raises() -> None:
+    """log_loss with tune_decision_thresholds=True is rejected."""
+    n_classes = 2
+    X, y = sklearn.datasets.make_classification(
+        n_samples=30 * n_classes,
+        n_classes=n_classes,
+        n_features=2,
+        n_informative=2,
+        n_redundant=0,
+        random_state=0,
+    )
+
+    clf = TabPFNClassifier(
+        eval_metric="log_loss",
+        tuning_config={
+            "tune_decision_thresholds": True,
+            "calibrate_temperature": False,
+            "tuning_holdout_frac": 0.1,
+            "tuning_n_folds": 1,
+        },
+        n_estimators=1,
+        random_state=0,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r".*log_loss.*does not support tune_decision_thresholds=True.*",
+    ):
+        clf.fit(X, y)
+
+
+def test__fit_with_log_loss_metric_with_temperature_calibration__is_allowed() -> None:
+    """Temperature calibration is the supported way to target log loss."""
+    n_classes = 2
+    X, y = sklearn.datasets.make_classification(
+        n_samples=30 * n_classes,
+        n_classes=n_classes,
+        n_features=2,
+        n_informative=2,
+        n_redundant=0,
+        random_state=0,
+    )
+
+    clf = TabPFNClassifier(
+        eval_metric="log_loss",
+        tuning_config={
+            "tune_decision_thresholds": False,
+            "calibrate_temperature": True,
+            "tuning_holdout_frac": 0.1,
+            "tuning_n_folds": 1,
+        },
+        n_estimators=1,
+        random_state=0,
+    )
+
+    clf.fit(X, y)
+    assert clf.predict_proba(X[:3]).shape == (3, n_classes)
+
+
 def test__fit_with_roc_auc_metric_with_temperature_calibration__warns() -> None:
     """Temperature calibration stays allowed for roc_auc, but still warns."""
     n_classes = 2


### PR DESCRIPTION
Stacked on #1153. Follows up on @oscarkey's review there:

> Claude notes that log_loss also expects probabilities not labels, so is also not working properly

That is right, and it is the same shape of bug #1153 fixes for `roc_auc`.

## The issue

The threshold search only ever scores hard labels:

```python
y_pred_tuned = (y_pred_probas >= threshold).astype(int)
current_loss = compute_metric_to_minimize(metric_name, y_true, y_pred_tuned)
```

That is correct for `f1`, `accuracy` and `balanced_accuracy`, which are defined on labels. It is not for the two metrics that need probabilities. `roc_auc` collapses to balanced accuracy (#1153). `log_loss` degenerates differently: sklearn clips the 0/1 input to `[eps, 1-eps]`, so a wrong prediction costs `-log(eps)` and a right one costs ~0, leaving log loss as a constant multiple of the error rate.

```
thr=0.2: log_loss=10.9032  error_rate=0.3025  ratio=36.0437
thr=0.5: log_loss= 8.0197  error_rate=0.2225  ratio=36.0437
thr=0.8: log_loss=13.7867  error_rate=0.3825  ratio=36.0437
-log(eps) = 36.0437

tuned threshold: log_loss=0.4478  accuracy=0.4478  identical=True
```

So `eval_metric='log_loss'` silently tunes for **accuracy**, and the tuned thresholds are bit-identical to `eval_metric='accuracy'`.

## Why reject rather than fix

Unlike `roc_auc`, thresholds *can* move log loss: the predict-time reweight (`probas / threshold`, then renormalize) is exactly a per-class additive offset in logit space, so it changes the probabilities log loss is computed on. But that family only corrects class-prior mismatch, and TabPFN already has the right tool for log loss. `find_optimal_temperature` minimizes log loss regardless of `eval_metric`, and temperature is a global confidence scale, which is the usual miscalibration.

On a model whose priors are already right, the log-loss-optimal threshold vector is the identity, while temperature still helps:

```
  none                            0.63998
  temperature T=0.8               0.62154
  threshold [1, 1, 0.8]           0.67694

  best threshold (1.0, 1.0)  ->   0.63998   <- optimum is "do not reweight"
  best temperature T=0.72    ->   0.61937
```

And because the search currently optimizes accuracy, it can land *worse* than not tuning at all: on a prior-mismatched example the accuracy-optimal threshold gave log loss 0.49188 against 0.47669 untuned.

Doing it properly would need a joint objective over the whole threshold vector, since renormalization couples the classes and the search is per-class one-vs-rest. That is not worth building for a family that is inert whenever temperature is available.

## Change

Extends the guard #1153 adds, so `log_loss` with `tune_decision_thresholds=True` raises and points at `calibrate_temperature=True`. Temperature calibration with `log_loss` is unaffected and is covered by a new test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hiNBqE62xrbYsxQXFrN71