### PR TITLE
Accept numpy arrays of strings as input

### DIFF
--- a/changelog/1246.fixed.md
+++ b/changelog/1246.fixed.md
@@ -1,0 +1,1 @@
+numpy arrays of strings are accepted as input at fit and predict, like `object` arrays and DataFrames.

--- a/src/tabpfn/preprocessing/clean.py
+++ b/src/tabpfn/preprocessing/clean.py
@@ -40,9 +40,10 @@ NUMERIC_DTYPE_KINDS = "?bBiufm"
 # converts those through its own units rather than numpy's raw integers.
 FAST_CONVERTIBLE_DTYPE_KINDS = "?bBiuf"
 OBJECT_DTYPE_KINDS = "OV"
-# numpy's fixed-width unicode strings; pandas reads them as string columns.
-UNICODE_DTYPE_KINDS = "U"
-BYTES_DTYPE_KINDS = "Sa"
+# Fixed-width unicode ("U") and numpy 2's variable-width strings ("T"); pandas
+# reads both as string columns.
+STRING_DTYPE_KINDS = "UT"
+BYTES_DTYPE_KINDS = "S"
 UNSUPPORTED_DTYPE_KINDS = "cM"  # Not needed, just for completeness
 PANDAS_BELOW_3 = Version(pd.__version__) < Version("3.0.0")
 # Before 3.0 `astype` copies every column by default, including the ones it is not
@@ -243,16 +244,17 @@ def fix_dtypes(  # noqa: D103
             # It's a numeric type, just wrap the array in pandas with the correct dtype
             X = pd.DataFrame(X, copy=False, dtype=numeric_dtype)
             convert_dtype = False
-        elif X.dtype.kind in OBJECT_DTYPE_KINDS + UNICODE_DTYPE_KINDS:
+        elif (
+            X.dtype.kind in OBJECT_DTYPE_KINDS + STRING_DTYPE_KINDS + BYTES_DTYPE_KINDS
+        ):
             # If numpy and object dtype, we rely on pandas to handle introspection
-            # of columns and rows to determine the dtypes. A unicode array holds
-            # strings the same way an object array of `str` does.
+            # of columns and rows to determine the dtypes. A string array holds
+            # strings the same way an object array of `str` does, and a byte string
+            # array does once decoded.
+            if X.dtype.kind in BYTES_DTYPE_KINDS:
+                X = _decode_bytes(X)
             X = pd.DataFrame(X, copy=True)
             convert_dtype = True
-        elif X.dtype.kind in BYTES_DTYPE_KINDS:
-            raise ValueError(
-                f"Byte string dtypes are not supported. Got dtype: {X.dtype}",
-            )
         else:
             raise ValueError(f"Invalid dtype for X: {X.dtype}")
     else:
@@ -313,6 +315,17 @@ def fix_dtypes(  # noqa: D103
     ):
         X = _cast_columns(X, numerical_columns, numeric_dtype)
     return X
+
+
+def _decode_bytes(X: np.ndarray) -> np.ndarray:
+    """Decode a byte string array as UTF-8, as `bytes.decode` does by default."""
+    try:
+        return np.char.decode(X, "utf-8")
+    except UnicodeDecodeError as e:
+        raise ValueError(
+            f"X holds byte strings that are not valid UTF-8 ({e}). Decode them to "
+            "`str` yourself before passing them."
+        ) from e
 
 
 def _column_kind(dtype: Any) -> str:

--- a/src/tabpfn/preprocessing/clean.py
+++ b/src/tabpfn/preprocessing/clean.py
@@ -40,9 +40,8 @@ NUMERIC_DTYPE_KINDS = "?bBiufm"
 # converts those through its own units rather than numpy's raw integers.
 FAST_CONVERTIBLE_DTYPE_KINDS = "?bBiuf"
 OBJECT_DTYPE_KINDS = "OV"
-# Fixed-width unicode ("U") and numpy 2's variable-width strings ("T"); pandas
-# reads both as string columns.
-STRING_DTYPE_KINDS = "UT"
+# numpy's fixed-width unicode strings; pandas reads them as string columns.
+UNICODE_DTYPE_KINDS = "U"
 BYTES_DTYPE_KINDS = "S"
 UNSUPPORTED_DTYPE_KINDS = "cM"  # Not needed, just for completeness
 PANDAS_BELOW_3 = Version(pd.__version__) < Version("3.0.0")
@@ -244,17 +243,16 @@ def fix_dtypes(  # noqa: D103
             # It's a numeric type, just wrap the array in pandas with the correct dtype
             X = pd.DataFrame(X, copy=False, dtype=numeric_dtype)
             convert_dtype = False
-        elif (
-            X.dtype.kind in OBJECT_DTYPE_KINDS + STRING_DTYPE_KINDS + BYTES_DTYPE_KINDS
-        ):
+        elif X.dtype.kind in OBJECT_DTYPE_KINDS + UNICODE_DTYPE_KINDS:
             # If numpy and object dtype, we rely on pandas to handle introspection
-            # of columns and rows to determine the dtypes. A string array holds
-            # strings the same way an object array of `str` does, and a byte string
-            # array does once decoded.
-            if X.dtype.kind in BYTES_DTYPE_KINDS:
-                X = _decode_bytes(X)
+            # of columns and rows to determine the dtypes. A unicode array holds
+            # strings the same way an object array of `str` does.
             X = pd.DataFrame(X, copy=True)
             convert_dtype = True
+        elif X.dtype.kind in BYTES_DTYPE_KINDS:
+            raise ValueError(
+                f"Byte string dtypes are not supported. Got dtype: {X.dtype}",
+            )
         else:
             raise ValueError(f"Invalid dtype for X: {X.dtype}")
     else:
@@ -315,17 +313,6 @@ def fix_dtypes(  # noqa: D103
     ):
         X = _cast_columns(X, numerical_columns, numeric_dtype)
     return X
-
-
-def _decode_bytes(X: np.ndarray) -> np.ndarray:
-    """Decode a byte string array as UTF-8, as `bytes.decode` does by default."""
-    try:
-        return np.char.decode(X, "utf-8")
-    except UnicodeDecodeError as e:
-        raise ValueError(
-            f"X holds byte strings that are not valid UTF-8 ({e}). Decode them to "
-            "`str` yourself before passing them."
-        ) from e
 
 
 def _column_kind(dtype: Any) -> str:

--- a/src/tabpfn/preprocessing/clean.py
+++ b/src/tabpfn/preprocessing/clean.py
@@ -32,18 +32,23 @@ if TYPE_CHECKING:
     )
     from tabpfn.preprocessing.torch import FeatureSchema
 
+# An array's dtype is told apart by numpy's one-letter dtype kind:
 # https://numpy.org/doc/2.1/reference/arrays.dtypes.html#checking-the-data-type
 
+# `?` bool, `b` signed byte, `B` unsigned byte, `i` signed integer, `u` unsigned
+# integer, `f` float, `m` timedelta.
 NUMERIC_DTYPE_KINDS = "?bBiufm"
 # The subset of the above that numpy casts to float64 the same way pandas does, so
 # a frame need not be built to convert it. Timedeltas ("m") are excluded: pandas
 # converts those through its own units rather than numpy's raw integers.
 FAST_CONVERTIBLE_DTYPE_KINDS = "?bBiuf"
-OBJECT_DTYPE_KINDS = "OV"
-# numpy's fixed-width unicode strings; pandas reads them as string columns.
-UNICODE_DTYPE_KINDS = "U"
-BYTES_DTYPE_KINDS = "S"
-UNSUPPORTED_DTYPE_KINDS = "cM"  # Not needed, just for completeness
+# `O` object, `V` void (structured records), `U` fixed-width unicode strings: pandas
+# reads the cells to work out each column's dtype.
+OBJECT_OR_STRING_DTYPE_KINDS = "OVU"
+# `S` fixed-width byte strings and `a`, its legacy alias: refused.
+BYTES_DTYPE_KINDS = "Sa"
+# `c` complex, `M` datetime64. Not needed, just for completeness.
+UNSUPPORTED_DTYPE_KINDS = "cM"
 PANDAS_BELOW_3 = Version(pd.__version__) < Version("3.0.0")
 # Before 3.0 `astype` copies every column by default, including the ones it is not
 # casting; from 3.0 copy-on-write makes the keyword a no-op and passing it warns.
@@ -243,10 +248,9 @@ def fix_dtypes(  # noqa: D103
             # It's a numeric type, just wrap the array in pandas with the correct dtype
             X = pd.DataFrame(X, copy=False, dtype=numeric_dtype)
             convert_dtype = False
-        elif X.dtype.kind in OBJECT_DTYPE_KINDS + UNICODE_DTYPE_KINDS:
-            # If numpy and object dtype, we rely on pandas to handle introspection
-            # of columns and rows to determine the dtypes. A unicode array holds
-            # strings the same way an object array of `str` does.
+        elif X.dtype.kind in OBJECT_OR_STRING_DTYPE_KINDS:
+            # For an object or string array we rely on pandas to introspect the
+            # cells and determine each column's dtype.
             X = pd.DataFrame(X, copy=True)
             convert_dtype = True
         elif X.dtype.kind in BYTES_DTYPE_KINDS:

--- a/src/tabpfn/preprocessing/clean.py
+++ b/src/tabpfn/preprocessing/clean.py
@@ -40,7 +40,9 @@ NUMERIC_DTYPE_KINDS = "?bBiufm"
 # converts those through its own units rather than numpy's raw integers.
 FAST_CONVERTIBLE_DTYPE_KINDS = "?bBiuf"
 OBJECT_DTYPE_KINDS = "OV"
-STRING_DTYPE_KINDS = "SaU"
+# numpy's fixed-width unicode strings; pandas reads them as string columns.
+UNICODE_DTYPE_KINDS = "U"
+BYTES_DTYPE_KINDS = "Sa"
 UNSUPPORTED_DTYPE_KINDS = "cM"  # Not needed, just for completeness
 PANDAS_BELOW_3 = Version(pd.__version__) < Version("3.0.0")
 # Before 3.0 `astype` copies every column by default, including the ones it is not
@@ -241,14 +243,15 @@ def fix_dtypes(  # noqa: D103
             # It's a numeric type, just wrap the array in pandas with the correct dtype
             X = pd.DataFrame(X, copy=False, dtype=numeric_dtype)
             convert_dtype = False
-        elif X.dtype.kind in OBJECT_DTYPE_KINDS:
+        elif X.dtype.kind in OBJECT_DTYPE_KINDS + UNICODE_DTYPE_KINDS:
             # If numpy and object dtype, we rely on pandas to handle introspection
-            # of columns and rows to determine the dtypes.
+            # of columns and rows to determine the dtypes. A unicode array holds
+            # strings the same way an object array of `str` does.
             X = pd.DataFrame(X, copy=True)
             convert_dtype = True
-        elif X.dtype.kind in STRING_DTYPE_KINDS:
+        elif X.dtype.kind in BYTES_DTYPE_KINDS:
             raise ValueError(
-                f"String dtypes are not supported. Got dtype: {X.dtype}",
+                f"Byte string dtypes are not supported. Got dtype: {X.dtype}",
             )
         else:
             raise ValueError(f"Invalid dtype for X: {X.dtype}")

--- a/tests/test_preprocessing/test_data_cleaning.py
+++ b/tests/test_preprocessing/test_data_cleaning.py
@@ -1302,3 +1302,45 @@ def test__fit_predict__a_float32_input_predicts_as_its_float64_equal() -> None:
         return model.fit(X, y).predict_proba(X)
 
     np.testing.assert_array_equal(proba(X32), proba(X64))
+
+
+def test__fix_dtypes__unicode_array__is_read_like_an_object_array() -> None:
+    """A fixed-width unicode array is read like an `object` array of `str`."""
+    unicode = np.array([["a", "1.5"], ["b", "2.5"], ["a", "3.5"]])
+    assert unicode.dtype.kind == "U"
+
+    pd.testing.assert_frame_equal(
+        fix_dtypes(unicode, cat_indices=[0]),
+        fix_dtypes(unicode.astype(object), cat_indices=[0]),
+    )
+
+
+def test__fix_dtypes__bytes_array__is_refused() -> None:
+    with pytest.raises(ValueError, match="Byte string dtypes are not supported"):
+        fix_dtypes(np.array([[b"a"], [b"b"]]), cat_indices=None)
+
+
+@pytest.mark.parametrize("estimator_cls", [TabPFNClassifier, TabPFNRegressor])
+def test__fit_predict__unicode_array__is_accepted_like_an_object_array(
+    estimator_cls: type[TabPFNClassifier] | type[TabPFNRegressor],
+) -> None:
+    """A numpy string array is accepted at fit and at predict, and predicts the same
+    as the same strings in an `object` array, whether the model was fitted on the
+    string array or on a DataFrame of it.
+    """
+    n = 40
+    X = np.array([[f"c{i % 3}", f"{i % 5}"] for i in range(n)])
+    assert X.dtype.kind == "U"
+    y = np.arange(n) % 2 if estimator_cls is TabPFNClassifier else np.arange(n) / n
+
+    fitted_on_array = estimator_cls(n_estimators=1, device="cpu", random_state=0)
+    fitted_on_array.fit(X, y)
+    np.testing.assert_array_equal(
+        fitted_on_array.predict(X), fitted_on_array.predict(X.astype(object))
+    )
+
+    fitted_on_frame = estimator_cls(n_estimators=1, device="cpu", random_state=0)
+    fitted_on_frame.fit(pd.DataFrame(X), y)
+    np.testing.assert_array_equal(
+        fitted_on_frame.predict(X), fitted_on_frame.predict(X.astype(object))
+    )

--- a/tests/test_preprocessing/test_data_cleaning.py
+++ b/tests/test_preprocessing/test_data_cleaning.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from unittest import mock
 
 import numpy as np
@@ -1304,43 +1305,72 @@ def test__fit_predict__a_float32_input_predicts_as_its_float64_equal() -> None:
     np.testing.assert_array_equal(proba(X32), proba(X64))
 
 
-def test__fix_dtypes__unicode_array__is_read_like_an_object_array() -> None:
-    """A fixed-width unicode array is read like an `object` array of `str`."""
-    unicode = np.array([["a", "1.5"], ["b", "2.5"], ["a", "3.5"]])
-    assert unicode.dtype.kind == "U"
+def _string_array_kinds() -> list:
+    """Every numpy string dtype: fixed-width unicode, and numpy 2's `StringDType`."""
+    kinds = [pytest.param(str, id="unicode")]
+    string_dtype = getattr(getattr(np, "dtypes", None), "StringDType", None)
+    if string_dtype is not None:
+        kinds.append(pytest.param(string_dtype(), id="StringDType"))
+    return kinds
+
+
+@pytest.mark.parametrize("dtype", _string_array_kinds())
+def test__fix_dtypes__string_array__is_read_like_an_object_array(dtype: object) -> None:
+    strings = np.array([["a", "1.5"], ["b", "2.5"], ["a", "3.5"]], dtype=dtype)
+    assert strings.dtype.kind in "UT"
 
     pd.testing.assert_frame_equal(
-        fix_dtypes(unicode, cat_indices=[0]),
-        fix_dtypes(unicode.astype(object), cat_indices=[0]),
+        fix_dtypes(strings, cat_indices=[0]),
+        fix_dtypes(strings.astype(object), cat_indices=[0]),
     )
 
 
-def test__fix_dtypes__bytes_array__is_refused() -> None:
-    with pytest.raises(ValueError, match="Byte string dtypes are not supported"):
-        fix_dtypes(np.array([[b"a"], [b"b"]]), cat_indices=None)
+def test__fix_dtypes__bytes_array__is_decoded_as_utf8() -> None:
+    strings = np.array([["a", "1.5"], ["\u00e9", "2.5"], ["a", "3.5"]])
+    encoded = np.char.encode(strings, "utf-8")
+    assert encoded.dtype.kind == "S"
+
+    pd.testing.assert_frame_equal(
+        fix_dtypes(encoded, cat_indices=[0]),
+        fix_dtypes(strings, cat_indices=[0]),
+    )
+
+
+def test__fix_dtypes__undecodable_bytes__are_refused() -> None:
+    with pytest.raises(ValueError, match="not valid UTF-8"):
+        fix_dtypes(np.array([[b"\xff"], [b"a"]]), cat_indices=None)
 
 
 @pytest.mark.parametrize("estimator_cls", [TabPFNClassifier, TabPFNRegressor])
-def test__fit_predict__unicode_array__is_accepted_like_an_object_array(
+@pytest.mark.parametrize(
+    "as_array",
+    [
+        pytest.param(lambda X: X, id="unicode"),
+        pytest.param(lambda X: np.char.encode(X, "utf-8"), id="bytes"),
+    ],
+)
+def test__fit_predict__string_array__is_accepted_like_an_object_array(
     estimator_cls: type[TabPFNClassifier] | type[TabPFNRegressor],
+    as_array: Callable[[np.ndarray], np.ndarray],
 ) -> None:
     """A numpy string array is accepted at fit and at predict, and predicts the same
     as the same strings in an `object` array, whether the model was fitted on the
     string array or on a DataFrame of it.
     """
     n = 40
-    X = np.array([[f"c{i % 3}", f"{i % 5}"] for i in range(n)])
-    assert X.dtype.kind == "U"
+    strings = np.array([[f"c{i % 3}", f"{i % 5}"] for i in range(n)])
+    X = as_array(strings)
+    assert X.dtype.kind in "US"
     y = np.arange(n) % 2 if estimator_cls is TabPFNClassifier else np.arange(n) / n
 
     fitted_on_array = estimator_cls(n_estimators=1, device="cpu", random_state=0)
     fitted_on_array.fit(X, y)
     np.testing.assert_array_equal(
-        fitted_on_array.predict(X), fitted_on_array.predict(X.astype(object))
+        fitted_on_array.predict(X), fitted_on_array.predict(strings.astype(object))
     )
 
     fitted_on_frame = estimator_cls(n_estimators=1, device="cpu", random_state=0)
-    fitted_on_frame.fit(pd.DataFrame(X), y)
+    fitted_on_frame.fit(pd.DataFrame(strings), y)
     np.testing.assert_array_equal(
-        fitted_on_frame.predict(X), fitted_on_frame.predict(X.astype(object))
+        fitted_on_frame.predict(X), fitted_on_frame.predict(strings.astype(object))
     )

--- a/tests/test_preprocessing/test_data_cleaning.py
+++ b/tests/test_preprocessing/test_data_cleaning.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from unittest import mock
 
 import numpy as np
@@ -1305,72 +1304,43 @@ def test__fit_predict__a_float32_input_predicts_as_its_float64_equal() -> None:
     np.testing.assert_array_equal(proba(X32), proba(X64))
 
 
-def _string_array_kinds() -> list:
-    """Every numpy string dtype: fixed-width unicode, and numpy 2's `StringDType`."""
-    kinds = [pytest.param(str, id="unicode")]
-    string_dtype = getattr(getattr(np, "dtypes", None), "StringDType", None)
-    if string_dtype is not None:
-        kinds.append(pytest.param(string_dtype(), id="StringDType"))
-    return kinds
-
-
-@pytest.mark.parametrize("dtype", _string_array_kinds())
-def test__fix_dtypes__string_array__is_read_like_an_object_array(dtype: object) -> None:
-    strings = np.array([["a", "1.5"], ["b", "2.5"], ["a", "3.5"]], dtype=dtype)
-    assert strings.dtype.kind in "UT"
+def test__fix_dtypes__unicode_array__is_read_like_an_object_array() -> None:
+    """A fixed-width unicode array is read like an `object` array of `str`."""
+    unicode = np.array([["a", "1.5"], ["b", "2.5"], ["a", "3.5"]])
+    assert unicode.dtype.kind == "U"
 
     pd.testing.assert_frame_equal(
-        fix_dtypes(strings, cat_indices=[0]),
-        fix_dtypes(strings.astype(object), cat_indices=[0]),
+        fix_dtypes(unicode, cat_indices=[0]),
+        fix_dtypes(unicode.astype(object), cat_indices=[0]),
     )
 
 
-def test__fix_dtypes__bytes_array__is_decoded_as_utf8() -> None:
-    strings = np.array([["a", "1.5"], ["\u00e9", "2.5"], ["a", "3.5"]])
-    encoded = np.char.encode(strings, "utf-8")
-    assert encoded.dtype.kind == "S"
-
-    pd.testing.assert_frame_equal(
-        fix_dtypes(encoded, cat_indices=[0]),
-        fix_dtypes(strings, cat_indices=[0]),
-    )
-
-
-def test__fix_dtypes__undecodable_bytes__are_refused() -> None:
-    with pytest.raises(ValueError, match="not valid UTF-8"):
-        fix_dtypes(np.array([[b"\xff"], [b"a"]]), cat_indices=None)
+def test__fix_dtypes__bytes_array__is_refused() -> None:
+    with pytest.raises(ValueError, match="Byte string dtypes are not supported"):
+        fix_dtypes(np.array([[b"a"], [b"b"]]), cat_indices=None)
 
 
 @pytest.mark.parametrize("estimator_cls", [TabPFNClassifier, TabPFNRegressor])
-@pytest.mark.parametrize(
-    "as_array",
-    [
-        pytest.param(lambda X: X, id="unicode"),
-        pytest.param(lambda X: np.char.encode(X, "utf-8"), id="bytes"),
-    ],
-)
-def test__fit_predict__string_array__is_accepted_like_an_object_array(
+def test__fit_predict__unicode_array__is_accepted_like_an_object_array(
     estimator_cls: type[TabPFNClassifier] | type[TabPFNRegressor],
-    as_array: Callable[[np.ndarray], np.ndarray],
 ) -> None:
     """A numpy string array is accepted at fit and at predict, and predicts the same
     as the same strings in an `object` array, whether the model was fitted on the
     string array or on a DataFrame of it.
     """
     n = 40
-    strings = np.array([[f"c{i % 3}", f"{i % 5}"] for i in range(n)])
-    X = as_array(strings)
-    assert X.dtype.kind in "US"
+    X = np.array([[f"c{i % 3}", f"{i % 5}"] for i in range(n)])
+    assert X.dtype.kind == "U"
     y = np.arange(n) % 2 if estimator_cls is TabPFNClassifier else np.arange(n) / n
 
     fitted_on_array = estimator_cls(n_estimators=1, device="cpu", random_state=0)
     fitted_on_array.fit(X, y)
     np.testing.assert_array_equal(
-        fitted_on_array.predict(X), fitted_on_array.predict(strings.astype(object))
+        fitted_on_array.predict(X), fitted_on_array.predict(X.astype(object))
     )
 
     fitted_on_frame = estimator_cls(n_estimators=1, device="cpu", random_state=0)
-    fitted_on_frame.fit(pd.DataFrame(strings), y)
+    fitted_on_frame.fit(pd.DataFrame(X), y)
     np.testing.assert_array_equal(
-        fitted_on_frame.predict(X), fitted_on_frame.predict(strings.astype(object))
+        fitted_on_frame.predict(X), fitted_on_frame.predict(X.astype(object))
     )


### PR DESCRIPTION
## What & why

`fix_dtypes` refused a numpy array of strings (dtype kind `U`) with a bare `ValueError` ("String dtypes are not supported"), at fit and at predict, while the same strings in an `object` array or a DataFrame were accepted and encoded. A model fitted on a DataFrame refused a numpy string array at predict but accepted the same array cast to `object`. The guard dates from the original V2 code; nothing depended on it, since the modality detector had already labelled the columns by the time it fired.

## How

- A unicode array is wrapped in a DataFrame the way an `object` array already is; the existing dtype conversion and ordinal encoding take it from there.
- The dtype-kind constants are named by what `fix_dtypes` does with them: `OBJECT_OR_STRING_DTYPE_KINDS = "OVU"` (object, void, unicode) takes the pandas introspection path; `BYTES_DTYPE_KINDS = "Sa"` is refused, now with a message that says "Byte string dtypes". Each letter is spelled out where the constants are defined.
- Scope is fixed-width unicode arrays only. Byte string arrays and numpy 2's `StringDType` are left as they were.

## Public API Changes

- [ ] No Public API changes
- [x] Yes, Public API changes (Details below)

A numpy array of strings is accepted by `fit` and `predict` where it was refused before. It behaves exactly like the same strings passed in a DataFrame.

## How Has This Been Tested?

`tests/test_preprocessing/test_data_cleaning.py`: `fix_dtypes` on a unicode array equals `fix_dtypes` on its `object` twin; a bytes array is refused; both estimators fit and predict on a unicode array and predict the same as on the `object` array, whether fitted on the array or on a DataFrame. The full files `test_data_cleaning`, `test_sklearn_estimator_checks`, `test_input_immutability`, `test_estimators`, `test_classifier_interface` and `test_regressor_interface` pass locally.

## Checklist

- [x] The changes have been tested locally.
- [ ] Documentation has been updated (if the public API or usage changes).
- [x] A changelog entry has been added (see `changelog/README.md`), or "no changelog needed" label requested.
- [x] The code follows the project's style guidelines.
- [x] I have considered the impact of these changes on the public API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
