### PR TITLE
docs: add concise estimator usage guidance

### DIFF
--- a/changelog/1247.changed.md
+++ b/changelog/1247.changed.md
@@ -1,0 +1,1 @@
+Clarify estimator usage guidance for TabPFN-3 and later versions, covering dataset capacity, subsampling, and automatic handling of categorical and missing feature values without manual preprocessing.

--- a/src/tabpfn/classifier.py
+++ b/src/tabpfn/classifier.py
@@ -132,7 +132,18 @@ DEFAULT_CLASSIFICATION_EVAL_METRIC = ClassifierEvalMetrics.ACCURACY
 
 
 class TabPFNClassifier(ClassifierMixin, BaseEstimator):
-    """TabPFNClassifier class."""
+    """TabPFN classifier with a scikit-learn-compatible interface.
+
+    Usage guidance:
+        - TabPFN-3 supports up to 1,000,000 rows, subject to feature count,
+          checkpoint limits, and memory.
+        - For large datasets or limited memory, use per-estimator subsampling,
+          e.g. ``inference_config={"SUBSAMPLE_SAMPLES": 50_000}``.
+        - Pass raw pandas DataFrames to ``fit`` and ``predict``. Categorical
+          strings/categories and missing feature values are handled automatically;
+          no manual integer/one-hot encoding, imputation, scaling, or outlier
+          removal is needed.
+    """
 
     configs_: list[ArchitectureConfig]
     """The configurations of the loaded models to be used for inference.

--- a/src/tabpfn/classifier.py
+++ b/src/tabpfn/classifier.py
@@ -135,8 +135,8 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
     """TabPFN classifier with a scikit-learn-compatible interface.
 
     Usage guidance:
-        - TabPFN-3 supports up to 1,000,000 rows, subject to feature count,
-          checkpoint limits, and memory.
+        - TabPFN-3 and later versions support up to 1,000,000 rows, subject to
+          feature count, checkpoint limits, and memory.
         - For large datasets or limited memory, use per-estimator subsampling,
           e.g. ``inference_config={"SUBSAMPLE_SAMPLES": 50_000}``.
         - Pass raw pandas DataFrames to ``fit`` and ``predict``. Categorical

--- a/src/tabpfn/regressor.py
+++ b/src/tabpfn/regressor.py
@@ -174,7 +174,18 @@ DEFAULT_REGRESSION_EVAL_METRIC = RegressorEvalMetrics.NLL
 
 
 class TabPFNRegressor(RegressorMixin, BaseEstimator):
-    """TabPFNRegressor class."""
+    """TabPFN regressor with a scikit-learn-compatible interface.
+
+    Usage guidance:
+        - TabPFN-3 supports up to 1,000,000 rows, subject to feature count,
+          checkpoint limits, and memory.
+        - For large datasets or limited memory, use per-estimator subsampling,
+          e.g. ``inference_config={"SUBSAMPLE_SAMPLES": 50_000}``.
+        - Pass raw pandas DataFrames to ``fit`` and ``predict``. Categorical
+          strings/categories and missing feature values are handled automatically;
+          no manual integer/one-hot encoding, imputation, scaling, or outlier
+          removal is needed.
+    """
 
     configs_: list[ArchitectureConfig]
     """The configurations of the loaded models to be used for inference.

--- a/src/tabpfn/regressor.py
+++ b/src/tabpfn/regressor.py
@@ -177,8 +177,8 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
     """TabPFN regressor with a scikit-learn-compatible interface.
 
     Usage guidance:
-        - TabPFN-3 supports up to 1,000,000 rows, subject to feature count,
-          checkpoint limits, and memory.
+        - TabPFN-3 and later versions support up to 1,000,000 rows, subject to
+          feature count, checkpoint limits, and memory.
         - For large datasets or limited memory, use per-estimator subsampling,
           e.g. ``inference_config={"SUBSAMPLE_SAMPLES": 50_000}``.
         - Pass raw pandas DataFrames to ``fit`` and ``predict``. Categorical


### PR DESCRIPTION
Agents often impose an outdated 10k-row cap and add unnecessary preprocessing. Add concise classifier/regressor docstrings covering the capacity of TabPFN-3 and later versions of up to 1M rows, per-estimator subsampling, and automatic handling of categorical and missing feature values.

Validation: Ruff formatting/lint and `git diff --check` passed. Documentation only; no API changes. Changelog entry included.
