### PR TITLE
Remove the dead cache_trainset_representation flag

### DIFF
--- a/changelog/1250.breaking.md
+++ b/changelog/1250.breaking.md
@@ -1,0 +1,1 @@
+Remove the dead `cache_trainset_representation` argument from `ArchitectureModule.get_architecture`, `load_model` and `load_model_criterion_config`, and the `fit_mode` argument from `initialize_tabpfn_model`. Every architecture ignored the flag since `InferenceEngineCacheKV` was removed; external architectures implementing the protocol must drop the parameter.

--- a/changelog/1250.changed.md
+++ b/changelog/1250.changed.md
@@ -1,0 +1,1 @@
+`fit_mode="fit_with_cache"` now uses the opt-in built-model cache (`TABPFN_MODEL_CACHE_SIZE`), where it previously rebuilt the model on every fit.

--- a/src/tabpfn/architectures/interface.py
+++ b/src/tabpfn/architectures/interface.py
@@ -143,20 +143,13 @@ class ArchitectureModule(Protocol):
         """
         ...
 
-    def get_architecture(
-        self,
-        config: ArchitectureConfig,
-        *,
-        cache_trainset_representation: bool,
-    ) -> Architecture:
+    def get_architecture(self, config: ArchitectureConfig) -> Architecture:
         """Construct a new instance of the model based on the given config.
 
         Args:
             config: The config returned by parse_config(). This method should use a
                 runtime isinstance() check to downcast the config to this architecture's
                 specific config class.
-            cache_trainset_representation: If True, the model should be configured to
-                cache the training data during inference to improve speed.
 
         Returns: the constructed architecture
         """

--- a/src/tabpfn/architectures/tabpfn_v2.py
+++ b/src/tabpfn/architectures/tabpfn_v2.py
@@ -1266,11 +1266,7 @@ def _prepare_targets(y: torch.Tensor, num_rows: int, batch_size: int) -> torch.T
     )
 
 
-def get_architecture(
-    config: ArchitectureConfig,
-    *,
-    cache_trainset_representation: bool = False,
-) -> TabPFNV2:
+def get_architecture(config: ArchitectureConfig) -> TabPFNV2:
     """Construct TabPFNV2 based on the given config.
 
     This factory method implements the interface defined in
@@ -1280,16 +1276,9 @@ def get_architecture(
         config: The config returned by parse_config(). This method should use a
             runtime isinstance() check to downcast the config to this architecture's
             specific config class.
-        cache_trainset_representation: Accepted for interface compatibility but
-            ignored. This architecture uses an explicit KV cache passed through
-            forward() (``kv_cache`` / ``return_kv_cache``) rather than model-internal
-            caching, so no special construction is required.
 
     Returns: the constructed architecture
     """
     assert isinstance(config, TabPFNV2Config)
-    # The explicit KV cache is selected at call time via forward()'s kv_cache /
-    # return_kv_cache arguments, so the model does not need configuring here.
-    del cache_trainset_representation
     n_out = config.max_num_classes or config.num_buckets
     return TabPFNV2(config=config, n_out=n_out)

--- a/src/tabpfn/architectures/tabpfn_v2_5.py
+++ b/src/tabpfn/architectures/tabpfn_v2_5.py
@@ -1093,11 +1093,7 @@ def parse_config(config: dict[str, Any]) -> tuple[TabPFNV2p5Config, dict[str, An
     return parsed_config, parsed_config.get_unused_config(config)
 
 
-def get_architecture(
-    config: ArchitectureConfig,
-    *,
-    cache_trainset_representation: bool = False,
-) -> TabPFNV2p5:
+def get_architecture(config: ArchitectureConfig) -> TabPFNV2p5:
     """Construct TabPFNV2.5 based on the given config.
 
     This factory method implements the interface defined in
@@ -1107,17 +1103,10 @@ def get_architecture(
         config: The config returned by parse_config(). This method should use a
             runtime isinstance() check to downcast the config to this architecture's
             specific config class.
-        cache_trainset_representation: Accepted for interface compatibility but
-            ignored. This architecture uses an explicit KV cache passed through
-            forward() (``kv_cache`` / ``return_kv_cache``) rather than model-internal
-            caching, so no special construction is required.
 
     Returns: the constructed architecture
     """
     assert isinstance(config, TabPFNV2p5Config)
-    # The explicit KV cache is selected at call time via forward()'s kv_cache /
-    # return_kv_cache arguments, so the model does not need configuring here.
-    del cache_trainset_representation
     task_type = "multiclass" if config.max_num_classes > 0 else "regression"
     n_out = config.max_num_classes if task_type == "multiclass" else config.num_buckets
     return TabPFNV2p5(config=config, n_out=n_out, task_type=task_type)

--- a/src/tabpfn/architectures/tabpfn_v2_6.py
+++ b/src/tabpfn/architectures/tabpfn_v2_6.py
@@ -1070,11 +1070,7 @@ def parse_config(config: dict[str, Any]) -> tuple[TabPFNV2p6Config, dict[str, An
     return parsed_config, parsed_config.get_unused_config(config)
 
 
-def get_architecture(
-    config: ArchitectureConfig,
-    *,
-    cache_trainset_representation: bool = False,
-) -> TabPFNV2p6:
+def get_architecture(config: ArchitectureConfig) -> TabPFNV2p6:
     """Construct TabPFNV2.6 based on the given config.
 
     This factory method implements the interface defined in
@@ -1084,17 +1080,10 @@ def get_architecture(
         config: The config returned by parse_config(). This method should use a
             runtime isinstance() check to downcast the config to this architecture's
             specific config class.
-        cache_trainset_representation: Accepted for interface compatibility but
-            ignored. This architecture uses an explicit KV cache passed through
-            forward() (``kv_cache`` / ``return_kv_cache``) rather than model-internal
-            caching, so no special construction is required.
 
     Returns: the constructed architecture
     """
     assert isinstance(config, TabPFNV2p6Config)
-    # The explicit KV cache is selected at call time via forward()'s kv_cache /
-    # return_kv_cache arguments, so the model does not need configuring here.
-    del cache_trainset_representation
     task_type = "multiclass" if config.max_num_classes > 0 else "regression"
     n_out = config.max_num_classes if task_type == "multiclass" else config.num_buckets
     return TabPFNV2p6(config=config, n_out=n_out, task_type=task_type)

--- a/src/tabpfn/architectures/tabpfn_v3.py
+++ b/src/tabpfn/architectures/tabpfn_v3.py
@@ -2471,17 +2471,9 @@ def parse_config(
     return parsed_config, parsed_config.get_unused_config(config)
 
 
-def get_architecture(
-    config: ArchitectureConfig,
-    *,
-    cache_trainset_representation: bool = False,
-) -> TabPFNV3:
+def get_architecture(config: ArchitectureConfig) -> TabPFNV3:
     """Construct TabPFN v3 from the given config."""
-    del cache_trainset_representation
     assert isinstance(config, TabPFNV3Config)
-    # cache_trainset_representation is accepted for interface compatibility but
-    # is a no-op: v3 uses explicit KV cache passing via forward() parameters
-    # (kv_cache / return_kv_cache) instead of model-internal caching.
     task_type = "multiclass" if config.is_classification else "regression"
     n_out = config.max_num_classes if task_type == "multiclass" else config.num_buckets
     return TabPFNV3(

--- a/src/tabpfn/base.py
+++ b/src/tabpfn/base.py
@@ -109,6 +109,7 @@ def initialize_tabpfn_model(
     | list[RegressorModelSpecs]
     | list[ClassifierModelSpecs],
     which: Literal["classifier", "regressor"],
+    *,
     softmax_temperature_override: float | None = None,
     n_estimators_override: int | None = None,
 ) -> tuple[

--- a/src/tabpfn/base.py
+++ b/src/tabpfn/base.py
@@ -109,7 +109,6 @@ def initialize_tabpfn_model(
     | list[RegressorModelSpecs]
     | list[ClassifierModelSpecs],
     which: Literal["classifier", "regressor"],
-    fit_mode: Literal["low_memory", "fit_preprocessors", "fit_with_cache"],
     softmax_temperature_override: float | None = None,
     n_estimators_override: int | None = None,
 ) -> tuple[
@@ -127,7 +126,6 @@ def initialize_tabpfn_model(
             provided, the model is loaded from the object.
 
         which: Which TabPFN model to load.
-        fit_mode: Determines caching behavior.
         softmax_temperature_override: The temperature the caller will apply to every
             model, or None if they did not ask for one. Only used to decide whether
             checkpoints are allowed to disagree on their temperature; the override
@@ -210,7 +208,6 @@ def initialize_tabpfn_model(
                     model_path=model_path,  # pyright: ignore[reportArgumentType]
                     # The classifier's bar distribution is not used
                     check_bar_distribution_criterion=False,
-                    cache_trainset_representation=(fit_mode == "fit_with_cache"),
                     estimator_type="classifier",
                     version=version.value,
                     download_if_not_exists=download_if_not_exists,
@@ -225,7 +222,6 @@ def initialize_tabpfn_model(
                     model_path=model_path,  # pyright: ignore[reportArgumentType]
                     # The regressor's bar distribution is required
                     check_bar_distribution_criterion=True,
-                    cache_trainset_representation=(fit_mode == "fit_with_cache"),
                     estimator_type="regressor",
                     version=version.value,
                     download_if_not_exists=download_if_not_exists,
@@ -493,7 +489,6 @@ def initialize_model_variables_helper(
         initialize_tabpfn_model(
             model_path=calling_instance.model_path,  # pyright: ignore[reportArgumentType]
             which=model_type,
-            fit_mode=calling_instance.fit_mode,  # pyright: ignore[reportArgumentType]
             softmax_temperature_override=overrides["SOFTMAX_TEMPERATURE"],
             n_estimators_override=overrides["N_ESTIMATORS"],
         )

--- a/src/tabpfn/model_loading.py
+++ b/src/tabpfn/model_loading.py
@@ -589,7 +589,6 @@ def load_model_criterion_config(
     model_path: ModelPath | list[ModelPath] | None,
     *,
     check_bar_distribution_criterion: Literal[False],
-    cache_trainset_representation: bool,
     version: Literal["v2", "v2.5", "v2.6", "v3"],
     estimator_type: Literal["classifier"],
     download_if_not_exists: bool,
@@ -608,7 +607,6 @@ def load_model_criterion_config(
     model_path: ModelPath | list[ModelPath] | None,
     *,
     check_bar_distribution_criterion: Literal[True],
-    cache_trainset_representation: bool,
     version: Literal["v2", "v2.5", "v2.6", "v3"],
     estimator_type: Literal["regressor"],
     download_if_not_exists: bool,
@@ -626,7 +624,6 @@ def load_model_criterion_config(
     model_path: ModelPath | list[ModelPath] | None,
     *,
     check_bar_distribution_criterion: bool,
-    cache_trainset_representation: bool,
     estimator_type: Literal["regressor", "classifier"],
     version: Literal["v2", "v2.5", "v2.6", "v3"],
     download_if_not_exists: bool,
@@ -651,8 +648,6 @@ def load_model_criterion_config(
             Whether to check if the criterion
             is a FullSupportBarDistribution, which is the expected criterion
             for models trained for regression.
-        cache_trainset_representation:
-            Whether the model should know to cache the trainset representation.
         estimator_type: Whether the model is a regressor or classifier.
         version: The version of the model.
         download_if_not_exists: Whether to download the model if it doesn't exist.
@@ -715,7 +710,6 @@ def load_model_criterion_config(
         loaded_model, criterion, architecture_config, inference_config = load_model(
             path=path,
             estimator_type=estimator_type,
-            cache_trainset_representation=cache_trainset_representation,
         )
         if check_bar_distribution_criterion and not isinstance(
             criterion,
@@ -923,16 +917,13 @@ def _load_checkpoint_cached(path: str, _identity: tuple[int, int]) -> dict:
 
 
 # Bounded, opt-in cache of *built* models (architecture + loaded weights),
-# keyed by (resolved path, file identity). Enabled by setting the env var
-# ``TABPFN_MODEL_CACHE_SIZE`` to a positive integer (an LRU of that size;
-# default 0 disables it, preserving prior behaviour). Only the non-mutating
-# build is cached: with ``cache_trainset_representation`` the model accumulates
-# the train-set representation during fit, so a shared instance can't be reused
-# across fits. The cached model is shared by reference and left in ``eval()``
-# mode — intended for repeated sequential fit/predict (cross-validation,
-# per-group models, or servers that manage their own concurrency). RES-2422
-# tracks the follow-up that externalises per-fit state so a single backbone can
-# be shared across threads too.
+# keyed by (resolved path, file identity, estimator type). Enabled by setting
+# the env var ``TABPFN_MODEL_CACHE_SIZE`` to a positive integer (an LRU of that
+# size; default 0 disables it, preserving prior behaviour). The cached model is
+# shared by reference and left in ``eval()`` mode — intended for repeated
+# sequential fit/predict (cross-validation, per-group models, or servers that
+# manage their own concurrency). RES-2422 tracks the follow-up that externalises
+# per-fit state so a single backbone can be shared across threads too.
 _BUILT_MODEL_CACHE: OrderedDict[tuple[str, tuple[int, int]], tuple] = OrderedDict()
 _BUILT_MODEL_CACHE_LOCK = Lock()
 
@@ -954,7 +945,6 @@ def load_model(
     *,
     path: Path,
     estimator_type: Literal["regressor", "classifier"],
-    cache_trainset_representation: bool = True,
 ) -> tuple[
     Architecture,
     nn.BCEWithLogitsLoss | nn.CrossEntropyLoss | FullSupportBarDistribution,
@@ -967,20 +957,17 @@ def load_model(
     skip disk I/O. When ``TABPFN_MODEL_CACHE_SIZE`` is a positive integer the
     *built* model (architecture + loaded weights) is also cached, as an LRU of
     that size, so repeated calls skip reconstruction and ``load_state_dict``
-    entirely. Only the non-mutating build (``cache_trainset_representation=False``)
-    is cached. Both caches invalidate when the file changes (mtime + size).
+    entirely. Both caches invalidate when the file changes (mtime + size).
 
     Args:
         path: Path to the checkpoint
         estimator_type: The task the estimator is being built for. A checkpoint
             with both heads backs either task, so this selects the criterion.
-        cache_trainset_representation: If True, the model will cache the
-            trainset representation. Forwarded to get_architecture.
     """
     resolved = str(path.resolve())
     identity = Checkpoint(resolved).identity()
 
-    use_cache = _get_built_model_cache_size() > 0 and not cache_trainset_representation
+    use_cache = _get_built_model_cache_size() > 0
     # `estimator_type` belongs in the key: the criterion differs per task, so a
     # checkpoint built for one task must not be served for the other.
     key = (resolved, identity, estimator_type)
@@ -995,7 +982,6 @@ def load_model(
         resolved,
         identity,
         estimator_type=estimator_type,
-        cache_trainset_representation=cache_trainset_representation,
     )
 
     if use_cache:
@@ -1013,7 +999,6 @@ def _build_model(
     identity: tuple[int, int],
     *,
     estimator_type: Literal["regressor", "classifier"],
-    cache_trainset_representation: bool = True,
 ) -> tuple[
     Architecture,
     nn.BCEWithLogitsLoss | nn.CrossEntropyLoss | FullSupportBarDistribution,
@@ -1036,10 +1021,7 @@ def _build_model(
         "Keys in config that were not parsed by architecture config: "
         f"{', '.join(unused_model_config.keys())}"
     )
-    model = architecture.get_architecture(
-        model_config,
-        cache_trainset_representation=cache_trainset_representation,
-    )
+    model = architecture.get_architecture(model_config)
 
     # A checkpoint may carry criterion state for a task it is not being loaded for
     # (save_tabpfn_model writes it for regressors), so it is always kept out of the

--- a/tests/test_architectures/test_attention_dispatch.py
+++ b/tests/test_architectures/test_attention_dispatch.py
@@ -69,7 +69,7 @@ def _model(nlayers: int = 2) -> tabpfn_v3.TabPFNV3:
         dist_embed_num_heads=3,
         feat_agg_num_heads=3,
     )
-    model = tabpfn_v3.get_architecture(config, cache_trainset_representation=False)
+    model = tabpfn_v3.get_architecture(config)
     model.to(torch.float32)
     return model
 

--- a/tests/test_architectures/test_compile.py
+++ b/tests/test_architectures/test_compile.py
@@ -68,7 +68,7 @@ def _tiny_model() -> tabpfn_v3.TabPFNV3:
         dist_embed_num_heads=3,
         feat_agg_num_heads=3,
     )
-    model = tabpfn_v3.get_architecture(config, cache_trainset_representation=False)
+    model = tabpfn_v3.get_architecture(config)
     model.to(torch.float32)
     return model
 

--- a/tests/test_architectures/test_init.py
+++ b/tests/test_architectures/test_init.py
@@ -29,8 +29,6 @@ class _FakeArchitectureModule(ArchitectureModule):
     def get_architecture(
         self,
         config: ArchitectureConfig,
-        *,
-        cache_trainset_representation: bool,
     ) -> Architecture:
         raise NotImplementedError
 

--- a/tests/test_architectures/test_tabpfn_v2.py
+++ b/tests/test_architectures/test_tabpfn_v2.py
@@ -26,7 +26,6 @@ def _build_small_arch(
             features_per_group=2,
             seed=seed,
         ),
-        cache_trainset_representation=False,
     )
     for param in model.parameters():
         if param.abs().sum() < 1e-6:

--- a/tests/test_architectures/test_tabpfn_v2_5.py
+++ b/tests/test_architectures/test_tabpfn_v2_5.py
@@ -45,9 +45,7 @@ def _create_small_v2_5(task_type: str = "multiclass") -> tabpfn_v2_5.TabPFNV2p5:
     )
 
     # Get the architectures
-    arch_v2_5 = tabpfn_v2_5.get_architecture(
-        configv2, cache_trainset_representation=False
-    )
+    arch_v2_5 = tabpfn_v2_5.get_architecture(configv2)
     for param in arch_v2_5.parameters():
         if param.abs().sum() < 1e-6:
             param.data += torch.randn_like(param) * 1e-1

--- a/tests/test_architectures/test_tabpfn_v2_6.py
+++ b/tests/test_architectures/test_tabpfn_v2_6.py
@@ -25,7 +25,7 @@ def _get_model() -> tabpfn_v2_6.TabPFNV2p6:
         features_per_group=3,
         num_thinking_rows=2,
     )
-    model = tabpfn_v2_6.get_architecture(config, cache_trainset_representation=False)
+    model = tabpfn_v2_6.get_architecture(config)
     model.to(torch.float64)
     return model
 

--- a/tests/test_architectures/test_tabpfn_v3.py
+++ b/tests/test_architectures/test_tabpfn_v3.py
@@ -34,7 +34,7 @@ def _get_model() -> tabpfn_v3.TabPFNV3:
         dist_embed_num_heads=3,
         feat_agg_num_heads=3,
     )
-    model = tabpfn_v3.get_architecture(config, cache_trainset_representation=False)
+    model = tabpfn_v3.get_architecture(config)
     model.to(torch.float32)
     return model
 
@@ -264,7 +264,7 @@ def _get_regression_model() -> tabpfn_v3.TabPFNV3:
         feat_agg_num_cls_tokens=2,
         dist_embed_num_inducing_points=8,
     )
-    model = tabpfn_v3.get_architecture(config, cache_trainset_representation=False)
+    model = tabpfn_v3.get_architecture(config)
     model.to(torch.float32)
     return model
 
@@ -373,7 +373,7 @@ def test__kv_cache__gqa_matches_standard() -> None:
         feat_agg_num_cls_tokens=2,
         dist_embed_num_inducing_points=8,
     )
-    arch = tabpfn_v3.get_architecture(config, cache_trainset_representation=False)
+    arch = tabpfn_v3.get_architecture(config)
     arch.to(torch.float32)
 
     torch.manual_seed(42)

--- a/tests/test_classifier_interface.py
+++ b/tests/test_classifier_interface.py
@@ -1011,7 +1011,6 @@ def test_initialize_model_variables_classifier_sets_required_attributes() -> Non
         initialize_tabpfn_model(
             model_path="auto",
             which="classifier",
-            fit_mode="low_memory",
         )
     )
     assert models is not None, "model should be initialized for classifier"
@@ -1385,7 +1384,6 @@ def _create_dummy_classifier_model_specs(
     )
     model = tabpfn_v2_5.get_architecture(
         config=minimal_config,
-        cache_trainset_representation=False,
     )
     inference_config = InferenceConfig.get_default(
         task_type="multiclass",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -70,8 +70,6 @@ class FakeArchitectureModule(ArchitectureModule):
     def get_architecture(
         self,
         config: ArchitectureConfig,
-        *,
-        cache_trainset_representation: bool,
     ) -> Architecture:
         raise NotImplementedError()
 

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -994,7 +994,6 @@ def test__resolve_kv_cache_precision__warns_when_unsupported() -> None:
             features_per_group=2,
             seed=0,
         ),
-        cache_trainset_representation=False,
     )
     with pytest.warns(UserWarning, match="not supported"):
         resolved = _resolve_kv_cache_precision(

--- a/tests/test_inference_config.py
+++ b/tests/test_inference_config.py
@@ -101,9 +101,7 @@ def _make_classifier_specs() -> ClassifierModelSpecs:
         nlayers=2,
         num_buckets=100,
     )
-    model = tabpfn_v2_5.get_architecture(
-        config=config, cache_trainset_representation=False
-    )
+    model = tabpfn_v2_5.get_architecture(config=config)
     inference_config = InferenceConfig.get_default(
         task_type="multiclass", model_version=ModelVersion.V2_5
     )
@@ -123,9 +121,7 @@ def _make_regressor_specs(max_num_classes: int = 10) -> RegressorModelSpecs:
         nlayers=2,
         num_buckets=100,
     )
-    model = tabpfn_v2_5.get_architecture(
-        config=config, cache_trainset_representation=False
-    )
+    model = tabpfn_v2_5.get_architecture(config=config)
     borders = torch.linspace(-3, 3, config.num_buckets + 1)
     norm_criterion = FullSupportBarDistribution(borders)
     inference_config = InferenceConfig.get_default(

--- a/tests/test_model_cache.py
+++ b/tests/test_model_cache.py
@@ -44,42 +44,19 @@ def test_cache_hit_reuses_built_model(ckpt: Path, monkeypatch: pytest.MonkeyPatc
     calls = _patch_build(monkeypatch)
     monkeypatch.setenv("TABPFN_MODEL_CACHE_SIZE", "4")
 
-    first = model_loading.load_model(
-        path=ckpt, estimator_type="classifier", cache_trainset_representation=False
-    )
-    second = model_loading.load_model(
-        path=ckpt, estimator_type="classifier", cache_trainset_representation=False
-    )
+    first = model_loading.load_model(path=ckpt, estimator_type="classifier")
+    second = model_loading.load_model(path=ckpt, estimator_type="classifier")
 
     assert first is second  # same built model handed back
     assert calls["n"] == 1  # built once, not twice
-
-
-def test_mutating_build_is_never_cached(ckpt: Path, monkeypatch: pytest.MonkeyPatch):
-    calls = _patch_build(monkeypatch)
-    monkeypatch.setenv("TABPFN_MODEL_CACHE_SIZE", "4")
-
-    # cache_trainset_representation=True mutates the model during fit, so it is
-    # rebuilt every time rather than served from the shared cache.
-    model_loading.load_model(
-        path=ckpt, estimator_type="classifier", cache_trainset_representation=True
-    )
-    model_loading.load_model(
-        path=ckpt, estimator_type="classifier", cache_trainset_representation=True
-    )
-    assert calls["n"] == 2
 
 
 def test_cache_disabled_by_default(ckpt: Path, monkeypatch: pytest.MonkeyPatch):
     calls = _patch_build(monkeypatch)
     monkeypatch.delenv("TABPFN_MODEL_CACHE_SIZE", raising=False)  # default 0 = off
 
-    model_loading.load_model(
-        path=ckpt, estimator_type="classifier", cache_trainset_representation=False
-    )
-    model_loading.load_model(
-        path=ckpt, estimator_type="classifier", cache_trainset_representation=False
-    )
+    model_loading.load_model(path=ckpt, estimator_type="classifier")
+    model_loading.load_model(path=ckpt, estimator_type="classifier")
     assert calls["n"] == 2  # no caching; prior behaviour preserved
 
 
@@ -91,30 +68,22 @@ def test_lru_eviction(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     b = tmp_path / "b.ckpt"
     b.write_bytes(b"b")
 
-    model_loading.load_model(
-        path=a, estimator_type="classifier", cache_trainset_representation=False
-    )
-    model_loading.load_model(
-        path=b, estimator_type="classifier", cache_trainset_representation=False
-    )  # evicts a
-    model_loading.load_model(
-        path=a, estimator_type="classifier", cache_trainset_representation=False
-    )  # rebuilds a
+    model_loading.load_model(path=a, estimator_type="classifier")
+    model_loading.load_model(path=b, estimator_type="classifier")  # evicts a
+    model_loading.load_model(path=a, estimator_type="classifier")  # rebuilds a
     assert calls["n"] == 3
 
 
 def test_load_model_signature_is_tracked_by_the_cache():
     """Tripwire: the cache correctness depends on `load_model`'s exact inputs.
 
-    It keys on (path, file-identity) and caches only when
-    ``cache_trainset_representation`` is False. So a *new build-affecting*
-    parameter must be added to the cache key (else a hit returns a stale model),
-    and a *new mutation flag* must extend the gate (else a mutated model gets
-    shared). If this assertion fails, revisit `_BUILT_MODEL_CACHE` / `load_model`
-    before updating the expected set.
+    It keys on (path, file-identity, estimator type), so a *new build-affecting*
+    parameter must be added to the cache key, else a hit returns a stale model.
+    If this assertion fails, revisit `_BUILT_MODEL_CACHE` / `load_model` before
+    updating the expected set.
     """
     params = set(inspect.signature(model_loading.load_model).parameters)
-    assert params == {"path", "estimator_type", "cache_trainset_representation"}, (
+    assert params == {"path", "estimator_type"}, (
         f"load_model parameters changed to {sorted(params)}; the built-model "
-        "cache key and/or its cache_trainset_representation gate must be updated."
+        "cache key must be updated."
     )

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -46,7 +46,7 @@ def test__load_model__no_architecture_name_in_checkpoint__loads_v2_architecture(
     tmp_path: Path,
 ) -> None:
     config = _get_minimal_v2_config()
-    model = tabpfn_v2.get_architecture(config, cache_trainset_representation=True)
+    model = tabpfn_v2.get_architecture(config)
     checkpoint = {"state_dict": model.state_dict(), "config": asdict(config)}
     checkpoint_path = tmp_path / "checkpoint.ckpt"
     torch.save(checkpoint, checkpoint_path)
@@ -69,8 +69,6 @@ class FakeArchitectureModule(ArchitectureModule):
     def get_architecture(
         self,
         config: ArchitectureConfig,
-        *,
-        cache_trainset_representation: bool,
     ) -> Architecture:
         return DummyArchitecture()
 
@@ -171,9 +169,7 @@ def test__load_v2_checkpoint__returns_v2_preprocessings(
     tmp_path: Path,
 ) -> None:
     architecture_config = _get_minimal_v2_config()
-    model = tabpfn_v2.get_architecture(
-        architecture_config, cache_trainset_representation=True
-    )
+    model = tabpfn_v2.get_architecture(architecture_config)
     # v2 checkpoints have no "architecture_name" key
     checkpoint = {
         "state_dict": model.state_dict(),
@@ -185,7 +181,6 @@ def test__load_v2_checkpoint__returns_v2_preprocessings(
     _, _, _, inference_config = model_loading.load_model_criterion_config(
         model_path=[checkpoint_path, checkpoint_path],
         check_bar_distribution_criterion=False,
-        cache_trainset_representation=False,
         estimator_type="classifier",
         version="v2",
         download_if_not_exists=False,
@@ -248,7 +243,6 @@ def test__load_v2_5_classification_ckpt__returns_v2_5_preprocessing(
     _, _, _, inference_config = model_loading.load_model_criterion_config(
         model_path=[checkpoint_path, checkpoint_path],
         check_bar_distribution_criterion=False,
-        cache_trainset_representation=False,
         estimator_type="classifier",
         version="v2.5",
         download_if_not_exists=False,
@@ -292,7 +286,6 @@ def test__load_v2_5_regression_ckpt__returns_v2_5_preprocessing(
     _, _, _, inference_config = model_loading.load_model_criterion_config(
         model_path=[checkpoint_path, checkpoint_path],
         check_bar_distribution_criterion=False,
-        cache_trainset_representation=False,
         estimator_type="regressor",
         version="v2.5",
         download_if_not_exists=False,
@@ -324,7 +317,7 @@ def _build_small_v3_checkpoint(
         dist_embed_num_heads=3,
         feat_agg_num_heads=3,
     )
-    model = tabpfn_v3.get_architecture(config, cache_trainset_representation=False)
+    model = tabpfn_v3.get_architecture(config)
     return {
         "state_dict": model.state_dict(),
         "config": asdict(config),
@@ -354,7 +347,6 @@ def test__load_v3_classification_ckpt__returns_inference_config_from_checkpoint(
     _, _, _, loaded_inference_config = model_loading.load_model_criterion_config(
         model_path=[checkpoint_path, checkpoint_path],
         check_bar_distribution_criterion=False,
-        cache_trainset_representation=False,
         estimator_type="classifier",
         version="v3",
         download_if_not_exists=False,
@@ -382,7 +374,6 @@ def test__load_v3_regression_ckpt__returns_bar_distribution_from_model_borders(
         model_loading.load_model_criterion_config(
             model_path=[checkpoint_path],
             check_bar_distribution_criterion=True,
-            cache_trainset_representation=False,
             estimator_type="regressor",
             version="v3",
             download_if_not_exists=False,
@@ -416,7 +407,6 @@ def test__load_multitask_ckpt__criterion_follows_the_requested_task(
         _, criterion, _, _ = model_loading.load_model_criterion_config(
             model_path=[checkpoint_path],
             check_bar_distribution_criterion=estimator_type == "regressor",
-            cache_trainset_representation=False,
             estimator_type=estimator_type,
             version="v3",
             download_if_not_exists=False,
@@ -447,7 +437,6 @@ def test__load_classification_only_ckpt__as_regressor__raises(
         model_loading.load_model_criterion_config(
             model_path=[checkpoint_path],
             check_bar_distribution_criterion=True,
-            cache_trainset_representation=False,
             estimator_type="regressor",
             version="v2.5",
             download_if_not_exists=False,
@@ -491,7 +480,6 @@ def test__load_checkpoints_with_inference_configs__returns_inference_config(
     loaded_models, _, _, loaded_config = model_loading.load_model_criterion_config(
         model_path=[checkpoint_1_path, checkpoint_2_path],
         check_bar_distribution_criterion=False,
-        cache_trainset_representation=False,
         estimator_type="classifier",
         version="v2",
         download_if_not_exists=False,
@@ -548,7 +536,6 @@ def test__load_multiple_models_with_difference_inference_configs__raises(
         model_loading.load_model_criterion_config(
             model_path=[checkpoint_1_path, checkpoint_2_path],
             check_bar_distribution_criterion=False,
-            cache_trainset_representation=False,
             estimator_type="classifier",
             version="v2",
             download_if_not_exists=False,
@@ -610,7 +597,6 @@ def test__load_model_criterion_config__parallel_downloads_do_not_crash(
         _, _, _, _ = model_loading.load_model_criterion_config(
             model_path=shared_checkpoint_path,
             check_bar_distribution_criterion=False,
-            cache_trainset_representation=False,
             estimator_type="classifier",
             version="v2",
             download_if_not_exists=True,
@@ -667,7 +653,6 @@ def test__load_ckpts_with_differing_softmax_temperatures__raises(
         model_loading.load_model_criterion_config(
             model_path=paths,
             check_bar_distribution_criterion=False,
-            cache_trainset_representation=False,
             estimator_type="classifier",
             version="v3",
             download_if_not_exists=False,
@@ -682,7 +667,6 @@ def test__load_ckpts_with_differing_softmax_temperatures__override__loads(
     loaded_models, _, _, loaded_config = model_loading.load_model_criterion_config(
         model_path=paths,
         check_bar_distribution_criterion=False,
-        cache_trainset_representation=False,
         estimator_type="classifier",
         version="v3",
         download_if_not_exists=False,
@@ -701,7 +685,6 @@ def test__load_ckpts_with_equal_softmax_temperatures__loads(tmp_path: Path) -> N
     _, _, _, loaded_config = model_loading.load_model_criterion_config(
         model_path=paths,
         check_bar_distribution_criterion=False,
-        cache_trainset_representation=False,
         estimator_type="classifier",
         version="v3",
         download_if_not_exists=False,
@@ -732,7 +715,6 @@ def test__load_ckpts_differing_beyond_softmax_temperature__raises(
         model_loading.load_model_criterion_config(
             model_path=paths,
             check_bar_distribution_criterion=False,
-            cache_trainset_representation=False,
             estimator_type="classifier",
             version="v3",
             download_if_not_exists=False,
@@ -754,7 +736,6 @@ def test__load_ckpt_without_softmax_temperature__uses_legacy_default(
     _, _, _, inference_config = model_loading.load_model_criterion_config(
         model_path=checkpoint_path,
         check_bar_distribution_criterion=False,
-        cache_trainset_representation=False,
         estimator_type="classifier",
         version="v3",
         download_if_not_exists=False,

--- a/tests/test_regressor_interface.py
+++ b/tests/test_regressor_interface.py
@@ -883,7 +883,6 @@ def test_initialize_model_variables_regressor_sets_required_attributes() -> None
         initialize_tabpfn_model(
             model_path="auto",
             which="regressor",
-            fit_mode="low_memory",
         )
     )
     assert model is not None, "model should be initialized for regressor"
@@ -1703,7 +1702,6 @@ def _create_dummy_regressor_model_specs() -> RegressorModelSpecs:
     return RegressorModelSpecs(
         model=tabpfn_v2_5.get_architecture(
             config=minimal_config,
-            cache_trainset_representation=False,
         ),
         architecture_config=minimal_config,
         inference_config=InferenceConfig.get_default(

--- a/tests/test_save_load_fitted_model.py
+++ b/tests/test_save_load_fitted_model.py
@@ -235,7 +235,7 @@ def test_saving_and_loading_model_with_weights(tmp_path: Path) -> None:
 
     # Load the model state
     models, architecture_configs, criterion, inference_config = initialize_tabpfn_model(
-        save_path, "regressor", fit_mode="low_memory"
+        save_path, "regressor"
     )
     loaded_regressor = TabPFNRegressor(
         model_path=RegressorModelSpecs(


### PR DESCRIPTION
## Issue

RES-2743 (base of #1219).

## Motivation and Context

`cache_trainset_representation` has been dead since `InferenceEngineCacheKV` was removed in #1057. Every architecture's `get_architecture` accepts it and immediately `del`s it; the KV cache is owned by the inference engine and selected at call time through `forward()`. The flag survived only because the `ArchitectureModule` protocol still declared it, which forced every implementation, every loader, and every test call site to carry it.

This removes it end to end:

- `ArchitectureModule.get_architecture(config)` no longer takes the kwarg; the four architectures drop the parameter and their "accepted for interface compatibility but ignored" notes.
- `load_model_criterion_config`, `load_model` and `_build_model` lose the parameter.
- The opt-in built-model cache (`TABPFN_MODEL_CACHE_SIZE`) no longer gates on the flag. The gate assumed a `fit_with_cache` build mutates the module, which it does not, so that fit mode now uses the cache like every other one.
- `initialize_tabpfn_model` loses its `fit_mode` argument, whose only job was computing the flag.
- Tests: every call site, the three fake `ArchitectureModule`s, the "mutating build is never cached" test, and the `load_model` signature tripwire.

#1219 is stacked on top and shrinks to keying the cache on device and dtype.

fomo-fitting side: PriorLabs/fomo-fitting#3776 drops the parameter from every architecture there. It is a draft until this merges and the tabpfn pin is bumped.

---

## Public API Changes

-   [ ] No Public API changes
-   [x] Yes, Public API changes (Details below)

- `ArchitectureModule.get_architecture` no longer accepts `cache_trainset_representation`. External architectures implementing the protocol must drop the parameter.
- `tabpfn.model_loading.load_model` and `load_model_criterion_config` no longer accept `cache_trainset_representation`.
- `tabpfn.base.initialize_tabpfn_model` no longer accepts `fit_mode`.
- With `TABPFN_MODEL_CACHE_SIZE` set, `fit_mode="fit_with_cache"` now uses the built-model cache. The default (cache off) is unchanged.

---

## How Has This Been Tested?

- ruff check / format clean.
- Cache off (shipping default): `tests/test_classifier_interface.py` and `tests/test_regressor_interface.py` pass on cpu and cuda; the touched unit files (`test_model_cache`, `test_model_loading`, `test_config`, `test_inference_config`, `test_inference`, `test_architectures/`, `test_save_load_fitted_model`) pass.
- Cache on, the interface suites fail with dtype/device collisions, as they did before this change (see #1219, which fixes that and is stacked on this PR).

---

## Checklist

-   [x] The changes have been tested locally.
-   [ ] Documentation has been updated (if the public API or usage changes).
-   [x] A changelog entry has been added (see `changelog/README.md`), or "no changelog needed" label requested.
-   [x] The code follows the project's style guidelines.
-   [x] I have considered the impact of these changes on the public API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

