### PR TITLE
Clarify and enforce categorical preprocessing contracts

### DIFF
--- a/src/tabpfn/base.py
+++ b/src/tabpfn/base.py
@@ -54,6 +54,7 @@ from tabpfn.utils import (
 from tabpfn.validation import (
     check_input_shape_matches,
     ensure_compatible_predict_input_sklearn,
+    validate_categorical_features_indices,
 )
 
 if TYPE_CHECKING:
@@ -416,20 +417,21 @@ def create_inference_engine(  # noqa: PLR0913
     raise ValueError(f"Invalid fit_mode: {fit_mode}")
 
 
-def include_category_dtype_columns(
+def resolve_categorical_features_indices(
     X: XType,
     categorical_features_indices: Sequence[int] | None,
 ) -> list[int] | None:
-    """Add the positions of `X`'s pandas `category` columns to the declared ones.
+    """Validate declared indices and merge pandas `category` column positions.
 
     A `category` dtype states the same intent as an entry in
     `categorical_features_indices`, so the two are merged here, before any column
-    moves, and the merged list drives everything downstream: the declared
-    categoricals are taken at face value, whatever their cardinality.
+    moves. The merged declarations drive date/text expansion and modality
+    detection; numeric columns remain subject to the categorical cardinality cap.
 
     Returns:
         The sorted union of both, or `None` when neither names a column.
     """
+    validate_categorical_features_indices(categorical_features_indices)
     declared = set(categorical_features_indices or ())
     if isinstance(X, pd.DataFrame):
         typed = {

--- a/src/tabpfn/base.py
+++ b/src/tabpfn/base.py
@@ -432,11 +432,12 @@ def include_category_dtype_columns(
     """
     declared = set(categorical_features_indices or ())
     if isinstance(X, pd.DataFrame):
-        declared.update(
+        typed = {
             i
             for i, dtype in enumerate(X.dtypes)
             if isinstance(dtype, pd.CategoricalDtype)
-        )
+        }
+        declared.update(typed)
     return sorted(declared) if declared else None
 
 

--- a/src/tabpfn/classifier.py
+++ b/src/tabpfn/classifier.py
@@ -209,9 +209,10 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
     """The transformer that expanded every text column before validation."""
 
     categorical_features_indices_: list[int] | None
-    """`categorical_features_indices`, plus every pandas `category` column of the
-    fit input, as positions in the validated input, where an expanded date or text
-    column has moved everything after it down."""
+    """Declared categorical column positions after date/text expansion, including
+    columns declared through pandas `category` dtype. Expanded source columns are
+    removed and their generated features appended, so these positions can differ
+    from those in the original fit input."""
 
     tuned_classification_thresholds_: npt.NDArray[Any] | None
     """The tuned classification thresholds for each class or None if no tuning is

--- a/src/tabpfn/classifier.py
+++ b/src/tabpfn/classifier.py
@@ -39,9 +39,9 @@ from tabpfn.base import (
     estimator_to_device,
     expand_dates_and_text,
     get_embeddings,
-    include_category_dtype_columns,
     initialize_model_variables_helper,
     reject_categoricals_for_differentiable_input,
+    resolve_categorical_features_indices,
     resolved_n_estimators,
     resolved_softmax_temperature,
 )
@@ -102,7 +102,6 @@ from tabpfn.validation import (
     ensure_compatible_fit_inputs,
     ensure_compatible_predict_input_sklearn,
     extract_input_shape,
-    validate_categorical_features_indices,
     validate_dataset_size,
     validate_num_classes,
 )
@@ -761,8 +760,7 @@ class TabPFNClassifier(ClassifierMixin, BaseEstimator):
         # input here, before any conversion.
         self.feature_names_in_, self.n_features_in_ = extract_input_shape(X)
 
-        validate_categorical_features_indices(self.categorical_features_indices)
-        categorical_indices = include_category_dtype_columns(
+        categorical_indices = resolve_categorical_features_indices(
             X, self.categorical_features_indices
         )
         X, date_transformer, text_transformer, feature_names, categorical_indices = (

--- a/src/tabpfn/preprocessing/modality_detection.py
+++ b/src/tabpfn/preprocessing/modality_detection.py
@@ -138,6 +138,10 @@ def _detect_feature_modality(
     big_enough_n_to_infer_cat: bool,
 ) -> FeatureModality:
     """Decide a single column's modality via heuristics."""
+    assert not isinstance(s.dtype, pd.CategoricalDtype), (
+        "Categorical dtype must be converted before modality detection; "
+        "preserve its intent in provided_categorical_indices."
+    )
     # Early exit: once a prefix already clears every threshold below, the full
     # count would land in the same bucket, so skip scanning the rest.
     # min_cardinality_for_text is included since it can exceed the other two.

--- a/src/tabpfn/regressor.py
+++ b/src/tabpfn/regressor.py
@@ -248,9 +248,10 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
     """The transformer that expanded every text column before validation."""
 
     categorical_features_indices_: list[int] | None
-    """`categorical_features_indices`, plus every pandas `category` column of the
-    fit input, as positions in the validated input, where an expanded date or text
-    column has moved everything after it down."""
+    """Declared categorical column positions after date/text expansion, including
+    columns declared through pandas `category` dtype. Expanded source columns are
+    removed and their generated features appended, so these positions can differ
+    from those in the original fit input."""
 
     eval_metric_: RegressorEvalMetrics
     """The validated evaluation metric to optimize for during prediction."""

--- a/src/tabpfn/regressor.py
+++ b/src/tabpfn/regressor.py
@@ -47,9 +47,9 @@ from tabpfn.base import (
     estimator_to_device,
     expand_dates_and_text,
     get_embeddings,
-    include_category_dtype_columns,
     initialize_model_variables_helper,
     reject_categoricals_for_differentiable_input,
+    resolve_categorical_features_indices,
     resolved_n_estimators,
     resolved_softmax_temperature,
 )
@@ -107,7 +107,6 @@ from tabpfn.validation import (
     ensure_compatible_fit_inputs,
     ensure_compatible_predict_input_sklearn,
     extract_input_shape,
-    validate_categorical_features_indices,
     validate_dataset_size,
 )
 
@@ -904,8 +903,7 @@ class TabPFNRegressor(RegressorMixin, BaseEstimator):
         # input here, before any conversion.
         self.feature_names_in_, self.n_features_in_ = extract_input_shape(X)
 
-        validate_categorical_features_indices(self.categorical_features_indices)
-        categorical_indices = include_category_dtype_columns(
+        categorical_indices = resolve_categorical_features_indices(
             X, self.categorical_features_indices
         )
         X, date_transformer, text_transformer, feature_names, categorical_indices = (

--- a/tests/test_preprocessing/test_modality_detection.py
+++ b/tests/test_preprocessing/test_modality_detection.py
@@ -277,6 +277,15 @@ def test__detected_categorical_without_reporting():
     assert result == FeatureModality.CATEGORICAL
 
 
+@pytest.mark.parametrize("values", [["a", "b", "a"], [1, 2, 1]])
+def test__detect_for_categorical_with_category_dtype__rejects_unconverted_input(
+    values: list,
+) -> None:
+    s = pd.Series(values, dtype="category")
+    with pytest.raises(AssertionError, match="Categorical dtype must be converted"):
+        _for_test_detect_with_defaults(s)
+
+
 def test__detect_textual_feature():
     s = pd.Series(["a", "b", "c", "a", "b", "c"])
     result = _for_test_detect_with_defaults(s, min_cardinality_for_text=2)


### PR DESCRIPTION
## Issue
Follow-up to Alan's review of #1245, stacked on `declared-categoricals-are-never-text`.

## Motivation and Context
Categorical declarations currently require separate validation and dtype-merging calls in both estimators, and modality detection relies on a comment to exclude unconverted pandas categorical dtypes.

This follow-up centralizes validation and merging in `resolve_categorical_features_indices`, validates before normalization, and names the dtype-derived indices `typed`. It asserts that modality detection receives converted values and restores the dtype test for both string and numeric categories. The fitted-index docstrings now explain that expanded source columns are removed and generated features appended.

The numeric declaration cardinality policy remains unchanged. Honoring numeric declarations unconditionally is a separate behavior change to discuss, as suggested in the parent review.

## Public API Changes
- [x] No Public API changes

## How Has This Been Tested?
- Both affected preprocessing modules and the classifier/regressor invalid-index tests: **126 passed, 4 skipped**.
- Ruff lint and formatting checks passed.
- `git diff --check` passed.

## Checklist
- [x] The changes have been tested locally.
- [x] Documentation has been updated.
- [x] No separate changelog entry: this follow-up will merge into #1245, which already includes one.
- [x] The code follows the project's style guidelines.
- [x] I have considered the impact of these changes on the public API.

