### PR TITLE
Build models from a checkpoint without the random parameter initialisation

### DIFF
--- a/changelog/1257.changed.md
+++ b/changelog/1257.changed.md
@@ -1,0 +1,1 @@
+Building a model from a checkpoint no longer runs torch's random parameter initialisation before the weights are loaded, which cuts the per-fit model construction from about a quarter of a second to a few tens of milliseconds on a full-size checkpoint. The loaded model is unchanged.

--- a/src/tabpfn/model_loading.py
+++ b/src/tabpfn/model_loading.py
@@ -17,6 +17,7 @@ import urllib.request
 import warnings
 import zipfile
 from collections import OrderedDict
+from contextlib import contextmanager
 from dataclasses import asdict, dataclass
 from enum import Enum
 from importlib import import_module
@@ -43,7 +44,7 @@ from tabpfn.inference_config import (
 from tabpfn.settings import settings
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterator
 
     from sklearn.base import BaseEstimator
 
@@ -1053,6 +1054,52 @@ def load_model(
     return result
 
 
+#: The `torch.nn.init` functions that `_skip_parameter_init` turns into no-ops.
+_PARAMETER_INIT_FUNCTIONS = (
+    "uniform_",
+    "normal_",
+    "trunc_normal_",
+    "constant_",
+    "ones_",
+    "zeros_",
+    "eye_",
+    "orthogonal_",
+    "xavier_uniform_",
+    "xavier_normal_",
+    "kaiming_uniform_",
+    "kaiming_normal_",
+)
+
+
+@contextmanager
+def _skip_parameter_init() -> Iterator[None]:
+    """Build a model without torch's random parameter initialisation.
+
+    Every parameter and persistent buffer of a model built here is overwritten by the
+    strict `load_state_dict` that follows, so the initialisation is wasted work: the
+    layers' `reset_parameters` draw random weights that are discarded, about a quarter
+    of a second per build on a full-size checkpoint, paid at every `fit`. For the
+    duration of the block the `torch.nn.init` functions return their tensor untouched;
+    they are restored afterwards. A model built inside it must be loaded before use.
+    """
+    originals = {
+        name: getattr(torch.nn.init, name) for name in _PARAMETER_INIT_FUNCTIONS
+    }
+
+    def leave_uninitialised(
+        tensor: torch.Tensor, *_args: Any, **_kwargs: Any
+    ) -> torch.Tensor:
+        return tensor
+
+    for name in originals:
+        setattr(torch.nn.init, name, leave_uninitialised)
+    try:
+        yield
+    finally:
+        for name, original in originals.items():
+            setattr(torch.nn.init, name, original)
+
+
 def _build_model(
     resolved: str,
     identity: tuple[int, int],
@@ -1081,10 +1128,11 @@ def _build_model(
         "Keys in config that were not parsed by architecture config: "
         f"{', '.join(unused_model_config.keys())}"
     )
-    model = architecture.get_architecture(
-        model_config,
-        cache_trainset_representation=cache_trainset_representation,
-    )
+    with _skip_parameter_init():
+        model = architecture.get_architecture(
+            model_config,
+            cache_trainset_representation=cache_trainset_representation,
+        )
 
     # A checkpoint may carry criterion state for a task it is not being loaded for
     # (save_tabpfn_model writes it for regressors), so it is always kept out of the

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -858,3 +858,53 @@ def test__load_ckpt_without_softmax_temperature__uses_legacy_default(
     )
 
     assert inference_config.SOFTMAX_TEMPERATURE == DEFAULT_SOFTMAX_TEMPERATURE == 0.9
+
+
+@pytest.mark.parametrize("architecture_name", ["tabpfn_v2", "tabpfn_v3"])
+def test__load_model__skips_the_random_init_and_matches_the_checkpoint(
+    tmp_path: Path, architecture_name: str
+) -> None:
+    """A model built without parameter initialisation matches the checkpoint exactly."""
+    if architecture_name == "tabpfn_v2":
+        config = _get_minimal_v2_config()
+        source = tabpfn_v2.get_architecture(config, cache_trainset_representation=False)
+        checkpoint = {"state_dict": source.state_dict(), "config": asdict(config)}
+    else:
+        inference_config = InferenceConfig.get_default("multiclass", ModelVersion.V2_5)
+        checkpoint = _build_small_v3_checkpoint(inference_config, max_num_classes=10)
+        source = tabpfn_v3.get_architecture(
+            TabPFNV3Config(**checkpoint["config"]), cache_trainset_representation=False
+        )
+        source.load_state_dict(checkpoint["state_dict"])
+    checkpoint_path = tmp_path / "checkpoint.ckpt"
+    torch.save(checkpoint, checkpoint_path)
+
+    loaded, *_ = model_loading.load_model(
+        path=checkpoint_path,
+        estimator_type="classifier",
+        cache_trainset_representation=False,
+    )
+    source_params = dict(source.named_parameters())
+    loaded_params = dict(loaded.named_parameters())
+    assert loaded_params.keys() == source_params.keys()
+    for name, parameter in source_params.items():
+        torch.testing.assert_close(loaded_params[name], parameter, rtol=0, atol=0)
+    source_buffers = dict(source.named_buffers())
+    loaded_buffers = dict(loaded.named_buffers())
+    assert loaded_buffers.keys() == source_buffers.keys()
+    for name, buffer in source_buffers.items():
+        torch.testing.assert_close(loaded_buffers[name], buffer, rtol=0, atol=0)
+
+
+def test__skip_parameter_init__is_scoped_to_the_block() -> None:
+    """Inside the block the init functions leave tensors alone; outside they work."""
+    tensor = torch.ones(3)
+    with model_loading._skip_parameter_init():
+        torch.nn.init.zeros_(tensor)
+        assert torch.equal(tensor, torch.ones(3))
+        layer = nn.Linear(
+            2, 2
+        )  # built inside: allocated, not initialised, still usable
+        assert layer.weight.shape == (2, 2)
+    torch.nn.init.zeros_(tensor)
+    assert torch.equal(tensor, torch.zeros(3))


### PR DESCRIPTION
Stacked on #1255.

`_build_model` constructs the architecture and then loads the checkpoint with a strict `load_state_dict`, which overwrites every parameter and persistent buffer. The construction still ran every layer's `reset_parameters`, drawing random weights only to discard them: about a quarter of a second per build on a full-size checkpoint, paid at every `fit` and, under bagging, at every child.

The architecture is now built inside a small context manager that turns the `torch.nn.init` functions into no-ops for the duration and restores them afterwards, so the tensors are allocated but not filled before the load. The result is the same model: the architectures register no non-persistent buffers, and the tensors they initialise themselves are parameters, so all of them come from the checkpoint. A test loads small v2 and v3 checkpoints and checks that every named parameter and buffer equals the source model's exactly; a second test checks the patch is scoped to the block.

On an 83.5M-parameter checkpoint the build goes from 287 ms to 19 ms, most of the remainder being the state-dict copy; the reference-prediction consistency tests pass unchanged. One caveat for reviewers: the context manager patches module-level functions, so a model constructed concurrently in another thread of the same process during that window would also skip its initialisation. The library builds models on the calling thread, and the parallel paths use separate processes, so no such window exists in the code as it stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi
