### PR TITLE
Faster frozen encoder, KDI fit and dtype fixing in the per-member preprocessing

### DIFF
--- a/changelog/1265.changed.md
+++ b/changelog/1265.changed.md
@@ -1,0 +1,1 @@
+Faster per-ensemble-member preprocessing: the frozen ordinal encoder in `clean_data` reads category codes instead of going through sklearn, `KDITransformerWithNaN` reads its quantile grid off the already-sorted column and computes the bandwidth constant once per fit, and `fix_dtypes` builds the cleaned frame with its category columns in one pass. Outputs are unchanged.

--- a/src/tabpfn/preprocessing/clean.py
+++ b/src/tabpfn/preprocessing/clean.py
@@ -355,8 +355,8 @@ def _align_columns_to_fitted_dtypes(
     as that fit-time dtype at predict. Two mismatches are handled:
 
     * string at fit, numeric at predict -> the column is cast to ``string``. Otherwise
-      sklearn's ``_check_unknown`` takes its numeric branch and compares float values
-      against the string ``categories_``, raising a ``TypeError``.
+      the float values are looked up against the string ``categories_`` and none of
+      them matches.
     * numeric at fit, string at predict -> the column is cast to numeric via
       ``pd.to_numeric(..., errors="coerce")``. Numeric-looking strings match their fit
       category; non-numeric strings become ``NaN`` (treated as missing).

--- a/src/tabpfn/preprocessing/clean.py
+++ b/src/tabpfn/preprocessing/clean.py
@@ -248,21 +248,7 @@ def fix_dtypes(  # noqa: D103
         # This will help us get better dtype inference later
         convert_dtype = True
     elif isinstance(X, np.ndarray):
-        if X.dtype.kind in NUMERIC_DTYPE_KINDS:
-            # It's a numeric type, just wrap the array in pandas with the correct dtype
-            X = pd.DataFrame(X, copy=False, dtype=numeric_dtype)
-            convert_dtype = False
-        elif X.dtype.kind in OBJECT_OR_STRING_DTYPE_KINDS:
-            # For an object or string array we rely on pandas to introspect the
-            # cells and determine each column's dtype.
-            X = pd.DataFrame(X, copy=True)
-            convert_dtype = True
-        elif X.dtype.kind in BYTES_DTYPE_KINDS:
-            raise ValueError(
-                f"Byte string dtypes are not supported. Got dtype: {X.dtype}",
-            )
-        else:
-            raise ValueError(f"Invalid dtype for X: {X.dtype}")
+        X, convert_dtype, cat_indices = _frame_from_array(X, cat_indices, numeric_dtype)
     else:
         raise ValueError(f"Invalid type for X: {type(X)}")
 
@@ -321,6 +307,46 @@ def fix_dtypes(  # noqa: D103
     ):
         X = _cast_columns(X, numerical_columns, numeric_dtype)
     return X
+
+
+def _frame_from_array(
+    X: np.ndarray,
+    cat_indices: Sequence[int | str] | None,
+    numeric_dtype: Literal["float32", "float64"],
+) -> tuple[pd.DataFrame, bool, Sequence[int | str] | None]:
+    """`X` as a frame, whether its dtypes still need inferring, and the categorical
+    columns still to be cast (None once the frame already holds them as category).
+    """
+    if X.dtype.kind in NUMERIC_DTYPE_KINDS:
+        # It's a numeric type, just wrap the array in pandas with the correct dtype
+        return pd.DataFrame(X, copy=False, dtype=numeric_dtype), False, cat_indices
+    if X.dtype.kind in OBJECT_OR_STRING_DTYPE_KINDS:
+        # For an object or string array we rely on pandas to introspect the cells and
+        # determine each column's dtype.
+        if cat_indices is not None and all(
+            isinstance(i, (int, np.integer)) for i in cat_indices
+        ):
+            return _frame_with_categoricals(X, cat_indices), True, None
+        return pd.DataFrame(X, copy=True), True, cat_indices
+    if X.dtype.kind in BYTES_DTYPE_KINDS:
+        raise ValueError(f"Byte string dtypes are not supported. Got dtype: {X.dtype}")
+    raise ValueError(f"Invalid dtype for X: {X.dtype}")
+
+
+def _frame_with_categoricals(
+    X: np.ndarray, cat_indices: Sequence[int | np.integer]
+) -> pd.DataFrame:
+    """`pd.DataFrame(X, copy=True)` with the columns at `cat_indices` cast to category.
+
+    Each column is built once, which is cheaper than casting them inside the frame
+    afterwards, where every column goes through the block manager on its own.
+    """
+    categorical = {int(i) for i in cat_indices}
+    columns = {
+        i: pd.Categorical(X[:, i]) if i in categorical else X[:, i].copy()
+        for i in range(X.shape[1])
+    }
+    return pd.DataFrame(columns, columns=pd.RangeIndex(X.shape[1]), copy=False)
 
 
 def _column_kind(dtype: Any) -> str:

--- a/src/tabpfn/preprocessing/modality_detection.py
+++ b/src/tabpfn/preprocessing/modality_detection.py
@@ -162,7 +162,9 @@ def _detect_feature_modality(
         min_cardinality_for_text=min_cardinality_for_text,
     )
     n_unique = 0
-    if len(s) > _EARLY_EXIT_PREFIX_ROWS:
+    # The prefix pass only pays off when it can save most of a long column; a column
+    # not much longer than the prefix is counted once, in full.
+    if len(s) > 2 * _EARLY_EXIT_PREFIX_ROWS:
         n_unique = _get_unique_with_sklearn_compatible_error(
             s.iloc[:_EARLY_EXIT_PREFIX_ROWS]
         )
@@ -307,7 +309,8 @@ def _is_numeric_pandas_series(s: pd.Series) -> bool:
     if pd.api.types.infer_dtype(s, skipna=True) in _INFERRED_NUMERIC_KINDS:
         return True
     if PANDAS_BELOW_3:
-        return all(_is_numeric_or_missing_for_old_pandas(value) for value in s)
+        # Over a list rather than the Series: iterating a Series is the slow part.
+        return all(map(_is_numeric_or_missing_for_old_pandas, s.tolist()))
     # The generator above stops at the first non-numeric value; `pd.to_numeric`
     # coerces the whole column first, so reject on a prefix instead: one
     # non-numeric value anywhere settles the answer, so a prefix that already

--- a/src/tabpfn/preprocessing/steps/kdi_transformer.py
+++ b/src/tabpfn/preprocessing/steps/kdi_transformer.py
@@ -8,12 +8,21 @@ import warnings
 from typing import Any
 
 import numpy as np
+import scipy.interpolate as spip
+import scipy.stats as spst
 import torch
+from scipy import integrate
+from scipy.special import ndtri
 from sklearn.preprocessing import PowerTransformer
 
 try:
     from kditransform import KDITransformer
+    from kditransform.kdi_transformer import BOUNDS_THRESHOLD
+    from kditransform.ksum import betas_for_order, h_Gauss_to_K, ksum_numba
 
+    # `norm.ppf(BOUNDS_THRESHOLD - spacing(1))` and its mirror, computed once.
+    _NORMAL_CLIP_MIN = float(ndtri(BOUNDS_THRESHOLD - np.spacing(1)))
+    _NORMAL_CLIP_MAX = float(ndtri(1 - (BOUNDS_THRESHOLD - np.spacing(1))))
     # This import fails on some systems, due to problems with numba
 except ImportError:
     KDITransformer = PowerTransformer  # fallback to avoid error
@@ -136,6 +145,188 @@ class KDITransformerWithNaN(KDITransformer):
         """Fit the transformer and transform the data."""
         self.fit(X, y)
         return self.transform(X)
+
+    # The two methods below mirror `kditransform.KDITransformer`'s and must give the
+    # same output to the last bit; `tests/test_preprocessing/test_kdi_transformer.py`
+    # checks that against the upstream class. They differ only in how the numbers are
+    # reached: the quantiles of the kernel density come from the column already sorted
+    # for the kernel sum instead of a second `np.quantile` pass, the bandwidth
+    # conversion constant is computed once instead of per column, and the normal
+    # output distribution goes through `ndtri` directly instead of `norm.ppf`.
+
+    def _polyexp_dense_fit(  # noqa: C901
+        self, X: np.ndarray, alphas: list, random_state: np.random.RandomState
+    ) -> None:
+        n_samples, _n_features = X.shape
+        wgts = np.ones(n_samples).astype(X.dtype)
+        betas = betas_for_order(self.polyexp_order)
+        # `h_Gauss_to_K(h, betas)` is `h` times a constant of `betas`.
+        h_to_k = h_Gauss_to_K(1.0, betas)
+
+        if self.polyexp_eval == "uniform":
+            n_eval = n_samples if self.n_quantiles is None else self.n_quantiles
+        elif self.polyexp_eval == "train":
+            n_eval = n_samples + (n_samples - 1) * 1
+        elif self.polyexp_eval == "auto":
+            n_eval = (
+                n_samples if self.n_quantiles is None else self.n_quantiles
+            ) + self.n_quantiles_
+
+        density_out = np.zeros(n_eval).astype(X.dtype)
+        counts = np.zeros(n_eval).astype(np.int64)
+        coefs = np.zeros_like(betas)
+        Ly = np.zeros((self.polyexp_order + 1, n_samples), order="C")
+        Ry = np.zeros((self.polyexp_order + 1, n_samples), order="C")
+
+        quantiles_per_column = []
+        for column, bandwidth in zip(X.T, alphas, strict=False):
+            col = column
+            alpha = bandwidth
+            if self.subsample_ < n_samples:
+                subsample_idx = random_state.choice(
+                    n_samples, size=self.subsample_, replace=False
+                )
+                col = col.take(subsample_idx, mode="clip")
+            if np.var(col) == 0:
+                quantiles = col[0] * np.ones_like(self.references_)
+            else:
+                xmin = np.min(col)
+                xmax = np.max(col)
+                if alpha == "scott":
+                    alpha = np.power(n_samples, (-1.0 / (1 + 4)))
+                elif alpha == "silverman":
+                    alpha = np.power(n_samples * (1 + 2.0) / 4.0, -1.0 / (1 + 4))
+                h = alpha * np.std(col) * h_to_k
+                col_mean = np.mean(col)
+                col -= col_mean
+                col_sort = np.sort(col)
+                if self.polyexp_eval == "uniform":
+                    col_eval = np.linspace(np.min(col), np.max(col), n_eval)
+                elif self.polyexp_eval == "train":
+                    midpts = col_sort[:-1] + 0.50 * np.diff(col_sort)
+                    col_eval = np.sort(np.concatenate([col_sort, midpts]))
+                elif self.polyexp_eval == "auto":
+                    col_u = np.linspace(
+                        np.min(col),
+                        np.max(col),
+                        n_samples if self.n_quantiles is None else self.n_quantiles,
+                    )
+                    col_s = _sorted_quantile_linear(col_sort, self.references_)
+                    col_eval = np.sort(np.concatenate([col_u, col_s]))
+                    assert len(col_eval) == n_eval
+
+                ksum_numba(
+                    col_sort,
+                    wgts,
+                    col_eval,
+                    h,
+                    betas,
+                    density_out,
+                    counts,
+                    coefs,
+                    Ly,
+                    Ry,
+                )
+                density_out /= n_samples * h
+                density_out[np.isnan(density_out)] = 1e-300
+                density_out[~np.isfinite(density_out)] = 1e-300
+                col += col_mean
+                col_sort += col_mean
+                col_eval += col_mean
+                T = integrate.cumulative_trapezoid(density_out, col_eval, initial=0)
+                intcx1 = 0.0
+                intcxN = T[-1]
+                m = 1.0 / (intcxN - intcx1)
+                b = -m * intcx1
+                T = m * T + b
+
+                inverse_func = spip.interp1d(
+                    T, col_eval, bounds_error=False, fill_value=(xmin, xmax)
+                )
+                quantiles = inverse_func(self.references_)
+            quantiles_per_column.append(quantiles)
+        self.quantiles_ = np.transpose(quantiles_per_column)
+        # Make sure that quantiles are monotonically increasing
+        self.quantiles_ = np.maximum.accumulate(self.quantiles_, axis=0)
+
+    def _transform_col(
+        self,
+        X_col: np.ndarray,
+        quantiles: np.ndarray,
+        inverse: bool,  # noqa: FBT001  called positionally by the base class
+    ) -> np.ndarray:
+        output_distribution = self.output_distribution
+
+        if not inverse:
+            lower_bound_x = quantiles[0]
+            upper_bound_x = quantiles[-1]
+            lower_bound_y = 0
+            upper_bound_y = 1
+        else:
+            lower_bound_x = 0
+            upper_bound_x = 1
+            lower_bound_y = quantiles[0]
+            upper_bound_y = quantiles[-1]
+            # for inverse transform, match a uniform distribution
+            with np.errstate(invalid="ignore"):  # hide NaN comparison warnings
+                if output_distribution == "normal":
+                    X_col = spst.norm.cdf(X_col)
+                # else output distribution is already a uniform distribution
+
+        # find index for lower and higher bounds
+        with np.errstate(invalid="ignore"):  # hide NaN comparison warnings
+            if output_distribution == "normal":
+                lower_bounds_idx = X_col - BOUNDS_THRESHOLD < lower_bound_x
+                upper_bounds_idx = X_col + BOUNDS_THRESHOLD > upper_bound_x
+            if output_distribution == "uniform":
+                lower_bounds_idx = X_col == lower_bound_x
+                upper_bounds_idx = X_col == upper_bound_x
+
+        isfinite_mask = ~np.isnan(X_col)
+        X_col_finite = X_col[isfinite_mask]
+        if not inverse:
+            # Interpolate in one direction and in the other and take the mean, so
+            # repeated values (and hence repeated quantiles) use both extremes.
+            X_col[isfinite_mask] = 0.5 * (
+                np.interp(X_col_finite, quantiles, self.references_)
+                - np.interp(-X_col_finite, -quantiles[::-1], -self.references_[::-1])
+            )
+        else:
+            X_col[isfinite_mask] = np.interp(X_col_finite, self.references_, quantiles)
+
+        X_col[upper_bounds_idx] = upper_bound_y
+        X_col[lower_bounds_idx] = lower_bound_y
+        # for forward transform, match the output distribution
+        if not inverse:
+            with np.errstate(invalid="ignore"):  # hide NaN comparison warnings
+                if output_distribution == "normal":
+                    X_col = ndtri(X_col)
+                    # clip so the inverse transform stays consistent instead of
+                    # mapping to infinity
+                    X_col = np.clip(X_col, _NORMAL_CLIP_MIN, _NORMAL_CLIP_MAX)
+                # else output distribution is uniform and the ppf is the identity
+
+        return X_col
+
+
+def _sorted_quantile_linear(col_sort: np.ndarray, q: np.ndarray) -> np.ndarray:
+    """`np.quantile(col, q)` (linear method) read off the already sorted column.
+
+    Reproduces numpy's arithmetic, including its `t >= 0.5` branch of the
+    interpolation, so the result is bit-identical.
+    """
+    n = len(col_sort)
+    virtual = q * (n - 1)
+    previous = np.floor(virtual)
+    gamma = virtual - previous
+    previous = previous.astype(np.intp)
+    following = np.minimum(previous + 1, n - 1)
+    lower = col_sort[previous]
+    upper = col_sort[following]
+    diff = upper - lower
+    out = lower + diff * gamma
+    np.subtract(upper, diff * (1 - gamma), out=out, where=gamma >= 0.5)
+    return out
 
 
 def get_all_kdi_transformers() -> dict[str, KDITransformerWithNaN]:

--- a/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
+++ b/src/tabpfn/preprocessing/steps/preprocessing_helpers.py
@@ -12,11 +12,13 @@ import pandas as pd
 from scipy import sparse
 from sklearn import get_config
 from sklearn.base import (
+    BaseEstimator,
     OneToOneFeatureMixin,
+    TransformerMixin,
     check_is_fitted,
 )
 from sklearn.compose import ColumnTransformer, make_column_selector
-from sklearn.preprocessing import FunctionTransformer, OrdinalEncoder
+from sklearn.preprocessing import FunctionTransformer
 
 from tabpfn.constants import DEFAULT_NUMPY_PREPROCESSING_DTYPE
 from tabpfn.preprocessing.steps.utils import is_identity_transformer
@@ -550,19 +552,146 @@ class OrderPreservingColumnTransformer(EfficientColumnTransformer):
         return names[self._stacked_positions(list(original_columns))]
 
 
+class CategoryOrdinalEncoder(OneToOneFeatureMixin, TransformerMixin, BaseEstimator):
+    """Ordinal codes for category and string columns, computed with pandas.
+
+    Same output as sklearn's `OrdinalEncoder(categories="auto",
+    handle_unknown="use_encoded_value", unknown_value=-1,
+    encoded_missing_value=np.nan)`: a column's sorted distinct values become
+    `0..k-1`, a value unseen at fit becomes -1,
+    and a missing value becomes NaN where the column had missing values at fit and -1
+    where it had none. `categories_` lists each column's values in that order, missing
+    last, in the dtype of the column's values (object for strings, numeric for numeric
+    categories), which the dtype alignment at predict reads. sklearn's encoder extracts
+    and validates every column separately on each call, which on a table of a few
+    hundred rows dwarfs the encoding; this one reads a category column's codes directly
+    and looks the rest up in a `pd.Index`.
+    """
+
+    def __init__(self, dtype: Any = np.float64):
+        self.dtype = dtype
+
+    def fit(self, X: XType, y: Any = None) -> Self:
+        """Record each column's sorted distinct values, missing last."""
+        del y
+        self._fit(_as_frame(X), encode=False)
+        return self
+
+    def fit_transform(self, X: XType, y: Any = None) -> np.ndarray:
+        """Fit and encode in one pass over the columns."""
+        del y
+        return self._fit(_as_frame(X), encode=True)
+
+    def transform(self, X: XType) -> np.ndarray:
+        """Map each value to its category's position; -1 if unseen, NaN if missing."""
+        X = _as_frame(X)
+        encoded = np.empty(X.shape, dtype=self.dtype)
+        for position, (_, column) in enumerate(X.items()):
+            known = self._known[position]
+            missing_code = self._missing_code[position]
+            if isinstance(column.dtype, pd.CategoricalDtype):
+                # Position of each of the column's own categories among the fitted
+                # ones, then one gather over the codes.
+                lookup = pd.Index(known).get_indexer(np.asarray(column.cat.categories))
+                encoded[:, position] = self._gather(
+                    column.cat.codes.to_numpy(), lookup, missing_code
+                )
+            else:
+                values = column.to_numpy()
+                out = pd.Index(known).get_indexer(values).astype(self.dtype)
+                out[pd.isna(values)] = missing_code
+                encoded[:, position] = out
+        return encoded
+
+    def _fit(self, X: pd.DataFrame, *, encode: bool) -> np.ndarray | None:
+        self.n_features_in_ = X.shape[1]
+        if all(isinstance(name, str) for name in X.columns):
+            self.feature_names_in_ = np.asarray(X.columns, dtype=object)
+        self.categories_: list[np.ndarray] = []
+        self._known: list[np.ndarray] = []
+        # What a missing value encodes to per column: NaN where the column had missing
+        # values at fit (they are then a category of their own), -1 (unseen) otherwise.
+        self._missing_code: list[float] = []
+        encoded = np.empty(X.shape, dtype=self.dtype) if encode else None
+        for position, (_, column) in enumerate(X.items()):
+            is_categorical = isinstance(column.dtype, pd.CategoricalDtype)
+            if is_categorical:
+                # The codes already say which categories occur; a `Categorical` holds
+                # every kind of missing value as NaN.
+                codes = column.cat.codes.to_numpy()
+                used = np.unique(codes)
+                has_missing = bool(len(used)) and used[0] < 0
+                used = used[1:] if has_missing else used
+                present = np.asarray(column.cat.categories)[used]
+                missing: list[Any] = [np.nan] if has_missing else []
+            else:
+                values = column.to_numpy()
+                missing_mask = pd.isna(values)
+                present = values[~missing_mask]
+                missing_values = values[missing_mask].tolist()
+                missing = []
+                if any(value is None for value in missing_values):
+                    missing.append(None)
+                if any(value is not None for value in missing_values):
+                    missing.append(np.nan)
+            known = _sorted_distinct(present)
+            if present.dtype == object:
+                categories = np.array(list(known) + missing, dtype=object)
+            else:
+                categories = np.append(known, np.nan) if missing else known
+            missing_code = np.nan if missing else -1.0
+            self.categories_.append(categories)
+            self._known.append(known)
+            self._missing_code.append(missing_code)
+            if encoded is None:
+                continue
+            if is_categorical:
+                # Every used category is known, so its rank among them is its code.
+                rank = {value: index for index, value in enumerate(known.tolist())}
+                lookup = np.full(len(column.cat.categories), -1)
+                lookup[used] = [rank[value] for value in present.tolist()]
+                encoded[:, position] = self._gather(codes, lookup, missing_code)
+            else:
+                out = pd.Index(known).get_indexer(values).astype(self.dtype)
+                out[missing_mask] = missing_code
+                encoded[:, position] = out
+        return encoded
+
+    def _gather(
+        self, codes: np.ndarray, lookup: np.ndarray, missing_code: float
+    ) -> np.ndarray:
+        """`lookup[codes]`, with the missing code (-1) mapped to `missing_code`."""
+        out = np.full(len(codes), missing_code, dtype=self.dtype)
+        seen = codes >= 0
+        out[seen] = lookup[codes[seen]]
+        return out
+
+
+def _sorted_distinct(present: np.ndarray) -> np.ndarray:
+    """`present`'s distinct values in sorted order, as sklearn's encoder orders them."""
+    if present.dtype != object:
+        return np.unique(present)
+    try:
+        return np.array(sorted(set(present.tolist())), dtype=object)
+    except TypeError as error:
+        types = sorted({type(value).__qualname__ for value in present})
+        raise TypeError(
+            "Encoders require their input argument must be uniformly strings or "
+            f"numbers. Got {types}"
+        ) from error
+
+
+def _as_frame(X: XType) -> pd.DataFrame:
+    """`X` as a frame, so columns can be read one at a time with their dtype."""
+    return X if isinstance(X, pd.DataFrame) else pd.DataFrame(X)
+
+
 def get_ordinal_encoder(
     *,
     numpy_dtype: np.floating = DEFAULT_NUMPY_PREPROCESSING_DTYPE,  # type: ignore
 ) -> OrderPreservingColumnTransformer:
     """Create a ColumnTransformer that ordinally encodes string/category columns."""
-    oe = OrdinalEncoder(
-        # TODO: Could utilize the categorical dtype values directly instead of "auto"
-        categories="auto",
-        dtype=numpy_dtype,  # type: ignore
-        handle_unknown="use_encoded_value",
-        unknown_value=-1,
-        encoded_missing_value=np.nan,  # Missing stays missing
-    )
+    oe = CategoryOrdinalEncoder(dtype=numpy_dtype)
     # Documentation of sklearn, deferring to pandas is misleading here. It's done
     # using a regex on the type of the column, and using `object`, `"object"` and
     # `np.object` will not pick up strings.

--- a/tests/test_preprocessing/test_data_cleaning.py
+++ b/tests/test_preprocessing/test_data_cleaning.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import warnings
 from unittest import mock
 
 import numpy as np
@@ -27,6 +28,7 @@ from tabpfn.preprocessing.clean import (
 )
 from tabpfn.preprocessing.datamodel import Feature, FeatureModality, FeatureSchema
 from tabpfn.preprocessing.steps.preprocessing_helpers import (
+    CategoryOrdinalEncoder,
     EfficientColumnTransformer,
     get_ordinal_encoder,
 )
@@ -1060,9 +1062,9 @@ def test__clean_data__object_passthrough_falls_back_to_the_encoder() -> None:
     # The real call still works, through sklearn, and learns the categories exactly
     # once. Declining the assembly *after* fitting them would pay for a second pass
     # over the data and then discard it, since `fit_transform` fits again itself.
-    unpatched_fit = OrdinalEncoder.fit
+    unpatched_fit = CategoryOrdinalEncoder._fit
     with mock.patch.object(
-        OrdinalEncoder, "fit", autospec=True, side_effect=unpatched_fit
+        CategoryOrdinalEncoder, "_fit", autospec=True, side_effect=unpatched_fit
     ) as fitted:
         out = process_text_na_dataframe(
             frame, ord_encoder=get_ordinal_encoder(), fit_encoder=True
@@ -1372,3 +1374,103 @@ def test__coerce_nullable_dtypes_to_numpy__selects_by_dtype() -> None:
             assert out[c].dtype == X[c].dtype, c
     assert list(out.columns) == list(X.columns)
     assert out["boolean"].isna().tolist() == [False, True, False]
+
+
+# ---------------------------------------------------------------------------
+# The pandas ordinal encoder against the sklearn encoder it replaces
+# ---------------------------------------------------------------------------
+
+
+def _sklearn_frozen_encoder() -> OrdinalEncoder:
+    """The encoder `get_ordinal_encoder` used to wrap."""
+    return OrdinalEncoder(
+        categories="auto",
+        dtype=np.float64,
+        handle_unknown="use_encoded_value",
+        unknown_value=-1,
+        encoded_missing_value=np.nan,
+    )
+
+
+def _category_frame() -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Category and string columns as `fix_dtypes` hands them on, at fit and predict."""
+    fit = pd.DataFrame(
+        {
+            "strings": pd.Categorical(["b", "a", None, "b", "c"]),
+            "ints": pd.Categorical([2, 1, 2, 1, 3]),
+            "floats": pd.Categorical([2.0, np.nan, 1.0, 2.0, 1.0]),
+            "unused_category": pd.Categorical(["x"] * 5, categories=["x", "y"]),
+            "string_dtype": pd.array(["p", "q", "p", "q", "p"], dtype="string"),
+            "all_missing": pd.Categorical([None] * 5, categories=["m"]),
+        }
+    )
+    predict = pd.DataFrame(
+        {
+            "strings": pd.Categorical(["a", "zzz", None]),
+            "ints": pd.Categorical([1, 5, 2]),
+            "floats": pd.Categorical([1.0, 7.0, np.nan]),
+            "unused_category": pd.Categorical(["y", "x", "x"]),
+            "string_dtype": pd.array(["q", "new", "p"], dtype="string"),
+            "all_missing": pd.Categorical(["m", None, "z"]),
+        }
+    )
+    return fit, predict
+
+
+def test__category_ordinal_encoder__matches_sklearn() -> None:
+    """Codes, unknown and missing handling and `categories_` match sklearn's encoder."""
+    fit, predict = _category_frame()
+    reference = _sklearn_frozen_encoder()
+    encoder = CategoryOrdinalEncoder()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        expected_fit = reference.fit_transform(fit)
+        expected_predict = reference.transform(predict)
+
+    np.testing.assert_array_equal(encoder.fit_transform(fit), expected_fit)
+    np.testing.assert_array_equal(encoder.transform(predict), expected_predict)
+    assert encoder.n_features_in_ == reference.n_features_in_
+    for ours, theirs in zip(encoder.categories_, reference.categories_, strict=True):
+        assert ours.dtype == theirs.dtype
+        assert len(ours) == len(theirs)
+        for a, b in zip(ours, theirs, strict=True):
+            assert (pd.isna(a) and pd.isna(b)) or a == b
+
+
+def test__category_ordinal_encoder__mixed_types_raise_like_sklearn() -> None:
+    """A column mixing strings and numbers is rejected, as sklearn rejects it."""
+    frame = pd.DataFrame({"mixed": np.array(["a", 1, "b"], dtype=object)})
+    with pytest.raises(TypeError, match="uniformly strings or numbers"):
+        CategoryOrdinalEncoder().fit(frame)
+
+
+def test__get_ordinal_encoder__matches_sklearn_through_clean_data() -> None:
+    """`clean_data` and a predict-time transform match the sklearn-backed encoder."""
+    fit, predict = _category_frame()
+    fit = fit.assign(number=np.arange(5, dtype=np.float64))
+    predict = predict.assign(number=np.arange(3, dtype=np.float64))
+    schema = FeatureSchema.from_only_categorical_indices(list(range(6)), 7)
+
+    cleaned, encoder, _ = clean_data(
+        X=fit.to_numpy(dtype=object), feature_schema=schema
+    )
+    transformed = clean_data_transform(
+        X=predict.to_numpy(dtype=object),
+        cat_indices=list(range(6)),
+        ord_encoder=encoder,
+    )
+
+    reference = get_ordinal_encoder()
+    reference.set_params(encoder=_sklearn_frozen_encoder())
+    fit_frame = fix_dtypes(fit.to_numpy(dtype=object), cat_indices=list(range(6)))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        expected = process_text_na_dataframe(
+            fit_frame, ord_encoder=reference, fit_encoder=True
+        )
+        expected_predict = process_text_na_dataframe(
+            fix_dtypes(predict.to_numpy(dtype=object), cat_indices=list(range(6))),
+            ord_encoder=reference,
+        )
+    np.testing.assert_array_equal(cleaned, expected)
+    np.testing.assert_array_equal(transformed, expected_predict)

--- a/tests/test_preprocessing/test_kdi_transformer.py
+++ b/tests/test_preprocessing/test_kdi_transformer.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 import torch
 
 from tabpfn.preprocessing.steps import KDITransformerWithNaN
+
+kditransform = pytest.importorskip("kditransform")
 
 
 def test__kdi_transformer_fit__with_nan_integration():
@@ -61,3 +64,55 @@ def test__kdi_transformer_fit_transform__with_nan_integration():
 
     # Verify non-NaN values are actual numbers (transformed)
     assert np.all(np.isfinite(Xt[~mask]))
+
+
+# ---------------------------------------------------------------------------
+# The overridden fit and transform against the kditransform class they mirror
+# ---------------------------------------------------------------------------
+
+
+def _kdi_cases() -> list[np.ndarray]:
+    rng = np.random.default_rng(0)
+    plain = rng.standard_normal((2165, 11)) * rng.uniform(0.1, 50, 11)
+    ties = np.round(rng.standard_normal((598, 6)) * 3)
+    with_nan = plain[:700].copy()
+    with_nan[rng.random(with_nan.shape) < 0.05] = np.nan
+    constant = plain[:300].copy()
+    constant[:, 2] = 4.0
+    small = rng.standard_normal((37, 3))
+    single = rng.standard_normal((1132, 1)).astype(np.float32).astype(np.float64)
+    return [plain, ties, with_nan, constant, small, single]
+
+
+@pytest.mark.parametrize("alpha", [0.3, 1.0, 3.0])
+@pytest.mark.parametrize("output_distribution", ["normal", "uniform"])
+def test__kdi_transformer__matches_kditransform_bit_for_bit(
+    alpha: float, output_distribution: str
+) -> None:
+    """Quantiles, forward and inverse transforms equal the upstream implementation."""
+    for X in _kdi_cases():
+        X_imputed = np.nan_to_num(X, nan=np.nan_to_num(np.nanmean(X, axis=0), nan=0))
+        reference = kditransform.KDITransformer(
+            alpha=alpha, output_distribution=output_distribution
+        )
+        ours = KDITransformerWithNaN(
+            alpha=alpha, output_distribution=output_distribution
+        )
+        # Fit on a copy: the upstream fit centres and un-centres its input in place,
+        # which moves it by a rounding error, while `KDITransformerWithNaN.fit` works
+        # on the imputed copy and leaves the input alone.
+        reference.fit(X_imputed.copy())
+        expected = reference.transform(X_imputed.copy())
+        result = ours.fit_transform(X)
+        np.testing.assert_array_equal(ours.quantiles_, reference.quantiles_)
+        np.testing.assert_array_equal(result[~np.isnan(X)], expected[~np.isnan(X)])
+        assert np.isnan(result[np.isnan(X)]).all()
+        X_new = X[: len(X) // 2] * 1.1 + 0.3
+        np.testing.assert_array_equal(
+            ours.transform(np.nan_to_num(X_new, nan=0.0)),
+            reference.transform(np.nan_to_num(X_new, nan=0.0)),
+        )
+        np.testing.assert_array_equal(
+            ours.inverse_transform(expected.copy()),
+            reference.inverse_transform(expected.copy()),
+        )


### PR DESCRIPTION
Stacked on #1263.

Three per-ensemble-member preprocessing costs that are paid once per member and dominated by per-call overhead rather than arithmetic on small tables. Outputs are identical in every case; the tests compare each new path with the one it replaces.

- `clean_data`'s frozen ordinal encoder wrapped sklearn's `OrdinalEncoder`, which extracts and validates each column separately on every call. `CategoryOrdinalEncoder` reads a category column's codes at fit, looks other columns up in a `pd.Index` at transform, and keeps the same codes, unknown (-1) and missing handling and `categories_`. On a 1,699 x 111 table with 88 preprocessing pipelines the encoder goes from 0.29 s to 0.10 s per fit.
- `KDITransformerWithNaN` carries its own copy of kditransform's polyexp fit and per-column transform: the quantile grid is read off the column that is already sorted for the kernel sum instead of a second `np.quantile` pass, the Gaussian-to-polyexp bandwidth constant is computed once per fit instead of per column, and the normal output goes through `ndtri`. Bit-identical to the upstream class; KDI fit per pipeline 0.43 s to 0.19 s on a 6,497 x 11 table.
- `fix_dtypes` builds the frame from the object array with its `pd.Categorical` columns in one pass instead of casting each column inside the frame, and modality detection skips the 1,024-row prefix count on columns shorter than twice that, where the full count decides the same way. Per member on the first table: 0.13 s to 0.08 s and 0.07 s to 0.04 s.

Whole `fit` on the 1,699 x 111 table: 2.05 s to 1.62 s (median of 3). The four `test_sklearn_estimator_checks` failures for `KDITransformerWithNaN` in this environment are present on the base branch as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELdutHiUqkvynzEP7EnPsi